### PR TITLE
fix: update dashboards according to schema changes

### DIFF
--- a/grafana/dashboards/EngineeringOverview.json
+++ b/grafana/dashboards/EngineeringOverview.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 13,
-  "iteration": 1653390976868,
+  "id": 12,
+  "iteration": 1658734029836,
   "links": [],
   "panels": [
     {
@@ -256,7 +256,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "with _inprogress_times as (\n  select\n    i.id as issue_id,\n    c.created_date as inprogress_time\n  from\n    lake.issues i\n    join lake.changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.to in ($inprogress_status) \n    and date(i.created_date) between STR_TO_DATE('$month','%Y-%m-%d') and STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n),\n\n_done_times as (\n  select\n    i.id as issue_id,\n    c.created_date as done_time\n  from\n    lake.issues i\n    join lake.changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.to in ($done_status)\n    and date(i.created_date) between STR_TO_DATE('$month','%Y-%m-%d') and STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n)\n\nselect\n  AVG(TIMESTAMPDIFF(MINUTE, inprogress_time, done_time) / 1440)\nfrom\n  _inprogress_times it\n  join _done_times dt on it.issue_id = dt.issue_id",
+          "rawSql": "with _inprogress_times as (\n  select\n    i.id as issue_id,\n    c.created_date as inprogress_time\n  from\n    lake.issues i\n    join lake.issue_changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.original_to_value in ($inprogress_status) \n    and date(i.created_date) between STR_TO_DATE('$month','%Y-%m-%d') and STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n),\n\n_done_times as (\n  select\n    i.id as issue_id,\n    c.created_date as done_time\n  from\n    lake.issues i\n    join lake.issue_changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.original_to_value in ($done_status)\n    and date(i.created_date) between STR_TO_DATE('$month','%Y-%m-%d') and STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n)\n\nselect\n  AVG(TIMESTAMPDIFF(MINUTE, inprogress_time, done_time) / 1440)\nfrom\n  _inprogress_times it\n  join _done_times dt on it.issue_id = dt.issue_id",
           "refId": "A",
           "select": [
             [
@@ -365,7 +365,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "with _inprogress_times as (\n  select\n    i.id as issue_id,\n    i.created_date,\n    c.created_date as inprogress_time\n  from\n    lake.issues i\n    join lake.changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.to in ($inprogress_status) \n    and $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n),\n\n_done_times as (\n  select\n    i.id as issue_id,\n    i.created_date,\n    c.created_date as done_time\n  from\n    lake.issues i\n    join lake.changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.to in ($done_status)\n    and $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n)\n\nselect\n  DATE_ADD(date(it.created_date), INTERVAL -DAY(date(it.created_date))+1 DAY) as time,\n  AVG(TIMESTAMPDIFF(MINUTE, inprogress_time, done_time) / 1440) as avg_issue_cycle_time_in_days\nfrom\n  _inprogress_times it\n  join _done_times dt on it.issue_id = dt.issue_id\ngroup by time",
+          "rawSql": "with _inprogress_times as (\n  select\n    i.id as issue_id,\n    i.created_date,\n    c.created_date as inprogress_time\n  from\n    lake.issues i\n    join lake.issue_changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.original_to_value in ($inprogress_status) \n    and $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n),\n\n_done_times as (\n  select\n    i.id as issue_id,\n    i.created_date,\n    c.created_date as done_time\n  from\n    lake.issues i\n    join lake.issue_changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'status'\n    and c.original_to_value in ($done_status)\n    and $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n)\n\nselect\n  DATE_ADD(date(it.created_date), INTERVAL -DAY(date(it.created_date))+1 DAY) as time,\n  AVG(TIMESTAMPDIFF(MINUTE, inprogress_time, done_time) / 1440) as avg_issue_cycle_time_in_days\nfrom\n  _inprogress_times it\n  join _done_times dt on it.issue_id = dt.issue_id\ngroup by time",
           "refId": "A",
           "select": [
             [
@@ -408,7 +408,7 @@
                 "value": null
               },
               {
-                "color": "orange",
+                "color": "yellow",
                 "value": 10
               },
               {
@@ -633,7 +633,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "with _num_issues_with_sprint_updated as (\n  select\n    count(*) as num_issues_with_sprint_updated\n  from\n    lake.issues i\n    join lake.changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'Sprint' and\n    c.from != '' and\n    c.to != '' and\n    date(i.created_date) between\n      STR_TO_DATE('$month','%Y-%m-%d') and\n      STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n),\n\n_total_num_issues as (\n  select\n    count(*) as total_num_issues\n  from\n    lake.issues i\n  where\n    date(i.created_date) between\n      STR_TO_DATE('$month','%Y-%m-%d') and\n      STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n)\n\nselect\n  now() as time,\n  100 - 100 * (select 1.0 * num_issues_with_sprint_updated from _num_issues_with_sprint_updated) / (select total_num_issues from _total_num_issues) as ratio;",
+          "rawSql": "with _num_issues_with_sprint_updated as (\n  select\n    count(*) as num_issues_with_sprint_updated\n  from\n    lake.issues i\n    join lake.issue_changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'Sprint' and\n    c.original_from_value != '' and\n    c.original_to_value != '' and\n    date(i.created_date) between\n      STR_TO_DATE('$month','%Y-%m-%d') and\n      STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n),\n\n_total_num_issues as (\n  select\n    count(*) as total_num_issues\n  from\n    lake.issues i\n  where\n    date(i.created_date) between\n      STR_TO_DATE('$month','%Y-%m-%d') and\n      STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY\n)\n\nselect\n  now() as time,\n  100 - 100 * (select 1.0 * num_issues_with_sprint_updated from _num_issues_with_sprint_updated) / (select total_num_issues from _total_num_issues) as ratio;",
           "refId": "A",
           "select": [
             [
@@ -739,7 +739,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "with _num_issues_with_sprint_updated as (\n  select\n    DATE_ADD(date(i.created_date), INTERVAL -DAY(date(i.created_date))+1 DAY) as time,\n    count(*) as num_issues_with_sprint_updated\n  from\n    lake.issues i\n    join lake.changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'Sprint'\n    and c.from != '' \n    and c.to != ''\n    and $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n  group by time\n),\n\n_total_num_issues as (\n  select\n    DATE_ADD(date(i.created_date), INTERVAL -DAY(date(i.created_date))+1 DAY) as time,\n    count(*) as total_num_issues\n  from\n    lake.issues i\n  where\n    $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n  group by time\n)\n\nselect\n  x.time,\n  100 - 100 * (1.0 * x.num_issues_with_sprint_updated / y.total_num_issues) as delivery_rate\nfrom \n  _num_issues_with_sprint_updated x \n  join _total_num_issues y on x.time = y.time",
+          "rawSql": "with _num_issues_with_sprint_updated as (\n  select\n    DATE_ADD(date(i.created_date), INTERVAL -DAY(date(i.created_date))+1 DAY) as time,\n    count(*) as num_issues_with_sprint_updated\n  from\n    lake.issues i\n    join lake.issue_changelogs c on i.id = c.issue_id\n  where\n    c.field_name = 'Sprint'\n    and c.original_from_value != '' \n    and c.original_to_value != ''\n    and $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n  group by time\n),\n\n_total_num_issues as (\n  select\n    DATE_ADD(date(i.created_date), INTERVAL -DAY(date(i.created_date))+1 DAY) as time,\n    count(*) as total_num_issues\n  from\n    lake.issues i\n  where\n    $__timeFilter(i.created_date)\n    and i.created_date >= DATE_ADD(DATE_ADD($__timeFrom(), INTERVAL -DAY($__timeFrom())+1 DAY), INTERVAL +1 MONTH)\n  group by time\n)\n\nselect\n  x.time,\n  100 - 100 * (1.0 * x.num_issues_with_sprint_updated / y.total_num_issues) as delivery_rate\nfrom \n  _num_issues_with_sprint_updated x \n  join _total_num_issues y on x.time = y.time",
           "refId": "A",
           "select": [
             [
@@ -821,7 +821,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select\n  count(*)\nfrom\n  lake.pull_requests pr\nwhere\n  pr.merged_date is not null and\n  date(pr.merged_date) between\n    STR_TO_DATE('$month','%Y-%m-%d') and\n    STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY and\n  pr.base_repo_id in ($repo_id);",
+          "rawSql": "select\n  count(*)\nfrom\n  lake.pull_requests pr\nwhere\n  pr.merged_date is not null \n  and date(pr.merged_date) between\n    STR_TO_DATE('$month','%Y-%m-%d')\n    and STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY \n  and pr.base_repo_id in ($repo_id);",
           "refId": "A",
           "select": [
             [
@@ -1380,7 +1380,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select\n  AVG(TIMESTAMPDIFF(MINUTE, pr.created_date, pr.merged_date) / 1440)\nfrom\n  lake.pull_requests pr\nwhere\n  pr.merged_date is not null\n  and pr.base_repo_id in ($repo_id)\n  and date(pr.created_date) between\n    STR_TO_DATE('$month','%Y-%m-%d') and\n    STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY",
+          "rawSql": "select\n  AVG(TIMESTAMPDIFF(MINUTE, pr.created_date, pr.merged_date) / 1440)\nfrom\n  lake.pull_requests pr\nwhere\n  pr.merged_date is not null\n  and pr.base_repo_id in ($repo_id)\n  and date(pr.created_date) between\n    STR_TO_DATE('$month','%Y-%m-%d') \n    and STR_TO_DATE('$month','%Y-%m-%d') + INTERVAL 1 MONTH - INTERVAL 1 DAY",
           "refId": "A",
           "select": [
             [
@@ -1729,8 +1729,8 @@
         "allValue": null,
         "current": {
           "selected": true,
-          "text": "2022-03",
-          "value": "2022-03-01"
+          "text": "2022-06",
+          "value": "2022-06-01"
         },
         "datasource": "mysql",
         "definition": "select\n  distinct(concat(date_format(DATE_ADD(date(created_date), INTERVAL -DAY(date(created_date))+1 DAY), '%Y-%m') , ':', date_format(DATE_ADD(date(created_date), INTERVAL -DAY(date(created_date))+1 DAY), '%Y-%m-%d'))) as month\nfrom\n  lake.issues i\norder by month desc",
@@ -1754,12 +1754,12 @@
         "current": {
           "selected": true,
           "text": [
-            "Highest",
-            "High"
+            "High",
+            "Highest"
           ],
           "value": [
-            "Highest",
-            "High"
+            "High",
+            "Highest"
           ]
         },
         "datasource": "mysql",
@@ -1784,18 +1784,14 @@
         "current": {
           "selected": true,
           "text": [
-            "In Progress",
-            "处理中",
-            "In Development"
+            "All"
           ],
           "value": [
-            "In Progress",
-            "处理中",
-            "In Development"
+            "$__all"
           ]
         },
         "datasource": "mysql",
-        "definition": "select `to` from changelogs where field_name = 'status'",
+        "definition": "select original_to_value from issue_changelogs where field_name = 'status'",
         "description": "Customize status(es) that are considered as \"In-Progress\"",
         "error": null,
         "hide": 0,
@@ -1804,7 +1800,7 @@
         "multi": true,
         "name": "inprogress_status",
         "options": [],
-        "query": "select `to` from changelogs where field_name = 'status'",
+        "query": "select original_to_value from issue_changelogs where field_name = 'status'",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1816,18 +1812,14 @@
         "current": {
           "selected": true,
           "text": [
-            "Resolved",
-            "已关闭",
-            "已完成"
+            "All"
           ],
           "value": [
-            "Resolved",
-            "已关闭",
-            "已完成"
+            "$__all"
           ]
         },
         "datasource": "mysql",
-        "definition": "select `to` from changelogs where field_name = 'status'",
+        "definition": "select original_to_value from issue_changelogs where field_name = 'status'",
         "description": "Customize status(es) that are considered as \"Done\"",
         "error": null,
         "hide": 0,
@@ -1836,7 +1828,7 @@
         "multi": true,
         "name": "done_status",
         "options": [],
-        "query": "select `to` from changelogs where field_name = 'status'",
+        "query": "select original_to_value from issue_changelogs where field_name = 'status'",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -1853,5 +1845,5 @@
   "timezone": "",
   "title": "Engineering Overview",
   "uid": "ZF6abXX7z",
-  "version": 46
+  "version": 1
 }

--- a/grafana/dashboards/GithubReleaseQualityAndContributionAnalysis.json
+++ b/grafana/dashboards/GithubReleaseQualityAndContributionAnalysis.json
@@ -16,21 +16,9 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 15,
-  "iteration": 1653992608241,
+  "iteration": 1658723594192,
   "links": [],
   "panels": [
-    {
-      "datasource": null,
-      "gridPos": {
-        "h": 1,
-        "w": 24,
-        "x": 0,
-        "y": 0
-      },
-      "id": 49,
-      "title": "Row title",
-      "type": "row"
-    },
     {
       "collapsed": false,
       "datasource": null,
@@ -38,7 +26,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 1
+        "y": 0
       },
       "id": 45,
       "panels": [],
@@ -69,7 +57,7 @@
         "h": 7,
         "w": 7,
         "x": 0,
-        "y": 2
+        "y": 1
       },
       "id": 15,
       "options": {
@@ -101,10 +89,11 @@
         {
           "format": "table",
           "group": [],
+          "hide": false,
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the bug distribution in major versions\nwith bugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\tand i.type = 'BUG'\n)\n\n\nSELECT \n\tconcat(SUBSTRING_INDEX(biet.tag_name,'.',2), '.x') as minor_version,\n\tcount(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
+          "rawSql": "-- Get the bug distribution in major versions\nwith bugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\tand i.type = 'BUG'\n)\n\n\nSELECT \n\tconcat(SUBSTRING_INDEX(biet.tag_name,'.',3), '.x') as minor_version,\n\tcount(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
           "refId": "A",
           "select": [
             [
@@ -203,7 +192,7 @@
         "h": 7,
         "w": 17,
         "x": 7,
-        "y": 2
+        "y": 1
       },
       "id": 29,
       "options": {
@@ -230,7 +219,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the number of fixed bugs in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n    -- distinct new_ref_id, old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs_of_tags as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name, \n\t\t-- SUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\tcount(*) as bug_count\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n\t-- GROUP BY 1,2\n\t  GROUP BY 1\n),\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where p.base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) as repo_id,\n    pr.id as pull_request_id,\n    count(c.sha) as commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT SUBSTRING_INDEX(new_ref_id,':', -1) FROM _last_5_tags)\n\tgroup by 1,2,3\n),\n\n_pr_worktype as(\n  select\n    distinct pri.pull_request_id,i.type\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_pr_elco_and_worktype as(\n  select\n    ccop.tag_name, \n    sum(case when pw.type = 'BUG' then commit_count else 0 end)/sum(commit_count) as cost_percentage\n  from \n    _commit_count_of_pr ccop\n    left join _pr_worktype pw on ccop.pull_request_id = pw.pull_request_id\n  GROUP BY 1\n)\n\nSELECT \n\tbot.tag_name,\n\tbot.bug_count,\n\tpeaw.cost_percentage as \"cost_percentage(bugfixing commits/total commits)\"\nFROM \n\t_bugs_of_tags bot\n\tjoin _pr_elco_and_worktype peaw on bot.tag_name = peaw.tag_name\nORDER BY 1",
+          "rawSql": "-- Get the number of fixed bugs in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n    -- distinct new_ref_id, old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs_of_tags as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name, \n\t\t-- SUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\tcount(*) as bug_count\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n\t-- GROUP BY 1,2\n\t  GROUP BY 1\n),\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where p.base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) as repo_id,\n    pr.id as pull_request_id,\n    count(c.sha) as commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT SUBSTRING_INDEX(new_ref_id,':', -1) FROM _last_5_tags)\n\tgroup by 1,2,3\n),\n\n_pr_worktype as(\n  select\n    distinct pri.pull_request_id,i.type\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_pr_elco_and_worktype as(\n  select\n    ccop.tag_name, \n    sum(case when pw.type = 'BUG' then commit_count else 0 end)/sum(commit_count) as cost_percentage\n  from \n    _commit_count_of_pr ccop\n    left join _pr_worktype pw on ccop.pull_request_id = pw.pull_request_id\n  GROUP BY 1\n)\n\nSELECT \n\tbot.tag_name,\n\tbot.bug_count,\n\tpeaw.cost_percentage as \"cost_percentage(bugfixing commits/total commits)\"\nFROM \n\t_bugs_of_tags bot\n\tjoin _pr_elco_and_worktype peaw on bot.tag_name = peaw.tag_name\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -274,83 +263,13 @@
           },
           "mappings": []
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "dev_eq"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts UNKNOWN"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts REQUIREMENT"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts BUG"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 9
+        "y": 8
       },
       "id": 55,
       "options": {
@@ -385,7 +304,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the  severity distribution in bugs\n-- Get the work-type distribution in the last n tags\nwith _last_n_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description, i.severity \n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand i.type = 'BUG'\n)\n\nSELECT \n   concat(biet.tag_name, \" \", case when biet.severity != '' then biet.severity else 'UNKNOWN' end) as severity,\n   count(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1\n\n-- SELECT \n-- \t case when biet.severity != '' then biet.severity else 'UNKNOWN' end as severity,\n-- \tcount(*) as bug_count\n-- FROM \n-- \tbugs_in_each_tag biet\n-- GROUP BY biet.severity",
+          "rawSql": "-- Get the  severity distribution in bugs\n-- Get the work-type distribution in the last n tags\nwith _last_n_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description, i.severity \n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand i.type = 'BUG'\n)\n\nSELECT \n   concat(biet.tag_name, \" \", case when biet.severity != '' then biet.severity else 'UNKNOWN' end) as severity,\n   count(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
           "refId": "A",
           "select": [
             [
@@ -505,7 +424,7 @@
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 9
+        "y": 8
       },
       "id": 53,
       "options": {
@@ -540,7 +459,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the  severity distribution in bugs\n-- Get the work-type distribution in the last n tags\nwith _last_n_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1,1\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description, i.severity \n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand i.type = 'BUG'\n)\n\nSELECT \n   concat(biet.tag_name, \" \", case when biet.severity != '' then biet.severity else 'UNKNOWN' end) as severity,\n   count(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1\n\n-- SELECT \n-- \t case when biet.severity != '' then biet.severity else 'UNKNOWN' end as severity,\n-- \tcount(*) as bug_count\n-- FROM \n-- \tbugs_in_each_tag biet\n-- GROUP BY biet.severity",
+          "rawSql": "-- Get the  severity distribution in bugs\n-- Get the work-type distribution in the last n tags\nwith _last_n_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1,1\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description, i.severity \n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand i.type = 'BUG'\n)\n\nSELECT \n   concat(biet.tag_name, \" \", case when biet.severity != '' then biet.severity else 'UNKNOWN' end) as severity,\n   count(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
           "refId": "A",
           "select": [
             [
@@ -584,83 +503,13 @@
           },
           "mappings": []
         },
-        "overrides": [
-          {
-            "__systemRef": "hideSeriesFrom",
-            "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "dev_eq"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
-            },
-            "properties": [
-              {
-                "id": "custom.hideFrom",
-                "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts UNKNOWN"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts REQUIREMENT"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts BUG"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          }
-        ]
+        "overrides": []
       },
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 9
+        "y": 8
       },
       "id": 51,
       "options": {
@@ -695,7 +544,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the  severity distribution in bugs\n-- Get the work-type distribution in the last n tags\nwith _last_n_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 2,1\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description, i.severity \n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand i.type = 'BUG'\n)\n\nSELECT \n   concat(biet.tag_name, \" \", case when biet.severity != '' then biet.severity else 'UNKNOWN' end) as severity,\n   count(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1\n\n-- SELECT \n-- \t case when biet.severity != '' then biet.severity else 'UNKNOWN' end as severity,\n-- \tcount(*) as bug_count\n-- FROM \n-- \tbugs_in_each_tag biet\n-- GROUP BY biet.severity",
+          "rawSql": "-- Get the  severity distribution in bugs\n-- Get the work-type distribution in the last n tags\nwith _last_n_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 2,1\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/tags/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) as repo_id,\n\t\ti.issue_key, i.type, i.title, i.description, i.severity \n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_n_tags)\n\t\tand i.type = 'BUG'\n)\n\nSELECT \n   concat(biet.tag_name, \" \", case when biet.severity != '' then biet.severity else 'UNKNOWN' end) as severity,\n   count(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
           "refId": "A",
           "select": [
             [
@@ -841,7 +690,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 16
+        "y": 15
       },
       "id": 43,
       "options": {
@@ -856,7 +705,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the number of fixed bugs in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n)\n\t\nselect distinct\n\tb.name as repo_name,\n\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name, \n\ti.issue_key as issue_key,\n\ti.title,\n\ti.assignee_name,\n\ti.lead_time_minutes/1440 as lead_time_in_days,\n\tconcat(b.url,'/',i.issue_key) as url\nfrom\n\trefs_issues_diffs rid\n\tleft join issues i on rid.issue_id = i.id\n\tjoin boards b on SUBSTRING_INDEX(rid.new_ref_id,':', 3) = b.id\nwhere\n\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT SUBSTRING_INDEX(new_ref_id,':', -1) FROM _last_5_tags)\n\tand i.type = 'BUG'\norder by tag_name desc",
+          "rawSql": "-- Get the number of fixed bugs in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n)\n\t\nselect distinct\n\tb.name as repo_name,\n\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name, \n\ti.issue_key as issue_key,\n\ti.title,\n\ti.assignee_name,\n\ti.lead_time_minutes/1440 as lead_time_in_days,\n\tconcat(b.url,'/',i.issue_key) as url\nfrom\n\trefs_issues_diffs rid\n\tleft join issues i on rid.issue_id = i.id\n\tjoin boards b on SUBSTRING_INDEX(rid.new_ref_id,':', 4) = b.id\nwhere\n\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT SUBSTRING_INDEX(new_ref_id,':', -1) FROM _last_5_tags)\n\tand i.type = 'BUG'\norder by tag_name desc",
           "refId": "A",
           "select": [
             [
@@ -907,7 +756,7 @@
         "h": 7,
         "w": 11,
         "x": 0,
-        "y": 23
+        "y": 22
       },
       "id": 30,
       "options": {
@@ -942,7 +791,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Component distribution of bugs fixed in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\ti.issue_key, i.component, i.severity, i.title, i.description\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n)\n\n\nSELECT\n\tcase when component = '' then 'unlabeled' else 'labeled' end as component,\n\tcount(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
+          "rawSql": "-- Component distribution of bugs fixed in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) as repo_id,\n\t\ti.issue_key, i.component, i.severity, i.title, i.description\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n)\n\n\nSELECT\n\tcase when component = '' then 'unlabeled' else 'labeled' end as component,\n\tcount(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nGROUP BY 1",
           "refId": "A",
           "select": [
             [
@@ -993,7 +842,7 @@
         "h": 7,
         "w": 13,
         "x": 11,
-        "y": 23
+        "y": 22
       },
       "id": 31,
       "options": {
@@ -1028,7 +877,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Component distribution of bugs fixed in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) as repo_id,\n\t\ti.issue_key, i.component, i.severity, i.title, i.description\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n)\n\n\nSELECT\n\tcomponent,\n\tcount(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nwhere \n  component != ''\nGROUP BY 1",
+          "rawSql": "-- Component distribution of bugs fixed in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\nbugs_in_each_tag as(\n\tselect \n\t\tSUBSTRING_INDEX(rid.new_ref_id,'refs/', -1) as tag_name, \n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) as repo_id,\n\t\ti.issue_key, i.component, i.severity, i.title, i.description\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n)\n\n\nSELECT\n\tcomponent,\n\tcount(*) as bug_count\nFROM \n\tbugs_in_each_tag biet\nwhere \n  component != ''\nGROUP BY 1",
           "refId": "A",
           "select": [
             [
@@ -1089,7 +938,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 30
+        "y": 29
       },
       "id": 23,
       "options": {
@@ -1115,7 +964,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the % of contributors who fixed 80% of bugs in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect \n\t\ti.issue_key, i.type, i.severity, i.title, i.description,\n\t\tpr.id, pr.author_name as pr_author, pr.created_date,\n\t\trank() over(partition by i.id order by pr.created_date asc) as pr_rank\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\t\tleft join pull_requests pr on pri.pull_request_id = pr.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n\torder by i.issue_key\n),\n\n_bug_fixed_count as(\n  SELECT \n    pr_author,\n    count(*) bug_fixed_count\n  FROM _bugs\n  WHERE pr_rank = 1\n  GROUP BY 1\n),\n\n_bug_fixed_count_running_total as(\n  SELECT \n    *, \n    sum(bug_fixed_count) OVER (Order by bug_fixed_count desc) AS running_total\n  FROM \n    _bug_fixed_count\n),\n\n_percentile as(\n  SELECT \n    pr_author,\n    bug_fixed_count,\n    running_total/sum(bug_fixed_count) OVER () AS cumulative_percentage\n  FROM \n    _bug_fixed_count_running_total\n)\n\n\nSELECT \n  count(case when cumulative_percentage <= 0.8 then pr_author else null end)/count(*) as \"% of contributors who fixed 80% of the bugs\"\nFROM _percentile",
+          "rawSql": "-- Get the % of contributors who fixed 80% of bugs in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect \n\t\ti.issue_key, i.type, i.severity, i.title, i.description,\n\t\tpr.id, pr.author_name as pr_author, pr.created_date,\n\t\trank() over(partition by i.id order by pr.created_date asc) as pr_rank\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\t\tleft join pull_requests pr on pri.pull_request_id = pr.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n\torder by i.issue_key\n),\n\n_bug_fixed_count as(\n  SELECT \n    pr_author,\n    count(*) bug_fixed_count\n  FROM _bugs\n  WHERE pr_rank = 1\n  GROUP BY 1\n),\n\n_bug_fixed_count_running_total as(\n  SELECT \n    *, \n    sum(bug_fixed_count) OVER (Order by bug_fixed_count desc) AS running_total\n  FROM \n    _bug_fixed_count\n),\n\n_percentile as(\n  SELECT \n    pr_author,\n    bug_fixed_count,\n    running_total/sum(bug_fixed_count) OVER () AS cumulative_percentage\n  FROM \n    _bug_fixed_count_running_total\n)\n\n\nSELECT \n  count(case when cumulative_percentage <= 0.8 then pr_author else null end)/count(*) as \"% of contributors who fixed 80% of the bugs\"\nFROM _percentile",
           "refId": "A",
           "select": [
             [
@@ -1185,7 +1034,7 @@
         "h": 7,
         "w": 18,
         "x": 6,
-        "y": 30
+        "y": 29
       },
       "id": 18,
       "options": {
@@ -1212,7 +1061,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the bug fixer distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect \n\t\ti.issue_key, i.type, i.severity, i.title, i.description,\n\t\tpr.id, pr.author_name as pr_author, pr.created_date,\n\t\trank() over(partition by i.id order by pr.created_date asc) as pr_rank\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\t\tleft join pull_requests pr on pri.pull_request_id = pr.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n\torder by i.issue_key\n)\n\nSELECT \n  pr_author,\n  count(*) bug_fixed_count\nFROM _bugs\nWHERE pr_rank = 1\nGROUP BY 1\nORDER BY 2 desc\nlimit 10",
+          "rawSql": "-- Get the bug fixer distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect \n\t\ti.issue_key, i.type, i.severity, i.title, i.description,\n\t\tpr.id, pr.author_name as pr_author, pr.created_date,\n\t\trank() over(partition by i.id order by pr.created_date asc) as pr_rank\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\t\tleft join pull_requests pr on pri.pull_request_id = pr.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n\torder by i.issue_key\n)\n\nSELECT \n  pr_author,\n  count(*) bug_fixed_count\nFROM _bugs\nWHERE pr_rank = 1\nGROUP BY 1\nORDER BY 2 desc\nlimit 10",
           "refId": "A",
           "select": [
             [
@@ -1269,7 +1118,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 37
+        "y": 36
       },
       "id": 33,
       "options": {
@@ -1365,7 +1214,7 @@
         "h": 6,
         "w": 20,
         "x": 4,
-        "y": 37
+        "y": 36
       },
       "id": 32,
       "options": {
@@ -1392,7 +1241,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the bug age in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect distinct\n\t\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name,\n\t\ti.id,\n\t\ti.lead_time_minutes\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n),\n\n_bugs_percentile as(\n  select \n    *,\n    percent_rank() over (partition by tag_name order by lead_time_minutes) as percentile\n  from _bugs order by 1\n),\n\n_avg_bug_age as(\n  select \n    tag_name,\n    avg(lead_time_minutes)/1440 as average_bug_age\n  from _bugs_percentile\n  group by 1\n),\n\n_50th_bug_age as(\n  select \n    tag_name,\n    min(lead_time_minutes)/1440 as \"50th_bug_age\"\n  from _bugs_percentile\n    where percentile >= 0.5\n  group by 1\n)\n\nselect \n  aba.*,\n  eba.50th_bug_age\nfrom \n  _avg_bug_age aba\n  join _50th_bug_age eba on aba.tag_name = eba.tag_name",
+          "rawSql": "-- Get the bug age in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect distinct\n\t\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name,\n\t\ti.id,\n\t\ti.lead_time_minutes\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n),\n\n_bugs_percentile as(\n  select \n    *,\n    percent_rank() over (partition by tag_name order by lead_time_minutes) as percentile\n  from _bugs order by 1\n),\n\n_avg_bug_age as(\n  select \n    tag_name,\n    avg(lead_time_minutes)/1440 as average_bug_age\n  from _bugs_percentile\n  group by 1\n),\n\n_50th_bug_age as(\n  select \n    tag_name,\n    min(lead_time_minutes)/1440 as \"50th_bug_age\"\n  from _bugs_percentile\n    where percentile >= 0.5\n  group by 1\n)\n\nselect \n  aba.*,\n  eba.50th_bug_age\nfrom \n  _avg_bug_age aba\n  join _50th_bug_age eba on aba.tag_name = eba.tag_name",
           "refId": "A",
           "select": [
             [
@@ -1449,7 +1298,7 @@
         "h": 6,
         "w": 4,
         "x": 0,
-        "y": 43
+        "y": 42
       },
       "id": 34,
       "options": {
@@ -1621,7 +1470,7 @@
         "h": 6,
         "w": 20,
         "x": 4,
-        "y": 43
+        "y": 42
       },
       "id": 38,
       "options": {
@@ -1636,7 +1485,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the bug fixer distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect distinct\n\t  b.name,\n\t\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name,\n\t\ti.issue_key as issue_key,\n    i.title,\n    i.lead_time_minutes/1440 as lead_time_in_days,\n    concat(b.url,'/',i.issue_key) as url\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\t\tjoin boards b on SUBSTRING_INDEX(rid.new_ref_id,':', 3) = b.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n),\n\n_bug_age_rank as(\n  select \n    *,\n    row_number() over (partition by tag_name order by lead_time_in_days desc) as bug_age_rank\n  from _bugs\n)\n\nselect \n  name,\n  tag_name,\n  issue_key,\n  title,\n  lead_time_in_days,\n  url\nfrom _bug_age_rank\nwhere bug_age_rank <=10 \norder by tag_name, lead_time_in_days desc",
+          "rawSql": "-- Get the bug fixer distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_bugs as(\n\tselect distinct\n\t  b.name,\n\t\tSUBSTRING_INDEX(rid.new_ref_id,'tags/', -1) as tag_name,\n\t\ti.issue_key as issue_key,\n    i.title,\n    i.lead_time_minutes/1440 as lead_time_in_days,\n    concat(b.url,'/',i.issue_key) as url\n\tfrom\n\t\trefs_issues_diffs rid\n\t\tleft join issues i on rid.issue_id = i.id\n\t\tleft join pull_request_issues pri on i.id = pri.issue_id\n\t\tjoin boards b on SUBSTRING_INDEX(rid.new_ref_id,':', 4) = b.id\n\twhere\n\t\tSUBSTRING_INDEX(rid.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rid.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rid.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand i.type = 'BUG'\n),\n\n_bug_age_rank as(\n  select \n    *,\n    row_number() over (partition by tag_name order by lead_time_in_days desc) as bug_age_rank\n  from _bugs\n)\n\nselect \n  name,\n  tag_name,\n  issue_key,\n  title,\n  lead_time_in_days,\n  url\nfrom _bug_age_rank\nwhere bug_age_rank <=10 \norder by tag_name, lead_time_in_days desc",
           "refId": "A",
           "select": [
             [
@@ -1742,7 +1591,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 49
+        "y": 48
       },
       "id": 35,
       "options": {
@@ -1918,7 +1767,7 @@
         "h": 6,
         "w": 18,
         "x": 6,
-        "y": 49
+        "y": 48
       },
       "id": 39,
       "options": {
@@ -1967,7 +1816,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 54
       },
       "id": 47,
       "panels": [],
@@ -2015,7 +1864,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 56
+        "y": 55
       },
       "id": 41,
       "options": {
@@ -2041,7 +1890,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "-- Get the bug distribution in last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 10\n)\n\nselect \n\tSUBSTRING_INDEX(rcd.new_ref_id,'refs/tags/', -1) as tag_name,\n\tSUBSTRING_INDEX(rcd.old_ref_id,'refs/tags/', -1) as old_tag_name,\n\tcount(*) as commit_count\nfrom\n\trefs_commits_diffs rcd\n\tleft join commits c on rcd.commit_sha = c.sha\nwhere\n\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) in ($repo_id)\n\t-- and rcd.new_ref_id in (select new_ref_id from _last_5_tags)\n\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\ngroup by 1,2\norder by 1",
+          "rawSql": "-- Get the bug distribution in last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 10\n)\n\nselect \n\tSUBSTRING_INDEX(rcd.new_ref_id,'refs/tags/', -1) as tag_name,\n\tSUBSTRING_INDEX(rcd.old_ref_id,'refs/tags/', -1) as old_tag_name,\n\tcount(*) as commit_count\nfrom\n\trefs_commits_diffs rcd\n\tleft join commits c on rcd.commit_sha = c.sha\nwhere\n\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) in ($repo_id)\n\t-- and rcd.new_ref_id in (select new_ref_id from _last_5_tags)\n\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\ngroup by 1,2\norder by 1",
           "refId": "A",
           "select": [
             [
@@ -2137,7 +1986,7 @@
         "h": 7,
         "w": 18,
         "x": 6,
-        "y": 56
+        "y": 55
       },
       "id": 42,
       "options": {
@@ -2151,7 +2000,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "-- Get the bug distribution in last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 10\n)\n\nselect \n\tSUBSTRING_INDEX(rcd.new_ref_id,'refs/tags/', -1) as new_tag_name,\n\tSUBSTRING_INDEX(rcd.old_ref_id,'refs/tags/', -1) as compared_tag_name,\n\tc.sha,\n\tc.message,\n\tc.additions,\n\tc.deletions,\n\tc.author_name\nfrom\n\trefs_commits_diffs rcd\n\tleft join commits c on rcd.commit_sha = c.sha\nwhere\n\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) in ($repo_id)\n\t-- and rcd.new_ref_id in (select new_ref_id from _last_5_tags)\n\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\norder by 1 desc",
+          "rawSql": "-- Get the bug distribution in last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 10\n)\n\nselect \n\tSUBSTRING_INDEX(rcd.new_ref_id,'refs/tags/', -1) as new_tag_name,\n\tSUBSTRING_INDEX(rcd.old_ref_id,'refs/tags/', -1) as compared_tag_name,\n\tc.sha,\n\tc.message,\n\tc.additions,\n\tc.deletions,\n\tc.author_name\nfrom\n\trefs_commits_diffs rcd\n\tleft join commits c on rcd.commit_sha = c.sha\nwhere\n\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) in ($repo_id)\n\t-- and rcd.new_ref_id in (select new_ref_id from _last_5_tags)\n\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\norder by 1 desc",
           "refId": "A",
           "select": [
             [
@@ -2197,25 +2046,16 @@
         },
         "overrides": [
           {
-            "__systemRef": "hideSeriesFrom",
             "matcher": {
-              "id": "byNames",
-              "options": {
-                "mode": "exclude",
-                "names": [
-                  "dev_eq"
-                ],
-                "prefix": "All except:",
-                "readOnly": true
-              }
+              "id": "byName",
+              "options": "v22.3.2.2-lts BUG"
             },
             "properties": [
               {
-                "id": "custom.hideFrom",
+                "id": "color",
                 "value": {
-                  "legend": false,
-                  "tooltip": false,
-                  "viz": false
+                  "fixedColor": "red",
+                  "mode": "fixed"
                 }
               }
             ]
@@ -2229,37 +2069,7 @@
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "blue",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts REQUIREMENT"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "yellow",
-                  "mode": "fixed"
-                }
-              }
-            ]
-          },
-          {
-            "matcher": {
-              "id": "byName",
-              "options": "v22.3.2.2-lts BUG"
-            },
-            "properties": [
-              {
-                "id": "color",
-                "value": {
-                  "fixedColor": "green",
+                  "fixedColor": "text",
                   "mode": "fixed"
                 }
               }
@@ -2271,7 +2081,7 @@
         "h": 7,
         "w": 8,
         "x": 0,
-        "y": 63
+        "y": 62
       },
       "id": 26,
       "options": {
@@ -2306,7 +2116,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the work-type distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1\n),\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha, p.pull_request_key as pull_request_key from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha, pull_request_key as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name,\n    pr.id as pull_request_id,\n    count(c.sha) as pr_commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\tgroup by 1,2\n),\n\n_pr_issues as(\n  select\n    pri.pull_request_id,\n    pri.issue_id,\n    i.issue_key,\n    i.type,\n    row_number() over(partition by issue_id ORDER by pr.created_date asc) as pr_rank\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_final_results as(\n  select\n    distinct ccop.*, pi.type\n  from \n    _commit_count_of_pr ccop\n    left join _pr_issues pi on ccop.pull_request_id = pi.pull_request_id\n      where pi.pr_rank = 1\n  order by 1\n)\n\nSELECT\n  tag_name,\n  case when type != '' then type else 'UNKNOWN' end as type,\n  sum(pr_commit_count) as commit_count\nfrom _final_results\ngroup by 1,2",
+          "rawSql": "-- Get the work-type distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1\n),\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha, p.pull_request_key as pull_request_key from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha, pull_request_key as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name,\n    pr.id as pull_request_id,\n    count(c.sha) as pr_commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\tgroup by 1,2\n),\n\n_pr_issues as(\n  select\n    pri.pull_request_id,\n    pri.issue_id,\n    i.issue_key,\n    i.type,\n    row_number() over(partition by issue_id ORDER by pr.created_date asc) as pr_rank\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_final_results as(\n  select\n    distinct ccop.*, pi.type\n  from \n    _commit_count_of_pr ccop\n    left join _pr_issues pi on ccop.pull_request_id = pi.pull_request_id\n      where pi.pr_rank = 1\n  order by 1\n)\n\nSELECT\n  tag_name,\n  case when type != '' then type else 'UNKNOWN' end as type,\n  sum(pr_commit_count) as commit_count\nfrom _final_results\ngroup by 1,2",
           "refId": "A",
           "select": [
             [
@@ -2350,13 +2160,44 @@
           },
           "mappings": []
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "v22.2.3.5-stable UNKNOWN"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "text",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "v22.2.3.5-stable BUG"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 7,
         "w": 8,
         "x": 8,
-        "y": 63
+        "y": 62
       },
       "id": 36,
       "options": {
@@ -2391,7 +2232,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the work-type distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1,1\n),\n\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha, p.pull_request_key as pull_request_key from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha, pull_request_key as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name,\n    pr.id as pull_request_id,\n    count(c.sha) as pr_commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\tgroup by 1,2\n),\n\n_pr_issues as(\n  select\n    pri.pull_request_id,\n    pri.issue_id,\n    i.issue_key,\n    i.type,\n    row_number() over(partition by issue_id ORDER by pr.created_date asc) as pr_rank\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_final_results as(\n  select\n    distinct ccop.*, pi.type\n  from \n    _commit_count_of_pr ccop\n    left join _pr_issues pi on ccop.pull_request_id = pi.pull_request_id\n      where pi.pr_rank = 1\n  order by 1\n)\n\nSELECT\n  tag_name,\n  case when type != '' then type else 'UNKNOWN' end as type,\n  sum(pr_commit_count) as commit_count\nfrom _final_results\ngroup by 1,2",
+          "rawSql": "-- Get the work-type distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 1,1\n),\n\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha, p.pull_request_key as pull_request_key from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha, pull_request_key as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name,\n    pr.id as pull_request_id,\n    count(c.sha) as pr_commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\tgroup by 1,2\n),\n\n_pr_issues as(\n  select\n    pri.pull_request_id,\n    pri.issue_id,\n    i.issue_key,\n    i.type,\n    row_number() over(partition by issue_id ORDER by pr.created_date asc) as pr_rank\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_final_results as(\n  select\n    distinct ccop.*, pi.type\n  from \n    _commit_count_of_pr ccop\n    left join _pr_issues pi on ccop.pull_request_id = pi.pull_request_id\n      where pi.pr_rank = 1\n  order by 1\n)\n\nSELECT\n  tag_name,\n  case when type != '' then type else 'UNKNOWN' end as type,\n  sum(pr_commit_count) as commit_count\nfrom _final_results\ngroup by 1,2",
           "refId": "A",
           "select": [
             [
@@ -2439,13 +2280,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "v22.1.4.30-stable BUG"
+              "options": "v22.1.4.30-stable UNKNOWN"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "dark-yellow",
+                  "fixedColor": "text",
                   "mode": "fixed"
                 }
               }
@@ -2454,13 +2295,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "v22.1.4.30-stable REQUIREMENT"
+              "options": "v22.1.4.30-stable BUG"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "blue",
+                  "fixedColor": "red",
                   "mode": "fixed"
                 }
               }
@@ -2472,7 +2313,7 @@
         "h": 7,
         "w": 8,
         "x": 16,
-        "y": 63
+        "y": 62
       },
       "id": 37,
       "options": {
@@ -2507,7 +2348,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get the work-type distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 2,1\n),\n\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha, p.pull_request_key as pull_request_key from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha, pull_request_key as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name,\n    pr.id as pull_request_id,\n    count(c.sha) as pr_commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 3) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\tgroup by 1,2\n),\n\n_pr_issues as(\n  select\n    pri.pull_request_id,\n    pri.issue_id,\n    i.issue_key,\n    i.type,\n    row_number() over(partition by issue_id ORDER by pr.created_date asc) as pr_rank\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_final_results as(\n  select\n    distinct ccop.*, pi.type\n  from \n    _commit_count_of_pr ccop\n    left join _pr_issues pi on ccop.pull_request_id = pi.pull_request_id\n      where pi.pr_rank = 1\n  order by 1\n)\n\nSELECT\n  tag_name,\n  case when type != '' then type else 'UNKNOWN' end as type,\n  sum(pr_commit_count) as commit_count\nfrom _final_results\ngroup by 1,2",
+          "rawSql": "-- Get the work-type distribution in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 2,1\n),\n\n\n_combine_pr as (\n  select pull_request_id as id, commit_sha, p.pull_request_key as pull_request_key from pull_request_commits left join pull_requests p on pull_request_commits.pull_request_id = p.id\n  where base_repo_id in ($repo_id)\n  union\n  select id, merge_commit_sha, pull_request_key as commit_sha from pull_requests where base_repo_id in ($repo_id)\n),\n\n_commit_count_of_pr as(\n  select\n    SUBSTRING_INDEX(rcd.new_ref_id,'tags/', -1) as tag_name,\n    pr.id as pull_request_id,\n    count(c.sha) as pr_commit_count\n  FROM \n    refs_commits_diffs rcd\n\t\tleft join commits c on rcd.commit_sha = c.sha\n\t\t-- left join pull_request_commits prc on c.sha = prc.commit_sha\n\t\tleft join _combine_pr pr on c.sha = pr.commit_sha\n\twhere\n\t\tSUBSTRING_INDEX(rcd.new_ref_id,':', 4) in ($repo_id)\n\t\t-- and rcd.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\t\tand SUBSTRING_INDEX(rcd.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n\tgroup by 1,2\n),\n\n_pr_issues as(\n  select\n    pri.pull_request_id,\n    pri.issue_id,\n    i.issue_key,\n    i.type,\n    row_number() over(partition by issue_id ORDER by pr.created_date asc) as pr_rank\n  from\n    pull_request_issues pri\n    left join pull_requests pr on pri.pull_request_id = pr.id\n    left join issues i on pri.issue_id = i.id\n  where \n    issue_number != 0\n),\n\n_final_results as(\n  select\n    distinct ccop.*, pi.type\n  from \n    _commit_count_of_pr ccop\n    left join _pr_issues pi on ccop.pull_request_id = pi.pull_request_id\n      where pi.pr_rank = 1\n  order by 1\n)\n\nSELECT\n  tag_name,\n  case when type != '' then type else 'UNKNOWN' end as type,\n  sum(pr_commit_count) as commit_count\nfrom _final_results\ngroup by 1,2",
           "refId": "A",
           "select": [
             [
@@ -2568,7 +2409,7 @@
         "h": 7,
         "w": 6,
         "x": 0,
-        "y": 70
+        "y": 69
       },
       "id": 27,
       "options": {
@@ -2594,7 +2435,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "-- Get each contributor's work in bugfixing in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_author_commits as(\n  SELECT \n  \tc.author_name,\n    count(c.sha) as commit_count\n  FROM \n    refs_commits_diffs rcf\n    left join commits c on rcf.commit_sha = c.sha\n  WHERE\n  \t-- rcf.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n  \tSUBSTRING_INDEX(rcf.new_ref_id,':', 3) in ($repo_id)\n  \tand SUBSTRING_INDEX(rcf.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n  GROUP BY 1\n),\n\n_author_commits_running_total as(\n  SELECT \n    *, \n    sum(commit_count) OVER (Order by commit_count desc) AS running_total\n  FROM \n    _author_commits\n),\n\n_percentile as(\n  SELECT \n    author_name,\n    commit_count,\n    running_total/sum(commit_count) OVER () AS cumulative_percentage\n  FROM \n    _author_commits_running_total\n)\n\n\nSELECT \n  count(case when cumulative_percentage <= 0.8 then author_name else null end)/count(*) as \"contributors who contributed 80% of dev_eq\"\nFROM _percentile",
+          "rawSql": "-- Get each contributor's work in bugfixing in the last 5 tags\nwith _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n),\n\n_author_commits as(\n  SELECT \n  \tc.author_name,\n    count(c.sha) as commit_count\n  FROM \n    refs_commits_diffs rcf\n    left join commits c on rcf.commit_sha = c.sha\n  WHERE\n  \t-- rcf.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n  \tSUBSTRING_INDEX(rcf.new_ref_id,':', 4) in ($repo_id)\n  \tand SUBSTRING_INDEX(rcf.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\n  GROUP BY 1\n),\n\n_author_commits_running_total as(\n  SELECT \n    *, \n    sum(commit_count) OVER (Order by commit_count desc) AS running_total\n  FROM \n    _author_commits\n),\n\n_percentile as(\n  SELECT \n    author_name,\n    commit_count,\n    running_total/sum(commit_count) OVER () AS cumulative_percentage\n  FROM \n    _author_commits_running_total\n)\n\n\nSELECT \n  count(case when cumulative_percentage <= 0.8 then author_name else null end)/count(*) as \"contributors who contributed 80% of dev_eq\"\nFROM _percentile",
           "refId": "A",
           "select": [
             [
@@ -2663,7 +2504,7 @@
         "h": 7,
         "w": 18,
         "x": 6,
-        "y": 70
+        "y": 69
       },
       "id": 3,
       "options": {
@@ -2688,7 +2529,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "with _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 3) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n)\n\n\nSELECT \n\tc.author_name,\n  count(c.sha) total_dev_eq\nFROM \n  refs_commits_diffs rcf\n  left join commits c on rcf.commit_sha = c.sha\nWHERE\n\t-- rcf.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\tSUBSTRING_INDEX(rcf.new_ref_id,':', 3) in ($repo_id)\n\tand SUBSTRING_INDEX(rcf.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\nGROUP BY 1\nORDER BY 2 desc\nlimit 10",
+          "rawSql": "with _last_5_tags as(\n  SELECT \n    -- distinct new_ref_id, old_ref_id\n    distinct SUBSTRING_INDEX(new_ref_id,':', -1) as new_ref_id, SUBSTRING_INDEX(old_ref_id,':', -1) as old_ref_id\n  FROM \n    refs_commits_diffs\n  WHERE\n\t\tSUBSTRING_INDEX(new_ref_id,':', 4) in ($repo_id)\n\tORDER BY 1 desc\n\tLIMIT 5\n)\n\n\nSELECT \n\tc.author_name,\n  count(c.sha) total_dev_eq\nFROM \n  refs_commits_diffs rcf\n  left join commits c on rcf.commit_sha = c.sha\nWHERE\n\t-- rcf.new_ref_id in (SELECT new_ref_id FROM _last_5_tags)\n\tSUBSTRING_INDEX(rcf.new_ref_id,':', 4) in ($repo_id)\n\tand SUBSTRING_INDEX(rcf.new_ref_id,':', -1) in (SELECT new_ref_id FROM _last_5_tags)\nGROUP BY 1\nORDER BY 2 desc\nlimit 10",
           "refId": "A",
           "select": [
             [
@@ -2760,5 +2601,5 @@
   "timezone": "",
   "title": "GitHub_Release_Quality_and_Contribution_Analysis",
   "uid": "2xuOaQUnk4",
-  "version": 4
+  "version": 3
 }

--- a/grafana/dashboards/WeeklyBugRetro.json
+++ b/grafana/dashboards/WeeklyBugRetro.json
@@ -15,8 +15,8 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": 5,
-  "iteration": 1655906148389,
+  "id": 8,
+  "iteration": 1658722995471,
   "links": [],
   "panels": [
     {
@@ -308,7 +308,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select\n  i.number as 'Issue Number',\n  i.title as 'Title',\n  i.url as 'Url'\nfrom\n  lake.issues as i\n\tjoin lake.board_issues bi on i.id = bi.issue_id\n\tjoin lake.boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and date(i.created_date) BETWEEN curdate() - INTERVAL WEEKDAY(curdate())+7 DAY AND curdate() - INTERVAL WEEKDAY(curdate())+1 DAY\n  and b.id in ($repo_id)",
+          "rawSql": "select\n  i.issue_key as 'Issue Number',\n  i.title as 'Title',\n  i.url as 'Url'\nfrom\n  lake.issues as i\n\tjoin lake.board_issues bi on i.id = bi.issue_id\n\tjoin lake.boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and date(i.created_date) BETWEEN curdate() - INTERVAL WEEKDAY(curdate())+7 DAY AND curdate() - INTERVAL WEEKDAY(curdate())+1 DAY\n  and b.id in ($repo_id)",
           "refId": "A",
           "select": [
             [
@@ -616,7 +616,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select\n  i.number as 'Issue Number',\n  i.title as 'Title',\n  i.url as 'Url'\nfrom\n  lake.issues as i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and status = 'DONE'\n  and date(i.resolution_date) BETWEEN curdate() - INTERVAL WEEKDAY(curdate())+7 DAY AND curdate() - INTERVAL WEEKDAY(curdate())+1 DAY\n  and b.id in ($repo_id)",
+          "rawSql": "select\n  i.issue_key as 'Issue Number',\n  i.title as 'Title',\n  i.url as 'Url'\nfrom\n  lake.issues as i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and status = 'DONE'\n  and date(i.resolution_date) BETWEEN curdate() - INTERVAL WEEKDAY(curdate())+7 DAY AND curdate() - INTERVAL WEEKDAY(curdate())+1 DAY\n  and b.id in ($repo_id)",
           "refId": "A",
           "select": [
             [
@@ -713,7 +713,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select\n  concat('#',i.title) as issue_key,\n  lead_time_minutes/1440 as lead_time\nfrom\n  lake.issues as i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and status = 'DONE'\n  and date(i.resolution_date) BETWEEN curdate() - INTERVAL WEEKDAY(curdate())+7 DAY AND curdate() - INTERVAL WEEKDAY(curdate())+1 DAY\n  and b.id in ($repo_id)\norder by lead_time desc",
+          "rawSql": "select\n  concat('#',i.issue_key, ' ', i.title) as issue_key,\n  lead_time_minutes/1440 as lead_time\nfrom\n  lake.issues as i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and status = 'DONE'\n  and date(i.resolution_date) BETWEEN curdate() - INTERVAL WEEKDAY(curdate())+7 DAY AND curdate() - INTERVAL WEEKDAY(curdate())+1 DAY\n  and b.id in ($repo_id)\norder by lead_time desc",
           "refId": "A",
           "select": [
             [
@@ -1040,7 +1040,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select \n  i.number as 'Issue Number',\n  i.title as 'Title',\n  (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as 'Queue Time in Days',\n  i.url as 'Url'\nfrom \n  lake.issues i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  i.type in ($issue_type)\n  and i.status != 'DONE'\n  and b.id in ($repo_id)\norder by 'Queue Time' desc",
+          "rawSql": "select \n  i.issue_key as 'Issue Number',\n  i.title as 'Title',\n  (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as 'Queue Time in Days',\n  i.url as 'Url'\nfrom \n  lake.issues i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  i.type in ($issue_type)\n  and i.status != 'DONE'\n  and b.id in ($repo_id)\norder by 'Queue Time' desc",
           "refId": "A",
           "select": [
             [
@@ -1136,7 +1136,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "select \n  concat('#', i.number) as issue_key,\n  (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as 'Queue Time in Days'\nfrom \n  lake.issues i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and i.status != 'DONE'\n  and b.id in ($repo_id)\norder by 2 desc",
+          "rawSql": "select \n  concat('#', i.issue_key, ' ', i.title) as issue_key,\n  (TIMESTAMPDIFF(MINUTE, i.created_date,NOW()))/1440 as 'Queue Time in Days'\nfrom \n  lake.issues i\n\tjoin board_issues bi on i.id = bi.issue_id\n\tjoin boards b on bi.board_id = b.id\nwhere\n  type in ($issue_type)\n  and i.status != 'DONE'\n  and b.id in ($repo_id)\norder by 2 desc",
           "refId": "A",
           "select": [
             [
@@ -1217,7 +1217,9 @@
         },
         "orientation": "auto",
         "showValue": "auto",
-        "text": {},
+        "text": {
+          "valueSize": 12
+        },
         "tooltip": {
           "mode": "single"
         }
@@ -1310,7 +1312,9 @@
         },
         "orientation": "auto",
         "showValue": "auto",
-        "text": {},
+        "text": {
+          "valueSize": 12
+        },
         "tooltip": {
           "mode": "single"
         }
@@ -1397,13 +1401,17 @@
         "barWidth": 0.71,
         "groupWidth": 0.7,
         "legend": {
-          "calcs": [],
+          "calcs": [
+            "mean"
+          ],
           "displayMode": "list",
           "placement": "bottom"
         },
         "orientation": "auto",
         "showValue": "auto",
-        "text": {},
+        "text": {
+          "valueSize": 12
+        },
         "tooltip": {
           "mode": "single"
         }
@@ -1415,7 +1423,7 @@
           "metricColumn": "none",
           "queryType": "randomWalk",
           "rawQuery": true,
-          "rawSql": "with calendar_date as(\n\tSELECT CAST((SYSDATE()-INTERVAL (H+T+U) DAY) AS date) d\n\tFROM ( SELECT 0 H\n\t\t\tUNION ALL SELECT 100 UNION ALL SELECT 200 UNION ALL SELECT 300\n\t\t) H CROSS JOIN ( SELECT 0 T\n\t\t\tUNION ALL SELECT  10 UNION ALL SELECT  20 UNION ALL SELECT  30\n\t\t\tUNION ALL SELECT  40 UNION ALL SELECT  50 UNION ALL SELECT  60\n\t\t\tUNION ALL SELECT  70 UNION ALL SELECT  80 UNION ALL SELECT  90\n\t\t) T CROSS JOIN ( SELECT 0 U\n\t\t\tUNION ALL SELECT   1 UNION ALL SELECT   2 UNION ALL SELECT   3\n\t\t\tUNION ALL SELECT   4 UNION ALL SELECT   5 UNION ALL SELECT   6\n\t\t\tUNION ALL SELECT   7 UNION ALL SELECT   8 UNION ALL SELECT   9\n\t\t) U\n\tWHERE\n\t\t(SYSDATE()-INTERVAL (H+T+U) DAY) >= (SYSDATE()-INTERVAL 6 MONTH)\n),\n\ncalendar_weeks as(\n  select \n  \tdistinct date(DATE_ADD(date(d), INTERVAL -WEEKDAY(date(d)) DAY)) as start_of_week\n  FROM calendar_date\n  ORDER BY 1 asc\n),\n\ncreated_bugs as (  \n  select \n    DATE_ADD(date(i.created_date), INTERVAL -WEEKDAY(date(i.created_date)) DAY) as time,\n    count(*) as bug_count\n  from\n    lake.issues as i\n\t  join lake.board_issues bi on i.id = bi.issue_id\n\t  join lake.boards b on bi.board_id = b.id\n  where \n    type in ($issue_type)\n    and $__timeFilter(i.created_date)\n    and b.id in ($repo_id)\n  group by time\n  order by time desc\n),\n\nresolved_bugs as (\n  select \n    DATE_ADD(date(i.resolution_date), INTERVAL -WEEKDAY(date(i.resolution_date)) DAY) as time,\n    count(*) as bug_count\n  from\n    lake.issues as i\n\t  join lake.board_issues bi on i.id = bi.issue_id\n\t  join lake.boards b on bi.board_id = b.id\n  where \n    type in ($issue_type)\n    and status = 'DONE'\n    and $__timeFilter(i.resolution_date)\n    and b.id in ($repo_id)\n  group by time\n  order by time desc\n),\n\nweekly_new_bug as(\n  select\n    cw.start_of_week as week,\n    case when bug_count is not null then bug_count else 0 end as weekly_new_bug\n  from calendar_weeks cw left join created_bugs cb on cw.start_of_week = cb.time\n),\n\nweekly_closed_bug as(\n  select\n    cw.start_of_week as week,\n    case when bug_count is not null then bug_count else 0 end as weekly_closed_bug\n  from calendar_weeks cw left join resolved_bugs cb on cw.start_of_week = cb.time\n),\n\nweekly_updates as(\n  SELECT t1.week, weekly_new_bug, weekly_closed_bug FROM weekly_new_bug t1\n  LEFT JOIN weekly_closed_bug t2 ON t1.week = t2.week\n  UNION\n  SELECT t1.week, weekly_new_bug, weekly_closed_bug FROM weekly_new_bug t1\n  RIGHT JOIN weekly_closed_bug t2 ON t1.week = t2.week\n),\n\n\noriginal_open_bugs as (\n  SELECT \n    count(distinct i.id) as original_open_bug_count\n  FROM\n    lake.issues as i\n\t  join lake.board_issues bi on i.id = bi.issue_id\n\t  join lake.boards b on bi.board_id = b.id\n  where \n    i.type in ($issue_type)\n    and i.created_date < $__timeFrom()\n    and (i.status != 'DONE' or $__timeFilter(i.resolution_date))\n    and b.id in ($repo_id)\n),\n\nweekly_updated_without_null as(\n  SELECT \n    week, \n    COALESCE(weekly_new_bug,0) as weekly_new_bug, \n    COALESCE(weekly_closed_bug,0) as weekly_closed_bug,\n    original_open_bug_count\n  from weekly_updates, original_open_bugs\n  where week is not null\n),\n\nweekly_delta as(\n  SELECT \n    *,\n    (weekly_new_bug - weekly_closed_bug) as weekly_delta\n  from weekly_updated_without_null\n  order by week asc\n),\n\nfinal_data as(\n  SELECT \n    *,\n    concat(date_format(week,'%m/%d'), ' - ', date_format(DATE_ADD(week, INTERVAL +6 DAY),'%m/%d')) as _week,\n    sum(weekly_delta) over(order by week asc) as weekly_accumulated\n  from weekly_delta\n)\n\nSELECT \n  _week,\n  (original_open_bug_count + weekly_accumulated) as total_outstanding_bug_count from final_data",
+          "rawSql": "with calendar_date as(\n\tSELECT CAST((SYSDATE()-INTERVAL (H+T+U) DAY) AS date) d\n\tFROM ( SELECT 0 H\n\t\t\tUNION ALL SELECT 100 UNION ALL SELECT 200 UNION ALL SELECT 300\n\t\t) H CROSS JOIN ( SELECT 0 T\n\t\t\tUNION ALL SELECT  10 UNION ALL SELECT  20 UNION ALL SELECT  30\n\t\t\tUNION ALL SELECT  40 UNION ALL SELECT  50 UNION ALL SELECT  60\n\t\t\tUNION ALL SELECT  70 UNION ALL SELECT  80 UNION ALL SELECT  90\n\t\t) T CROSS JOIN ( SELECT 0 U\n\t\t\tUNION ALL SELECT   1 UNION ALL SELECT   2 UNION ALL SELECT   3\n\t\t\tUNION ALL SELECT   4 UNION ALL SELECT   5 UNION ALL SELECT   6\n\t\t\tUNION ALL SELECT   7 UNION ALL SELECT   8 UNION ALL SELECT   9\n\t\t) U\n\tWHERE\n\t\t(SYSDATE()-INTERVAL (H+T+U) DAY) >= (SYSDATE()-INTERVAL 6 MONTH)\n),\n\ncalendar_weeks as(\n  select \n  \tdistinct date(DATE_ADD(date(d), INTERVAL -WEEKDAY(date(d)) DAY)) as start_of_week\n  FROM calendar_date\n  ORDER BY 1 asc\n),\n\ncreated_bugs as (  \n  select \n    DATE_ADD(date(i.created_date), INTERVAL -WEEKDAY(date(i.created_date)) DAY) as time,\n    count(*) as bug_count\n  from\n    lake.issues as i\n\t  join lake.board_issues bi on i.id = bi.issue_id\n\t  join lake.boards b on bi.board_id = b.id\n  where \n    type in ($issue_type)\n    and $__timeFilter(i.created_date)\n    and b.id in ($repo_id)\n  group by time\n  order by time desc\n),\n\nresolved_bugs as (\n  select \n    DATE_ADD(date(i.resolution_date), INTERVAL -WEEKDAY(date(i.resolution_date)) DAY) as time,\n    count(*) as bug_count\n  from\n    lake.issues as i\n\t  join lake.board_issues bi on i.id = bi.issue_id\n\t  join lake.boards b on bi.board_id = b.id\n  where \n    type in ($issue_type)\n    and status = 'DONE'\n    and $__timeFilter(i.resolution_date)\n    and b.id in ($repo_id)\n  group by time\n  order by time desc\n),\n\nweekly_new_bug as(\n  select\n    cw.start_of_week as week,\n    case when bug_count is not null then bug_count else 0 end as weekly_new_bug\n  from calendar_weeks cw left join created_bugs cb on cw.start_of_week = cb.time\n),\n\nweekly_closed_bug as(\n  select\n    cw.start_of_week as week,\n    case when bug_count is not null then bug_count else 0 end as weekly_closed_bug\n  from calendar_weeks cw left join resolved_bugs cb on cw.start_of_week = cb.time\n),\n\nweekly_updates as(\n  SELECT t1.week, weekly_new_bug, weekly_closed_bug FROM weekly_new_bug t1\n  LEFT JOIN weekly_closed_bug t2 ON t1.week = t2.week\n  UNION\n  SELECT t1.week, weekly_new_bug, weekly_closed_bug FROM weekly_new_bug t1\n  RIGHT JOIN weekly_closed_bug t2 ON t1.week = t2.week\n),\n\n\noriginal_open_bugs as (\n  SELECT \n    count(distinct i.id) as original_open_bug_count\n  FROM\n    lake.issues as i\n\t  join lake.board_issues bi on i.id = bi.issue_id\n\t  join lake.boards b on bi.board_id = b.id\n  where \n    i.type in ($issue_type)\n    and i.created_date < $__timeFrom()\n    and (i.status != 'DONE' or $__timeFilter(i.resolution_date))\n    and b.id in ($repo_id)\n),\n\nweekly_updated_without_null as(\n  SELECT \n    week, \n    COALESCE(weekly_new_bug,0) as weekly_new_bug, \n    COALESCE(weekly_closed_bug,0) as weekly_closed_bug,\n    original_open_bug_count\n  from weekly_updates, original_open_bugs\n  where week is not null\n),\n\nweekly_delta as(\n  SELECT \n    *,\n    (weekly_new_bug - weekly_closed_bug) as weekly_delta\n  from weekly_updated_without_null\n  order by week asc\n),\n\nfinal_data as(\n  SELECT \n    *,\n    concat(date_format(week,'%m/%d'), ' - ', date_format(DATE_ADD(week, INTERVAL +6 DAY),'%m/%d')) as _week,\n    sum(weekly_delta) over(order by week asc) as weekly_accumulated\n  from weekly_delta\n)\n\nSELECT \n  _week,\n  (original_open_bug_count + weekly_accumulated) as \"Total No. of Outstanding Bugs By the End of Week\" from final_data",
           "refId": "A",
           "select": [
             [
@@ -1452,8 +1460,8 @@
         "allValue": null,
         "current": {
           "selected": false,
-          "text": "apache/incubator-devlake",
-          "value": "github:GithubRepo:384111310"
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "mysql",
         "definition": "select concat(name, '-', id) as text from repos",
@@ -1506,5 +1514,5 @@
   "timezone": "",
   "title": "Weekly Bug Retro",
   "uid": "-5EKA5w7k",
-  "version": 29
+  "version": 3
 }


### PR DESCRIPTION
# Summary
1. update Weekly Bug Retro as `issues.number` -> `issues.issue_key`
2. update GitHub Release Quality and Contribution Dashboards as the composition of ref id changed.
3. update Engineering dashboard as `changelogs` -> `issue_changelogs`, `to` -> `original_to_value`, etc.

### Does this close any open issues?
Closes #2588 

### Screenshots
![image](https://user-images.githubusercontent.com/14050754/180724648-9fb2226e-b140-4051-bce8-04b3912a6298.png)

![image](https://user-images.githubusercontent.com/14050754/180724718-b1d4de8c-aefe-434e-9ec3-a37472c76f12.png)

