### PR TITLE
refactor: zentao plugin

### DIFF
--- a/backend/plugins/zentao/api/blueprint_V200_test.go
+++ b/backend/plugins/zentao/api/blueprint_V200_test.go
@@ -82,7 +82,6 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 				Subtasks: []string{},
 				Options: map[string]interface{}{
 					"ConnectionId": uint64(1),
-					"productId":    int64(0),
 					"projectId":    int64(1),
 				},
 			},

--- a/backend/plugins/zentao/api/init.go
+++ b/backend/plugins/zentao/api/init.go
@@ -34,8 +34,7 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var projectScopeHelper *api.ScopeApiHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoScopeConfig]
 
-var productRemoteHelper *api.RemoteApiHelper[models.ZentaoConnection, models.ZentaoProduct, models.ZentaoProductRes, api.BaseRemoteGroupResponse]
-var projectRemoteHelper *api.RemoteApiHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.NoRemoteGroupResponse]
+var projectRemoteHelper *api.RemoteApiHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.BaseRemoteGroupResponse]
 var basicRes context.BasicRes
 var scHelper *api.ScopeConfigHelper[models.ZentaoScopeConfig]
 
@@ -63,12 +62,8 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		projectParams,
 		nil,
 	)
-	productRemoteHelper = api.NewRemoteHelper[models.ZentaoConnection, models.ZentaoProduct, models.ZentaoProductRes, api.BaseRemoteGroupResponse](
-		basicRes,
-		vld,
-		connectionHelper,
-	)
-	projectRemoteHelper = api.NewRemoteHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.NoRemoteGroupResponse](
+
+	projectRemoteHelper = api.NewRemoteHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.BaseRemoteGroupResponse](
 		basicRes,
 		vld,
 		connectionHelper,

--- a/backend/plugins/zentao/api/remote.go
+++ b/backend/plugins/zentao/api/remote.go
@@ -74,35 +74,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 	}
 	gid := groupId[0]
 	if gid == "" {
-		return productRemoteHelper.GetScopesFromRemote(input, getGroup, nil)
-	} else if gid == `products` {
-		/*
-			return productRemoteHelper.GetScopesFromRemote(input,
-				nil,
-				func(basicRes context2.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.ZentaoConnection) ([]models.ZentaoProductRes, errors.Error) {
-					query := initialQuery(queryData)
-					// create api client
-					apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, &connection)
-					if err != nil {
-						return nil, err
-					}
-
-					query.Set("sort", "name")
-					// list projects part
-					res, err := apiClient.Get("/products", query, nil)
-					if err != nil {
-						return nil, err
-					}
-
-					resBody := &ProductResponse{}
-					err = api.UnmarshalResponse(res, resBody)
-					if err != nil {
-						return nil, err
-					}
-					return resBody.Values, nil
-				})
-		*/
-		return nil, errors.BadInput.New("products are currently unsupported")
+		return projectRemoteHelper.GetScopesFromRemote(input, getGroup, nil)
 	} else if gid == `projects` {
 		return projectRemoteHelper.GetScopesFromRemote(input,
 			nil,

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -86,6 +86,7 @@ func (p Zentao) GetTablesInfo() []dal.Tabler {
 		&models.ZentaoBugRepoCommit{},
 		&models.ZentaoConnection{},
 		&models.ZentaoScopeConfig{},
+		&models.ZentaoExecutionStory{},
 	}
 }
 
@@ -103,22 +104,20 @@ func (p Zentao) ScopeConfig() dal.Tabler {
 
 func (p Zentao) SubTaskMetas() []plugin.SubTaskMeta {
 	return []plugin.SubTaskMeta{
-		//tasks.ConvertProductMeta,
 		tasks.ConvertProjectMeta,
-
-		tasks.DBGetChangelogMeta,
-		tasks.ConvertChangelogMeta,
 
 		// both
 		tasks.CollectAccountMeta,
 		tasks.ExtractAccountMeta,
 		tasks.ConvertAccountMeta,
 
-		tasks.CollectDepartmentMeta,
-		tasks.ExtractDepartmentMeta,
-		tasks.ConvertDepartmentMeta,
+		//tasks.CollectDepartmentMeta,
+		//tasks.ExtractDepartmentMeta,
+		//tasks.ConvertDepartmentMeta,
 
 		// project
+		tasks.CollectExecutionSummaryMeta,
+		tasks.ExtractExecutionSummaryMeta,
 		tasks.CollectExecutionMeta,
 		tasks.ExtractExecutionMeta,
 		tasks.ConvertExecutionMeta,
@@ -137,6 +136,7 @@ func (p Zentao) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectStoryMeta,
 		tasks.ExtractStoryMeta,
 		tasks.ConvertStoryMeta,
+		tasks.ConvertExecutionStoryMeta,
 
 		tasks.CollectBugMeta,
 		tasks.ExtractBugMeta,
@@ -153,6 +153,9 @@ func (p Zentao) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectBugRepoCommitsMeta,
 		tasks.ExtractBugRepoCommitsMeta,
 		tasks.ConvertBugRepoCommitsMeta,
+
+		tasks.DBGetChangelogMeta,
+		tasks.ConvertChangelogMeta,
 	}
 }
 
@@ -195,6 +198,9 @@ func (p Zentao) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 		ProductList: map[int64]string{},
 		StoryList:   map[int64]int64{},
 		FromBugList: map[int]bool{},
+		Stories:     map[int64]struct{}{},
+		Tasks:       map[int64]struct{}{},
+		Bugs:        map[int64]struct{}{},
 	}
 
 	if connection.DbUrl != "" {

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -87,6 +87,9 @@ func (p Zentao) GetTablesInfo() []dal.Tabler {
 		&models.ZentaoConnection{},
 		&models.ZentaoScopeConfig{},
 		&models.ZentaoExecutionStory{},
+		&models.ZentaoExecutionSummary{},
+		&models.ZentaoProductSummary{},
+		&models.ZentaoProjectStory{},
 	}
 }
 

--- a/backend/plugins/zentao/models/archived/changelog.go
+++ b/backend/plugins/zentao/models/archived/changelog.go
@@ -27,14 +27,14 @@ type ZentaoChangelog struct {
 	archived.NoPKModel `json:"-"`
 	ConnectionId       uint64    `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey;type:BIGINT  NOT NULL"`
 	Id                 int64     `json:"id" mapstructure:"id" gorm:"primaryKey;type:BIGINT  NOT NULL;autoIncrement:false"`
-	ObjectId           int       `json:"objectId" mapstructure:"objectId" gorm:"index; NOT NULL"`
-	Execution          int       `json:"execution" mapstructure:"execution" `
+	ObjectId           int64     `json:"objectId" mapstructure:"objectId" gorm:"index; NOT NULL"`
+	Execution          int64     `json:"execution" mapstructure:"execution" `
 	Actor              string    `json:"actor" mapstructure:"actor" `
 	Action             string    `json:"action" mapstructure:"action"`
 	Extra              string    `json:"extra" mapstructure:"extra"`
 	ObjectType         string    `json:"objectType" mapstructure:"objectType"`
-	Project            int       `json:"project" mapstructure:"project"`
-	Product            int       `json:"product" mapstructure:"product"`
+	Project            int64     `json:"project" mapstructure:"project"`
+	Product            int64     `json:"product" mapstructure:"product"`
 	Vision             string    `json:"vision" mapstructure:"vision"`
 	Comment            string    `json:"comment" mapstructure:"comment"`
 	Efforted           string    `json:"efforted" mapstructure:"efforted"`

--- a/backend/plugins/zentao/models/archived/execution_stories.go
+++ b/backend/plugins/zentao/models/archived/execution_stories.go
@@ -15,21 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoExecutionStory struct {
+	archived.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey"`
+	ProjectId    int64  `gorm:"primaryKey"`
+	ExecutionId  int64  `gorm:"primaryKey"`
+	StoryId      int64  `gorm:"primaryKey"`
+}
+
+func (ZentaoExecutionStory) TableName() string {
+	return "_tool_zentao_execution_stories"
 }

--- a/backend/plugins/zentao/models/archived/execution_summary.go
+++ b/backend/plugins/zentao/models/archived/execution_summary.go
@@ -15,21 +15,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoExecutionSummary struct {
+	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
+	Id           int64  `gorm:"primaryKey;type:BIGINT  NOT NULL;autoIncrement:false"`
+	Name         string `gorm:"type:varchar(255)"`
+	Project      int64
+	Code         string `gorm:"type:varchar(255)"`
+	Type         string `gorm:"type:varchar(255)"`
+	archived.NoPKModel
+}
+
+func (ZentaoExecutionSummary) TableName() string {
+	return "_tool_zentao_execution_summary"
 }

--- a/backend/plugins/zentao/models/archived/product_summary.go
+++ b/backend/plugins/zentao/models/archived/product_summary.go
@@ -15,21 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoProductSummary struct {
+	archived.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey"`
+	ProjectId    int64  `gorm:"primaryKey"`
+	Id           int64  `gorm:"primaryKey;autoIncrement:false"`
+	Name         string `gorm:"type:VARCHAR(255)"`
+}
+
+func (ZentaoProductSummary) TableName() string {
+	return "_tool_zentao_product_summary"
 }

--- a/backend/plugins/zentao/models/archived/project_stories.go
+++ b/backend/plugins/zentao/models/archived/project_stories.go
@@ -15,21 +15,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoProjectStory struct {
+	archived.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
+	ProjectId    int64  `gorm:"primaryKey"`
+	StoryId      int64  `gorm:"primaryKey"`
+}
+
+func (ZentaoProjectStory) TableName() string {
+	return "_tool_zentao_project_stories"
 }

--- a/backend/plugins/zentao/models/bug.go
+++ b/backend/plugins/zentao/models/bug.go
@@ -31,17 +31,6 @@ type ApiAccount struct {
 	Realname string `json:"realname"`
 }
 
-func (a ApiAccount) getId() int64 {
-	return 0
-}
-
-func (a ApiAccount) getName() string {
-	return ""
-}
-func (a ApiAccount) getAccount() string {
-	return ""
-}
-
 func (a *ApiAccount) UnmarshalJSON(data []byte) error {
 	var dst struct {
 		ID       int64  `json:"id"`

--- a/backend/plugins/zentao/models/bug.go
+++ b/backend/plugins/zentao/models/bug.go
@@ -18,9 +18,52 @@ limitations under the License.
 package models
 
 import (
+	"bytes"
+	"encoding/json"
 	"github.com/apache/incubator-devlake/core/models/common"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
+
+type ApiAccount struct {
+	ID       int64  `json:"id"`
+	Account  string `json:"account"`
+	Avatar   string `json:"avatar"`
+	Realname string `json:"realname"`
+}
+
+func (a ApiAccount) getId() int64 {
+	return 0
+}
+
+func (a ApiAccount) getName() string {
+	return ""
+}
+func (a ApiAccount) getAccount() string {
+	return ""
+}
+
+func (a *ApiAccount) UnmarshalJSON(data []byte) error {
+	var dst struct {
+		ID       int64  `json:"id"`
+		Account  string `json:"account"`
+		Avatar   string `json:"avatar"`
+		Realname string `json:"realname"`
+	}
+	data = bytes.TrimSpace(data)
+	if string(data) == "null" {
+		a = nil
+	}
+	if len(data) > 1 && data[0] == '"' && data[len(data)-1] == '"' {
+		dst.Account = string(data[1 : len(data)-1])
+	} else {
+		err := json.Unmarshal(data, &dst)
+		if err != nil {
+			return err
+		}
+	}
+	*a = dst
+	return nil
+}
 
 type ZentaoBugRes struct {
 	ID             int64               `json:"id"`
@@ -55,17 +98,17 @@ type ZentaoBugRes struct {
 	ActivatedDate  *helper.Iso8601Time `json:"activatedDate"`
 	FeedbackBy     string              `json:"feedbackBy"`
 	NotifyEmail    string              `json:"notifyEmail"`
-	OpenedBy       *ZentaoAccount      `json:"openedBy"`
+	OpenedBy       *ApiAccount         `json:"openedBy"`
 	OpenedDate     *helper.Iso8601Time `json:"openedDate"`
 	OpenedBuild    string              `json:"openedBuild"`
-	AssignedTo     *ZentaoAccount      `json:"assignedTo"`
+	AssignedTo     *ApiAccount         `json:"assignedTo"`
 	AssignedDate   *helper.Iso8601Time `json:"assignedDate"`
 	Deadline       string              `json:"deadline"`
-	ResolvedBy     *ZentaoAccount      `json:"resolvedBy"`
+	ResolvedBy     *ApiAccount         `json:"resolvedBy"`
 	Resolution     string              `json:"resolution"`
 	ResolvedBuild  string              `json:"resolvedBuild"`
 	ResolvedDate   *helper.Iso8601Time `json:"resolvedDate"`
-	ClosedBy       *ZentaoAccount      `json:"closedBy"`
+	ClosedBy       *ApiAccount         `json:"closedBy"`
 	ClosedDate     *helper.Iso8601Time `json:"closedDate"`
 	DuplicateBug   int                 `json:"duplicateBug"`
 	LinkBug        string              `json:"linkBug"`
@@ -80,7 +123,7 @@ type ZentaoBugRes struct {
 	RepoType       string              `json:"repoType"`
 	IssueKey       string              `json:"issueKey"`
 	Testtask       int                 `json:"testtask"`
-	LastEditedBy   *ZentaoAccount      `json:"lastEditedBy"`
+	LastEditedBy   *ApiAccount         `json:"lastEditedBy"`
 	LastEditedDate *helper.Iso8601Time `json:"lastEditedDate"`
 	Deleted        bool                `json:"deleted"`
 	PriOrder       string              `json:"priOrder"`

--- a/backend/plugins/zentao/models/bug_test.go
+++ b/backend/plugins/zentao/models/bug_test.go
@@ -1,0 +1,121 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestApiAccount_UnmarshalJSON(t *testing.T) {
+	type bug struct {
+		NotifyEmail string `json:"notifyEmail"`
+		OpenedBy    *ApiAccount
+	}
+
+	type args struct {
+		data []byte
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bug
+		wantErr bool
+	}{
+		{
+			"string",
+			args{
+				data: []byte(`{
+								  "notifyEmail": "caitlyn.langosh@yahoo.com",
+								  "openedBy": "admin"
+								}`),
+			},
+			bug{
+				NotifyEmail: "caitlyn.langosh@yahoo.com",
+				OpenedBy:    &ApiAccount{Account: "admin"},
+			},
+			false,
+		},
+		{
+			"empty string",
+			args{
+				data: []byte(`{
+								  "notifyEmail": "caitlyn.langosh@yahoo.com",
+								  "openedBy": ""
+								}`),
+			},
+			bug{
+				NotifyEmail: "caitlyn.langosh@yahoo.com",
+				OpenedBy:    &ApiAccount{},
+			},
+			false,
+		},
+		{
+			"struct",
+			args{
+				data: []byte(`{
+								  "notifyEmail": "caitlyn.langosh@yahoo.com",
+								  "openedBy": {
+									"id": 1,
+									"account": "admin",
+									"avatar": "https://example.com/avatar.png",
+									"realname": "root"
+								  }
+								}`),
+			},
+			bug{
+				NotifyEmail: "caitlyn.langosh@yahoo.com",
+				OpenedBy: &ApiAccount{
+					ID:       1,
+					Account:  "admin",
+					Avatar:   "https://example.com/avatar.png",
+					Realname: "root",
+				},
+			},
+			false,
+		},
+		{
+			"null",
+			args{
+				data: []byte(`{
+								  "notifyEmail": "caitlyn.langosh@yahoo.com",
+								  "openedBy": null
+								}`),
+			},
+			bug{
+				NotifyEmail: "caitlyn.langosh@yahoo.com",
+				OpenedBy:    nil,
+			},
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var dst bug
+			if err := json.Unmarshal(tt.args.data, &dst); (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !reflect.DeepEqual(dst, tt.want) {
+				t.Errorf("UnmarshalJSON() got = %v, want %v", dst, tt.want)
+			}
+			t.Logf("%+v\n", dst.OpenedBy)
+		})
+	}
+}

--- a/backend/plugins/zentao/models/changelog.go
+++ b/backend/plugins/zentao/models/changelog.go
@@ -27,14 +27,14 @@ type ZentaoChangelog struct {
 	common.NoPKModel `json:"-"`
 	ConnectionId     uint64    `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey;type:BIGINT  NOT NULL"`
 	Id               int64     `json:"id" mapstructure:"id" gorm:"primaryKey;type:BIGINT  NOT NULL;autoIncrement:false"`
-	ObjectId         int       `json:"objectId" mapstructure:"objectId" gorm:"index; NOT NULL"`
-	Execution        int       `json:"execution" mapstructure:"execution" `
+	ObjectId         int64     `json:"objectId" mapstructure:"objectId" gorm:"index; NOT NULL"`
+	Execution        int64     `json:"execution" mapstructure:"execution" `
 	Actor            string    `json:"actor" mapstructure:"actor" `
 	Action           string    `json:"action" mapstructure:"action"`
 	Extra            string    `json:"extra" mapstructure:"extra"`
 	ObjectType       string    `json:"objectType" mapstructure:"objectType"`
-	Project          int       `json:"project" mapstructure:"project"`
-	Product          int       `json:"product" mapstructure:"product"`
+	Project          int64     `json:"project" mapstructure:"project"`
+	Product          int64     `json:"product" mapstructure:"product"`
 	Vision           string    `json:"vision" mapstructure:"vision"`
 	Comment          string    `json:"comment" mapstructure:"comment"`
 	Efforted         string    `json:"efforted" mapstructure:"efforted"`

--- a/backend/plugins/zentao/models/execution_stories.go
+++ b/backend/plugins/zentao/models/execution_stories.go
@@ -15,21 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package models
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/common"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoExecutionStory struct {
+	common.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
+	ProjectId    int64  `gorm:"primaryKey"`
+	ExecutionId  int64  `gorm:"primaryKey"`
+	StoryId      int64  `gorm:"primaryKey"`
+}
+
+func (ZentaoExecutionStory) TableName() string {
+	return "_tool_zentao_execution_stories"
 }

--- a/backend/plugins/zentao/models/execution_summary.go
+++ b/backend/plugins/zentao/models/execution_summary.go
@@ -15,21 +15,22 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package models
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/common"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoExecutionSummary struct {
+	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
+	Id           int64  `gorm:"primaryKey;type:BIGINT  NOT NULL;autoIncrement:false"`
+	Name         string `gorm:"type:varchar(255)"`
+	Project      int64
+	Code         string `gorm:"type:varchar(255)"`
+	Type         string `gorm:"type:varchar(255)"`
+	common.NoPKModel
+}
+
+func (ZentaoExecutionSummary) TableName() string {
+	return "_tool_zentao_execution_summary"
 }

--- a/backend/plugins/zentao/models/migrationscripts/20230705_add_execution_stories.go
+++ b/backend/plugins/zentao/models/migrationscripts/20230705_add_execution_stories.go
@@ -1,0 +1,45 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/zentao/models/archived"
+)
+
+type addExecutionStoryAndExecutionSummary struct{}
+
+func (*addExecutionStoryAndExecutionSummary) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(
+		basicRes,
+		&archived.ZentaoExecutionStory{},
+		&archived.ZentaoExecutionSummary{},
+		&archived.ZentaoProductSummary{},
+		&archived.ZentaoProjectStory{},
+	)
+}
+
+func (*addExecutionStoryAndExecutionSummary) Version() uint64 {
+	return 20230705135809
+}
+
+func (*addExecutionStoryAndExecutionSummary) Name() string {
+	return "add table _tool_zentao_execution_stories, _tool_zentao_execution_summary and _tool_zentao_product_summary"
+}

--- a/backend/plugins/zentao/models/product.go
+++ b/backend/plugins/zentao/models/product.go
@@ -18,10 +18,7 @@ limitations under the License.
 package models
 
 import (
-	"fmt"
-
 	"github.com/apache/incubator-devlake/core/models/common"
-	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
 
@@ -76,42 +73,6 @@ func getAccountId(account *ZentaoAccount) int64 {
 	return 0
 }
 
-func (res ZentaoProductRes) ConvertApiScope() plugin.ToolLayerScope {
-	return &ZentaoProduct{
-		Id:             res.ID,
-		Program:        res.Program,
-		Name:           res.Name,
-		Code:           res.Code,
-		Bind:           res.Bind,
-		Line:           res.Line,
-		Type:           `product`,
-		ProductType:    res.Type,
-		Status:         res.Status,
-		SubStatus:      res.SubStatus,
-		Description:    res.Description,
-		POId:           getAccountId(res.PO),
-		QDId:           getAccountId(res.QD),
-		RDId:           getAccountId(res.RD),
-		Acl:            res.Acl,
-		Reviewer:       res.Reviewer,
-		CreatedById:    getAccountId(res.CreatedBy),
-		CreatedDate:    res.CreatedDate,
-		CreatedVersion: res.CreatedVersion,
-		OrderIn:        res.OrderIn,
-		Deleted:        res.Deleted,
-		Plans:          res.Plans,
-		Releases:       res.Releases,
-		Builds:         res.Builds,
-		Cases:          res.Cases,
-		Projects:       res.Projects,
-		Executions:     res.Executions,
-		Bugs:           res.Bugs,
-		Docs:           res.Docs,
-		Progress:       res.Progress,
-		CaseReview:     res.CaseReview,
-	}
-}
-
 type ZentaoProduct struct {
 	common.NoPKModel `json:"-"`
 	ConnectionId     uint64 `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey;type:BIGINT  NOT NULL"`
@@ -151,19 +112,4 @@ type ZentaoProduct struct {
 
 func (ZentaoProduct) TableName() string {
 	return "_tool_zentao_products"
-}
-
-func (p ZentaoProduct) ScopeId() string {
-	return fmt.Sprintf(`products/%d`, p.Id)
-}
-
-func (p ZentaoProduct) ScopeParams() interface{} {
-	return &ZentaoApiParams{
-		ConnectionId: p.ConnectionId,
-		ZentaoId:     fmt.Sprintf("products/%d", p.Id),
-	}
-}
-
-func (p ZentaoProduct) ScopeName() string {
-	return p.Name
 }

--- a/backend/plugins/zentao/models/product.go
+++ b/backend/plugins/zentao/models/product.go
@@ -66,13 +66,6 @@ type ZentaoProductRes struct {
 	CaseReview bool    `json:"caseReview" mapstructure:"caseReview"`
 }
 
-func getAccountId(account *ZentaoAccount) int64 {
-	if account != nil {
-		return account.ID
-	}
-	return 0
-}
-
 type ZentaoProduct struct {
 	common.NoPKModel `json:"-"`
 	ConnectionId     uint64 `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey;type:BIGINT  NOT NULL"`

--- a/backend/plugins/zentao/models/product_summary.go
+++ b/backend/plugins/zentao/models/product_summary.go
@@ -15,21 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package models
 
-import (
-	"github.com/apache/incubator-devlake/core/plugin"
-)
+import "github.com/apache/incubator-devlake/core/models/common"
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoProductSummary struct {
+	common.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey"`
+	ProjectId    int64  `gorm:"primaryKey"`
+	Id           int64  `gorm:"primaryKey;autoIncrement:false"`
+	Name         string `gorm:"type:VARCHAR(255)"`
+}
+
+func (ZentaoProductSummary) TableName() string {
+	return "_tool_zentao_product_summary"
 }

--- a/backend/plugins/zentao/models/project.go
+++ b/backend/plugins/zentao/models/project.go
@@ -157,7 +157,7 @@ func (p ZentaoProject) ScopeName() string {
 func (p ZentaoProject) ScopeParams() interface{} {
 	return &ZentaoApiParams{
 		ConnectionId: p.ConnectionId,
-		ZentaoId:     fmt.Sprintf("projects/%d", p.Id),
+		ProjectId:    p.Id,
 	}
 }
 
@@ -171,5 +171,5 @@ func (p ZentaoProject) ConvertApiScope() plugin.ToolLayerScope {
 
 type ZentaoApiParams struct {
 	ConnectionId uint64
-	ZentaoId     string
+	ProjectId    int64
 }

--- a/backend/plugins/zentao/models/project_stories.go
+++ b/backend/plugins/zentao/models/project_stories.go
@@ -15,21 +15,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package migrationscripts
+package models
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/models/common"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addScopeConfigTables),
-		new(addIssueRepoCommitsTables),
-		new(addInitChangelogTables),
-		new(addTaskLeft),
-		new(addExecutionStoryAndExecutionSummary),
-		new(addRawParamTableForScope),
-	}
+type ZentaoProjectStory struct {
+	common.NoPKModel
+	ConnectionId uint64 `gorm:"primaryKey;type:BIGINT  NOT NULL"`
+	ProjectId    int64  `gorm:"primaryKey"`
+	StoryId      int64  `gorm:"primaryKey"`
+}
+
+func (ZentaoProjectStory) TableName() string {
+	return "_tool_zentao_project_stories"
 }

--- a/backend/plugins/zentao/models/remote_db.go
+++ b/backend/plugins/zentao/models/remote_db.go
@@ -29,9 +29,21 @@ type ZentaoRemoteDbHistoryBase struct {
 }
 
 type ZentaoRemoteDbHistory struct {
-	Id     int `gorm:"column:id"`
-	Action int `gorm:"column:action"`
+	Id     int64 `gorm:"column:id"`
+	Action int64 `gorm:"column:action"`
 	ZentaoRemoteDbHistoryBase
+}
+
+func (h ZentaoRemoteDbHistory) ToChangelogDetail(connectionId uint64) *ZentaoChangelogDetail {
+	return &ZentaoChangelogDetail{
+		ConnectionId: connectionId,
+		Id:           h.Id,
+		ChangelogId:  h.Action,
+		Field:        h.Field,
+		Old:          h.Old,
+		New:          h.New,
+		Diff:         h.Diff,
+	}
 }
 
 func (ZentaoRemoteDbHistory) TableName() string {
@@ -39,12 +51,12 @@ func (ZentaoRemoteDbHistory) TableName() string {
 }
 
 type ZentaoRemoteDbAction struct {
-	Id         int       `gorm:"column:id"`
+	Id         int64     `gorm:"column:id"`
 	ObjectType string    `gorm:"column:objectType"`
-	ObjectId   int       `gorm:"column:objectID"`
+	ObjectId   int64     `gorm:"column:objectID"`
 	Product    string    `gorm:"column:product"`
-	Project    int       `gorm:"column:project"`
-	Execution  int       `gorm:"column:execution"`
+	Project    int64     `gorm:"column:project"`
+	Execution  int64     `gorm:"column:execution"`
 	Actor      string    `gorm:"column:actor"`
 	Action     string    `gorm:"column:action"`
 	Date       time.Time `gorm:"column:date"`
@@ -55,6 +67,25 @@ type ZentaoRemoteDbAction struct {
 	Efforted   string    `gorm:"column:efforted"`
 }
 
+func (a ZentaoRemoteDbAction) ToChangelog(connectionId uint64) *ZentaoChangelog {
+	return &ZentaoChangelog{
+		ConnectionId: connectionId,
+		Id:           a.Id,
+		ObjectId:     a.ObjectId,
+		Execution:    a.Execution,
+		Actor:        a.Actor,
+		Action:       a.Action,
+		Extra:        a.Extra,
+		ObjectType:   a.ObjectType,
+		Project:      a.Project,
+		Vision:       a.Vision,
+		Comment:      a.Comment,
+		Efforted:     a.Efforted,
+		Date:         a.Date,
+		Read:         a.Read,
+	}
+}
+
 func (ZentaoRemoteDbAction) TableName() string {
 	return "zt_action"
 }
@@ -63,34 +94,36 @@ type ZentaoRemoteDbActionHistory struct {
 	ZentaoRemoteDbAction
 	ZentaoRemoteDbHistoryBase
 
-	ActionId  int `gorm:"column:aid"`
-	HistoryId int `gorm:"column:hid"`
+	ActionId  int64 `gorm:"column:aid"`
+	HistoryId int64 `gorm:"column:hid"`
 }
 
-func (ah *ZentaoRemoteDbActionHistory) Convert() *ZentaoChangelogCom {
+func (ah *ZentaoRemoteDbActionHistory) Convert(connectId uint64) *ZentaoChangelogCom {
 	return &ZentaoChangelogCom{
 		&ZentaoChangelog{
-			Id:         int64(ah.ActionId),
-			ObjectId:   ah.ObjectId,
-			Execution:  ah.Execution,
-			Actor:      ah.Actor,
-			Action:     ah.Action,
-			Extra:      ah.Extra,
-			ObjectType: ah.ObjectType,
-			Project:    ah.Project,
-			Vision:     ah.Vision,
-			Comment:    ah.Comment,
-			Efforted:   ah.Efforted,
-			Date:       ah.Date,
-			Read:       ah.Read,
+			ConnectionId: connectId,
+			Id:           ah.ActionId,
+			ObjectId:     ah.ObjectId,
+			Execution:    ah.Execution,
+			Actor:        ah.Actor,
+			Action:       ah.Action,
+			Extra:        ah.Extra,
+			ObjectType:   ah.ObjectType,
+			Project:      ah.Project,
+			Vision:       ah.Vision,
+			Comment:      ah.Comment,
+			Efforted:     ah.Efforted,
+			Date:         ah.Date,
+			Read:         ah.Read,
 		},
 		&ZentaoChangelogDetail{
-			Id:          int64(ah.HistoryId),
-			ChangelogId: int64(ah.ActionId),
-			Field:       ah.Field,
-			Old:         ah.Old,
-			New:         ah.New,
-			Diff:        ah.Diff,
+			ConnectionId: connectId,
+			Id:           ah.HistoryId,
+			ChangelogId:  ah.ActionId,
+			Field:        ah.Field,
+			Old:          ah.Old,
+			New:          ah.New,
+			Diff:         ah.Diff,
 		},
 	}
 }

--- a/backend/plugins/zentao/tasks/account_collector.go
+++ b/backend/plugins/zentao/tasks/account_collector.go
@@ -36,13 +36,9 @@ func CollectAccount(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_ACCOUNT_TABLE,
+			Ctx:     taskCtx,
+			Table:   RAW_ACCOUNT_TABLE,
+			Options: data.Options,
 		},
 		ApiClient:   data.ApiClient,
 		PageSize:    100,

--- a/backend/plugins/zentao/tasks/account_convertor.go
+++ b/backend/plugins/zentao/tasks/account_convertor.go
@@ -57,13 +57,9 @@ func ConvertAccount(taskCtx plugin.SubTaskContext) errors.Error {
 		InputRowType: reflect.TypeOf(models.ZentaoAccount{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_ACCOUNT_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_ACCOUNT_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolEntity := inputRow.(*models.ZentaoAccount)

--- a/backend/plugins/zentao/tasks/account_extractor.go
+++ b/backend/plugins/zentao/tasks/account_extractor.go
@@ -40,13 +40,9 @@ func ExtractAccount(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_ACCOUNT_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_ACCOUNT_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			account := &models.ZentaoAccount{}
@@ -55,9 +51,7 @@ func ExtractAccount(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, errors.Default.WrapRaw(err)
 			}
 			account.ConnectionId = data.Options.ConnectionId
-			results := make([]interface{}, 0)
-			results = append(results, account)
-			return results, nil
+			return []interface{}{account}, nil
 		},
 	})
 

--- a/backend/plugins/zentao/tasks/bug_repo_commits_convertor.go
+++ b/backend/plugins/zentao/tasks/bug_repo_commits_convertor.go
@@ -40,16 +40,12 @@ var ConvertBugRepoCommitsMeta = plugin.SubTaskMeta{
 }
 
 func ConvertBugRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
-	return RangeProductOneByOne(taskCtx, ConvertBugRepoCommitsForOneProduct)
-}
-
-func ConvertBugRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	db := taskCtx.GetDal()
 
 	cursor, err := db.Cursor(
 		dal.From(&models.ZentaoBugRepoCommit{}),
-		dal.Where(`product = ? and connection_id = ?`, data.Options.ProductId, data.Options.ConnectionId),
+		dal.Where(`project = ? and connection_id = ?`, data.Options.ProjectId, data.Options.ConnectionId),
 	)
 	if err != nil {
 		return err
@@ -61,13 +57,9 @@ func ConvertBugRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Er
 		InputRowType: reflect.TypeOf(models.ZentaoBugRepoCommit{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_BUG_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_BUG_REPO_COMMITS_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolEntity := inputRow.(*models.ZentaoBugRepoCommit)

--- a/backend/plugins/zentao/tasks/bug_repo_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/bug_repo_commits_extractor.go
@@ -38,27 +38,15 @@ var ExtractBugRepoCommitsMeta = plugin.SubTaskMeta{
 }
 
 func ExtractBugRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
-	return RangeProductOneByOne(taskCtx, ExtractBugRepoCommitsForOneProduct)
-}
-
-func ExtractBugRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 
-	// this Extract only work for product
-	if data.Options.ProductId == 0 {
-		return nil
-	}
 	re := regexp.MustCompile(`(\d+)(?:,\s*(\d+))*`)
 
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_BUG_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_BUG_REPO_COMMITS_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			res := &models.ZentaoBugRepoCommitsRes{}
@@ -66,14 +54,18 @@ func ExtractBugRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Er
 			if err != nil {
 				return nil, errors.Default.WrapRaw(err)
 			}
-
+			var input bugCommitInput
+			err = json.Unmarshal(row.Input, &input)
+			if err != nil {
+				return nil, errors.Default.WrapRaw(err)
+			}
 			results := make([]interface{}, 0)
 			match := re.FindStringSubmatch(res.Log.Comment)
 			for i := 1; i < len(match); i++ {
 				if match[i] != "" {
 					bugRepoCommits := &models.ZentaoBugRepoCommit{
 						ConnectionId: data.Options.ConnectionId,
-						Product:      data.Options.ProductId,
+						Product:      input.Product,
 						Project:      data.Options.ProjectId,
 						RepoUrl:      res.Repo.CodePath,
 						CommitSha:    res.Revision,

--- a/backend/plugins/zentao/tasks/changelog_dbget.go
+++ b/backend/plugins/zentao/tasks/changelog_dbget.go
@@ -99,6 +99,9 @@ func (h actionHistoryHandler) collectActionHistory(rdb dal.Dal, connectionId uin
 		}
 		if zcc.ChangelogDetail.Id != 0 {
 			err = h.changelogDetailBachSave.Add(zcc.ChangelogDetail)
+			if err != nil {
+				return err
+			}
 		}
 	}
 	err = h.changelogBachSave.Flush()

--- a/backend/plugins/zentao/tasks/changelog_dbget.go
+++ b/backend/plugins/zentao/tasks/changelog_dbget.go
@@ -18,7 +18,6 @@ limitations under the License.
 package tasks
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/apache/incubator-devlake/core/dal"
@@ -29,6 +28,85 @@ import (
 )
 
 var _ plugin.SubTaskEntryPoint = DBGetActionHistory
+
+type actionHistoryHandler struct {
+	changelogBachSave       *api.BatchSave
+	changelogDetailBachSave *api.BatchSave
+	stories                 map[int64]struct{}
+	tasks                   map[int64]struct{}
+	bugs                    map[int64]struct{}
+}
+
+func newActionHistoryHandler(taskCtx plugin.SubTaskContext, divider *api.BatchSaveDivider) (*actionHistoryHandler, errors.Error) {
+	data := taskCtx.GetData().(*ZentaoTaskData)
+	changelogBachSave, err := divider.ForType(reflect.TypeOf(&models.ZentaoChangelog{}))
+	if err != nil {
+		return nil, err
+	}
+	changelogDetailBachSave, err := divider.ForType(reflect.TypeOf(&models.ZentaoChangelogDetail{}))
+	if err != nil {
+		return nil, err
+	}
+	return &actionHistoryHandler{
+		changelogBachSave:       changelogBachSave,
+		changelogDetailBachSave: changelogDetailBachSave,
+		stories:                 data.Stories,
+		tasks:                   data.Tasks,
+		bugs:                    data.Bugs,
+	}, nil
+}
+
+func (h actionHistoryHandler) collectActionHistory(rdb dal.Dal, connectionId uint64) errors.Error {
+	clause := []dal.Clause{
+		dal.Select("*,zt_action.id aid,zt_history.id hid "),
+		dal.From("zt_action"),
+		dal.Join("LEFT JOIN zt_history on zt_history.action = zt_action.id"),
+		dal.Where("zt_action.objectType IN ?", []string{"story", "task", "bug"}),
+	}
+	cursor, err := rdb.Cursor(clause...)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	for cursor.Next() {
+		var ah models.ZentaoRemoteDbActionHistory
+		err = rdb.Fetch(cursor, &ah)
+		if err != nil {
+			return err
+		}
+		switch ah.ObjectType {
+		case "story":
+			if _, ok := h.stories[ah.ObjectId]; !ok {
+				continue
+			}
+		case "task":
+			if _, ok := h.tasks[ah.ObjectId]; !ok {
+				continue
+			}
+		case "bug":
+			if _, ok := h.bugs[ah.ObjectId]; !ok {
+				continue
+			}
+		default:
+			continue
+		}
+
+		zcc := ah.Convert(connectionId)
+		err = h.changelogBachSave.Add(zcc.Changelog)
+		if err != nil {
+			return err
+		}
+		if zcc.ChangelogDetail.Id != 0 {
+			err = h.changelogDetailBachSave.Add(zcc.ChangelogDetail)
+		}
+	}
+	err = h.changelogBachSave.Flush()
+	if err != nil {
+		return err
+	}
+	return h.changelogDetailBachSave.Flush()
+}
 
 func DBGetActionHistory(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
@@ -45,31 +123,11 @@ func DBGetActionHistory(taskCtx plugin.SubTaskContext) errors.Error {
 			panic(err1)
 		}
 	}()
-
-	return dBGetActionHistory(data, func(zcc *models.ZentaoChangelogCom) errors.Error {
-		batch, err := divider.ForType(reflect.TypeOf(zcc.Changelog))
-		if err != nil {
-			return err
-		}
-		zcc.Changelog.ConnectionId = data.Options.ConnectionId
-		zcc.Changelog.Product = int(data.Options.ProductId)
-		err = batch.Add(zcc.Changelog)
-		if err != nil {
-			return err
-		}
-		if zcc.ChangelogDetail.Id != 0 {
-			batch, err = divider.ForType(reflect.TypeOf(zcc.ChangelogDetail))
-			if err != nil {
-				return err
-			}
-			zcc.ChangelogDetail.ConnectionId = data.Options.ConnectionId
-			err = batch.Add(zcc.ChangelogDetail)
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	handler, err := newActionHistoryHandler(taskCtx, divider)
+	if err != nil {
+		return err
+	}
+	return handler.collectActionHistory(data.RemoteDb, data.Options.ConnectionId)
 }
 
 var DBGetChangelogMeta = plugin.SubTaskMeta{
@@ -78,45 +136,4 @@ var DBGetChangelogMeta = plugin.SubTaskMeta{
 	EnabledByDefault: true,
 	Description:      "get action and history data to be changelog from Zentao databases",
 	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
-}
-
-// it is work for zentao version 18.3
-func dBGetActionHistory(data *ZentaoTaskData, callback func(*models.ZentaoChangelogCom) errors.Error) errors.Error {
-	rdb := data.RemoteDb
-	atn := (models.ZentaoRemoteDbAction{}).TableName()
-	htn := (models.ZentaoRemoteDbHistory{}).TableName()
-
-	clause := []dal.Clause{
-		dal.Select(fmt.Sprintf("*,%s.id aid,%s.id hid ", atn, htn)),
-		dal.From(atn),
-	}
-
-	if data.Options.ProductId != 0 {
-		clause = append(clause, dal.Where(fmt.Sprintf("%s.product = ?", atn), fmt.Sprintf(",%d,", data.Options.ProductId)))
-	}
-	if data.Options.ProjectId != 0 {
-		clause = append(clause, dal.Where(fmt.Sprintf("%s.project = ?", atn), data.Options.ProjectId))
-	}
-	clause = append(clause, dal.Join(fmt.Sprintf("LEFT JOIN %s on %s.action = %s.id", htn, htn, atn)))
-
-	cursor, err := rdb.Cursor(clause...)
-	if err != nil {
-		return err
-	}
-	defer cursor.Close()
-
-	for cursor.Next() {
-		actionHistory := &models.ZentaoRemoteDbActionHistory{}
-		err = rdb.Fetch(cursor, actionHistory)
-		if err != nil {
-			return err
-		}
-
-		err = callback(actionHistory.Convert())
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/backend/plugins/zentao/tasks/department_collector.go
+++ b/backend/plugins/zentao/tasks/department_collector.go
@@ -36,17 +36,13 @@ func CollectDepartment(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_DEPARTMENT_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_DEPARTMENT_TABLE,
 		},
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
-		UrlTemplate: "/users",
+		UrlTemplate: "/departments",
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
@@ -55,14 +51,12 @@ func CollectDepartment(taskCtx plugin.SubTaskContext) errors.Error {
 		},
 		GetTotalPages: GetTotalPagesFromResponse,
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
-			var data struct {
-				Users []json.RawMessage `json:"users"`
-			}
+			var data []json.RawMessage
 			err := api.UnmarshalResponse(res, &data)
 			if err != nil {
-				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
+				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao departments collector")
 			}
-			return data.Users, nil
+			return data, nil
 		},
 	})
 	if err != nil {

--- a/backend/plugins/zentao/tasks/department_convertor.go
+++ b/backend/plugins/zentao/tasks/department_convertor.go
@@ -56,13 +56,9 @@ func ConvertDepartment(taskCtx plugin.SubTaskContext) errors.Error {
 		InputRowType: reflect.TypeOf(models.ZentaoDepartment{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_DEPARTMENT_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_DEPARTMENT_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolEntity := inputRow.(*models.ZentaoDepartment)

--- a/backend/plugins/zentao/tasks/department_extractor.go
+++ b/backend/plugins/zentao/tasks/department_extractor.go
@@ -40,13 +40,9 @@ func ExtractDepartment(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_DEPARTMENT_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_DEPARTMENT_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			department := &models.ZentaoDepartment{}
@@ -55,9 +51,7 @@ func ExtractDepartment(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, errors.Default.WrapRaw(err)
 			}
 			department.ConnectionId = data.Options.ConnectionId
-			results := make([]interface{}, 0)
-			results = append(results, department)
-			return results, nil
+			return []interface{}{department}, nil
 		},
 	})
 

--- a/backend/plugins/zentao/tasks/execution_collector.go
+++ b/backend/plugins/zentao/tasks/execution_collector.go
@@ -31,10 +31,6 @@ const RAW_EXECUTION_TABLE = "zentao_api_executions"
 
 var _ plugin.SubTaskEntryPoint = CollectExecutions
 
-type executionInput struct {
-	Path string
-}
-
 func CollectExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	cursor, iterator, err := getExecutionIterator(taskCtx)

--- a/backend/plugins/zentao/tasks/execution_collector.go
+++ b/backend/plugins/zentao/tasks/execution_collector.go
@@ -20,38 +20,37 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/url"
-
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"net/http"
+	"net/url"
 )
 
 const RAW_EXECUTION_TABLE = "zentao_api_executions"
 
 var _ plugin.SubTaskEntryPoint = CollectExecutions
 
+type executionInput struct {
+	Path string
+}
+
 func CollectExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
-
-	// this collect only work for project
-	if data.Options.ProjectId == 0 {
-		return nil
+	cursor, iterator, err := getExecutionIterator(taskCtx)
+	if err != nil {
+		return err
 	}
-
+	defer cursor.Close()
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_EXECUTION_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_EXECUTION_TABLE,
 		},
+		Input:       iterator,
 		ApiClient:   data.ApiClient,
-		UrlTemplate: "/{{ .Params.ZentaoId }}/executions",
+		UrlTemplate: "/executions/{{ .Input.Id }}",
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
@@ -59,14 +58,12 @@ func CollectExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 			return query, nil
 		},
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
-			var data struct {
-				Executions []json.RawMessage `json:"executions"`
-			}
+			var data json.RawMessage
 			err := api.UnmarshalResponse(res, &data)
 			if err != nil {
-				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
+				return nil, err
 			}
-			return data.Executions, nil
+			return []json.RawMessage{data}, nil
 		},
 	})
 	if err != nil {

--- a/backend/plugins/zentao/tasks/execution_convertor.go
+++ b/backend/plugins/zentao/tasks/execution_convertor.go
@@ -57,13 +57,9 @@ func ConvertExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 		InputRowType: reflect.TypeOf(models.ZentaoExecution{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_EXECUTION_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_EXECUTION_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolExecution := inputRow.(*models.ZentaoExecution)

--- a/backend/plugins/zentao/tasks/execution_extractor.go
+++ b/backend/plugins/zentao/tasks/execution_extractor.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -39,20 +38,11 @@ var ExtractExecutionMeta = plugin.SubTaskMeta{
 func ExtractExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 
-	// this Extract only work for project
-	if data.Options.ProjectId == 0 {
-		return nil
-	}
-
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_EXECUTION_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_EXECUTION_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			res := &models.ZentaoExecutionRes{}
@@ -60,10 +50,15 @@ func ExtractExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 			if err != nil {
 				return nil, errors.Default.WrapRaw(err)
 			}
-
-			// append product to taskdata
+			var results []interface{}
 			for _, product := range res.Products {
-				data.ProductList[product.ID] = product.Name
+				p := &models.ZentaoProductSummary{
+					ConnectionId: data.Options.ConnectionId,
+					ProjectId:    data.Options.ProjectId,
+					Id:           product.ID,
+					Name:         product.Name,
+				}
+				results = append(results, p)
 			}
 
 			execution := &models.ZentaoExecution{
@@ -126,7 +121,6 @@ func ExtractExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 				Progress:       res.Progress,
 				CaseReview:     res.CaseReview,
 			}
-			results := make([]interface{}, 0)
 			results = append(results, execution)
 			return results, nil
 		},

--- a/backend/plugins/zentao/tasks/iterator.go
+++ b/backend/plugins/zentao/tasks/iterator.go
@@ -1,0 +1,105 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+type iteratorConcator struct {
+	index     int
+	iterators []api.Iterator
+}
+
+func newIteratorConcator(iterators ...api.Iterator) *iteratorConcator {
+	return &iteratorConcator{iterators: iterators}
+}
+
+func (w *iteratorConcator) HasNext() bool {
+	for w.index < len(w.iterators) {
+		if w.iterators[w.index].HasNext() {
+			return true
+		}
+		w.index++
+	}
+	return false
+}
+
+func (w *iteratorConcator) Fetch() (interface{}, errors.Error) {
+	if w.index >= len(w.iterators) {
+		return nil, errors.Default.New("index out of range")
+	}
+	return w.iterators[w.index].Fetch()
+}
+
+func (w *iteratorConcator) Close() errors.Error {
+	for _, iterator := range w.iterators {
+		iterator.Close()
+	}
+	return nil
+}
+
+type iteratorWrapper struct {
+	original    api.Iterator
+	wrapperFunc func(interface{}) interface{}
+}
+
+func newIteratorWrapper(original api.Iterator, wrapperFunc func(interface{}) interface{}) *iteratorWrapper {
+	return &iteratorWrapper{original: original, wrapperFunc: wrapperFunc}
+}
+
+func (w *iteratorWrapper) HasNext() bool {
+	return w.original.HasNext()
+}
+
+func (w *iteratorWrapper) Fetch() (interface{}, errors.Error) {
+	data, err := w.original.Fetch()
+	if err != nil {
+		return nil, err
+	}
+	return w.wrapperFunc(data), nil
+}
+
+func (w *iteratorWrapper) Close() errors.Error {
+	return w.original.Close()
+}
+
+type iteratorFromSlice struct {
+	index int
+	data  []interface{}
+}
+
+func newIteratorFromSlice(data []interface{}) *iteratorFromSlice {
+	return &iteratorFromSlice{data: data}
+}
+
+func (i *iteratorFromSlice) HasNext() bool {
+	return i.index < len(i.data)
+}
+
+func (i *iteratorFromSlice) Fetch() (interface{}, errors.Error) {
+	data := i.data[i.index]
+	i.index++
+	return data, nil
+}
+
+func (i *iteratorFromSlice) Close() errors.Error {
+	i.index = len(i.data) - 1
+	return nil
+}

--- a/backend/plugins/zentao/tasks/project_convertor.go
+++ b/backend/plugins/zentao/tasks/project_convertor.go
@@ -59,13 +59,9 @@ func ConvertProjects(taskCtx plugin.SubTaskContext) errors.Error {
 		InputRowType: reflect.TypeOf(models.ZentaoProject{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_PROJECT_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_PROJECT_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolProject := inputRow.(*models.ZentaoProject)

--- a/backend/plugins/zentao/tasks/shared.go
+++ b/backend/plugins/zentao/tasks/shared.go
@@ -31,10 +31,6 @@ import (
 	"github.com/apache/incubator-devlake/plugins/zentao/models"
 )
 
-type productInput struct {
-	ProductId int64
-}
-
 type input struct {
 	Id int64
 }

--- a/backend/plugins/zentao/tasks/story_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/story_commits_extractor.go
@@ -39,27 +39,14 @@ var ExtractStoryCommitsMeta = plugin.SubTaskMeta{
 }
 
 func ExtractStoryCommits(taskCtx plugin.SubTaskContext) errors.Error {
-	return RangeProductOneByOne(taskCtx, ExtractStoryCommitsForOneProduct)
-}
-
-func ExtractStoryCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
-
-	// this Extract only work for product
-	if data.Options.ProductId == 0 {
-		return nil
-	}
 
 	re := regexp.MustCompile(`href='(.*?)'`)
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_STORY_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_STORY_COMMITS_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			res := &models.ZentaoStoryCommitsRes{}
@@ -78,7 +65,6 @@ func ExtractStoryCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Erro
 				ID:           res.ID,
 				ObjectType:   res.ObjectType,
 				ObjectID:     res.ObjectID,
-				Product:      data.Options.ProductId,
 				Project:      data.Options.ProjectId,
 				Execution:    res.Execution,
 				Actor:        res.Actor,

--- a/backend/plugins/zentao/tasks/story_repo_commits_collector.go
+++ b/backend/plugins/zentao/tasks/story_repo_commits_collector.go
@@ -42,10 +42,6 @@ var CollectStoryRepoCommitsMeta = plugin.SubTaskMeta{
 }
 
 func CollectStoryRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
-	return RangeProductOneByOne(taskCtx, CollectStoryRepoCommitsForOneProduct)
-}
-
-func CollectStoryRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*ZentaoTaskData)
 
@@ -54,8 +50,8 @@ func CollectStoryRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.
 		dal.Select("object_id, repo_revision"),
 		dal.From(&models.ZentaoStoryCommit{}),
 		dal.Where(
-			"product = ? AND connection_id = ?",
-			data.Options.ProductId, data.Options.ConnectionId,
+			"project = ? AND connection_id = ?",
+			data.Options.ProjectId, data.Options.ConnectionId,
 		),
 	}
 
@@ -72,13 +68,9 @@ func CollectStoryRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.
 	// collect story repo commits
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_STORY_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_STORY_REPO_COMMITS_TABLE,
 		},
 		ApiClient:   data.ApiClient,
 		Input:       iterator,

--- a/backend/plugins/zentao/tasks/story_repo_commits_convertor.go
+++ b/backend/plugins/zentao/tasks/story_repo_commits_convertor.go
@@ -40,16 +40,12 @@ var ConvertStoryRepoCommitsMeta = plugin.SubTaskMeta{
 }
 
 func ConvertStoryRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
-	return RangeProductOneByOne(taskCtx, ConvertStoryRepoCommitsForOneProduct)
-}
-
-func ConvertStoryRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	db := taskCtx.GetDal()
 
 	cursor, err := db.Cursor(
 		dal.From(&models.ZentaoStoryRepoCommit{}),
-		dal.Where(`product = ? and connection_id = ?`, data.Options.ProductId, data.Options.ConnectionId),
+		dal.Where(`project = ? and connection_id = ?`, data.Options.ProjectId, data.Options.ConnectionId),
 	)
 	if err != nil {
 		return err
@@ -61,13 +57,9 @@ func ConvertStoryRepoCommitsForOneProduct(taskCtx plugin.SubTaskContext) errors.
 		InputRowType: reflect.TypeOf(models.ZentaoStoryRepoCommit{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_STORY_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_STORY_REPO_COMMITS_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolEntity := inputRow.(*models.ZentaoStoryRepoCommit)

--- a/backend/plugins/zentao/tasks/task_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/task_commits_extractor.go
@@ -41,21 +41,12 @@ var ExtractTaskCommitsMeta = plugin.SubTaskMeta{
 func ExtractTaskCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 
-	// this Extract only work for project
-	if data.Options.ProjectId == 0 {
-		return nil
-	}
-
 	re := regexp.MustCompile(`href='(.*?)'`)
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_TASK_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_TASK_COMMITS_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			res := &models.ZentaoTaskCommitsRes{}
@@ -74,7 +65,6 @@ func ExtractTaskCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				ID:           res.ID,
 				ObjectType:   res.ObjectType,
 				ObjectID:     res.ObjectID,
-				Product:      data.Options.ProductId,
 				Project:      data.Options.ProjectId,
 				Execution:    res.Execution,
 				Actor:        res.Actor,

--- a/backend/plugins/zentao/tasks/task_convertor.go
+++ b/backend/plugins/zentao/tasks/task_convertor.go
@@ -45,7 +45,7 @@ func ConvertTask(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*ZentaoTaskData)
 	db := taskCtx.GetDal()
 	storyIdGen := didgen.NewDomainIdGenerator(&models.ZentaoStory{})
-	bugIdGen := didgen.NewDomainIdGenerator(&models.ZentaoBug{})
+	//bugIdGen := didgen.NewDomainIdGenerator(&models.ZentaoBug{})
 	boardIdGen := didgen.NewDomainIdGenerator(&models.ZentaoProject{})
 	executionIdGen := didgen.NewDomainIdGenerator(&models.ZentaoExecution{})
 	taskIdGen := didgen.NewDomainIdGenerator(&models.ZentaoTask{})
@@ -62,13 +62,9 @@ func ConvertTask(taskCtx plugin.SubTaskContext) errors.Error {
 		InputRowType: reflect.TypeOf(models.ZentaoTask{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_TASK_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_TASK_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolEntity := inputRow.(*models.ZentaoTask)
@@ -126,22 +122,6 @@ func ConvertTask(taskCtx plugin.SubTaskContext) errors.Error {
 			}
 
 			results = append(results, domainEntity, domainBoardIssue, sprintIssueTask)
-
-			if toolEntity.StoryID != 0 {
-				sprintIssueStory := &ticket.SprintIssue{
-					SprintId: sprintId,
-					IssueId:  storyIdGen.Generate(data.Options.ConnectionId, toolEntity.StoryID),
-				}
-				results = append(results, sprintIssueStory)
-			}
-
-			if toolEntity.FromBug != 0 {
-				sprintIssueBug := &ticket.SprintIssue{
-					SprintId: sprintId,
-					IssueId:  bugIdGen.Generate(data.Options.ConnectionId, int64(toolEntity.FromBug)),
-				}
-				results = append(results, sprintIssueBug)
-			}
 
 			return results, nil
 		},

--- a/backend/plugins/zentao/tasks/task_data.go
+++ b/backend/plugins/zentao/tasks/task_data.go
@@ -36,12 +36,18 @@ type ZentaoOptions struct {
 	// Such As How many rows do your want
 	// You can use it in subtasks, and you need to pass it to main.go and pipelines.
 	ConnectionId uint64 `json:"connectionId"`
-	ProductId    int64  `json:"productId" mapstructure:"productId"`
 	ProjectId    int64  `json:"projectId" mapstructure:"projectId"`
 	// TODO not support now
 	TimeAfter     string              `json:"timeAfter" mapstructure:"timeAfter,omitempty"`
 	ScopeConfigId uint64              `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
 	ScopeConfigs  *ZentaoScopeConfigs `json:"scopeConfigs" mapstructure:"scopeConfigs,omitempty"`
+}
+
+func (o *ZentaoOptions) GetParams() any {
+	return models.ZentaoApiParams{
+		ConnectionId: o.ConnectionId,
+		ProjectId:    o.ProjectId,
+	}
 }
 
 type TypeMappings map[string]string
@@ -104,6 +110,9 @@ type ZentaoTaskData struct {
 	ProductList map[int64]string // set if it is setting project id, it is map[id]name
 	StoryList   map[int64]int64  // set if it is run the task_extractor
 	FromBugList map[int]bool     // set if it is run the task_extracor
+	Stories     map[int64]struct{}
+	Tasks       map[int64]struct{}
+	Bugs        map[int64]struct{}
 	ApiClient   *helper.ApiAsyncClient
 }
 
@@ -117,8 +126,8 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*ZentaoOption
 	if op.ConnectionId == 0 {
 		return nil, fmt.Errorf("connectionId is invalid")
 	}
-	if op.ProductId == 0 && op.ProjectId == 0 {
-		return nil, fmt.Errorf("please set productId")
+	if op.ProjectId == 0 {
+		return nil, fmt.Errorf("please set projectId")
 	}
 	return &op, nil
 }

--- a/backend/plugins/zentao/tasks/task_repo_commits_collector.go
+++ b/backend/plugins/zentao/tasks/task_repo_commits_collector.go
@@ -68,13 +68,9 @@ func CollectTaskRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	// collect task repo commits
 	collector, err := api.NewApiCollector(api.ApiCollectorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_TASK_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_TASK_REPO_COMMITS_TABLE,
 		},
 		ApiClient:   data.ApiClient,
 		Input:       iterator,

--- a/backend/plugins/zentao/tasks/task_repo_commits_convertor.go
+++ b/backend/plugins/zentao/tasks/task_repo_commits_convertor.go
@@ -57,13 +57,9 @@ func ConvertTaskRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 		InputRowType: reflect.TypeOf(models.ZentaoTaskRepoCommit{}),
 		Input:        cursor,
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_TASK_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_TASK_REPO_COMMITS_TABLE,
 		},
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			toolEntity := inputRow.(*models.ZentaoTaskRepoCommit)

--- a/backend/plugins/zentao/tasks/task_repo_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/task_repo_commits_extractor.go
@@ -48,13 +48,9 @@ func ExtractTaskRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	re := regexp.MustCompile(`(\d+)(?:,\s*(\d+))*`)
 	extractor, err := api.NewApiExtractor(api.ApiExtractorArgs{
 		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
-			Ctx: taskCtx,
-			Params: ScopeParams(
-				data.Options.ConnectionId,
-				data.Options.ProjectId,
-				data.Options.ProductId,
-			),
-			Table: RAW_TASK_REPO_COMMITS_TABLE,
+			Ctx:     taskCtx,
+			Options: data.Options,
+			Table:   RAW_TASK_REPO_COMMITS_TABLE,
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			res := &models.ZentaoTaskRepoCommitsRes{}
@@ -69,7 +65,6 @@ func ExtractTaskRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				if match[i] != "" {
 					taskRepoCommits := &models.ZentaoTaskRepoCommit{
 						ConnectionId: data.Options.ConnectionId,
-						Product:      data.Options.ProductId,
 						Project:      data.Options.ProjectId,
 						RepoUrl:      res.Repo.CodePath,
 						CommitSha:    res.Revision,


### PR DESCRIPTION
### Summary
- Introduced four tables `_tool_zentao_product_summary`, `_tool_zentao_execution_summary`,  `_tool_zentao_execution_stories` and `_tool_zentao_project_stories`
- Modified the format of `_raw_data_params`, now it's like `{"ConnectionId":2,"ProjectId":24}`
- Fixed the missing data issue caused by executing the same subtask multiple times
- Removed `ProductId` from `ZentaoOptions`
- Introduced `iteratorConcator` to concat multiple iterators

