### PR TITLE
fix(config-ui): BP in advanced mode cannot be displayed normally

### DIFF
--- a/config-ui/src/pages/blueprint/detail/configuration-panel.tsx
+++ b/config-ui/src/pages/blueprint/detail/configuration-panel.tsx
@@ -137,7 +137,7 @@ export const ConfigurationPanel = ({ from, blueprint, onRefresh }: Props) => {
               title: 'Data Time Range',
               dataIndex: 'timeRange',
               key: 'timeRange',
-              render: (val) => `${formatTime(val)} to Now`,
+              render: (val) => (blueprint.mode === ModeEnum.normal ? `${formatTime(val)} to Now` : 'N/A'),
             },
             {
               title: 'Sync Frequency',
@@ -159,7 +159,7 @@ export const ConfigurationPanel = ({ from, blueprint, onRefresh }: Props) => {
           ]}
           dataSource={[
             {
-              timeRange: blueprint.settings.timeAfter,
+              timeRange: blueprint?.settings?.timeAfter,
               frequency: blueprint.cronConfig,
               isManual: blueprint.isManual,
               skipFailed: blueprint.skipOnFail,


### PR DESCRIPTION
### Summary
Fixed BP in advanced mode cannot be displayed normally.

### Does this close any open issues?
Closes #5651 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/37237996/bb0a96cd-f7a7-45ff-aca5-e4998c2dd505)

