### PR TITLE
fix: can not add connection to bp

### DIFF
--- a/backend/plugins/zentao/api/blueprint_V200_test.go
+++ b/backend/plugins/zentao/api/blueprint_V200_test.go
@@ -62,7 +62,7 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockBasicRes(t)
 
 	bs := &plugin.BlueprintScopeV200{
-		Id: "project/1",
+		Id: "1",
 	}
 	/*bs2 := &plugin.BlueprintScopeV200{
 		Id: "product/1",

--- a/backend/plugins/zentao/api/blueprint_v200.go
+++ b/backend/plugins/zentao/api/blueprint_v200.go
@@ -18,7 +18,6 @@ limitations under the License.
 package api
 
 import (
-	"strings"
 	"time"
 
 	"github.com/apache/incubator-devlake/core/errors"
@@ -67,13 +66,9 @@ func makePipelinePlanV200(
 			ConnectionId: connection.ID,
 		}
 
-		//scopeType := strings.Split(bpScope.Id, `/`)[0]
-		scopeId := strings.Split(bpScope.Id, `/`)[1]
-
 		var entities []string
 
-		//if scopeType == `project` {
-		project, scopeConfig, err := projectScopeHelper.DbHelper().GetScopeAndConfig(connection.ID, scopeId)
+		project, scopeConfig, err := projectScopeHelper.DbHelper().GetScopeAndConfig(connection.ID, bpScope.Id)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
### Summary
Fix the Zentao connections can not be added to the blueprint

### Does this close any open issues?
related to #5653 
