### PR TITLE
feat: filter out the GitLab repos that users only have the Guest perm…

### DIFF
--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -104,7 +104,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 				if err != nil {
 					return nil, err
 				}
-				// Filter out projects where the user only has Guest permission
+
 				filteredProjects := make([]models.GitlabApiProject, 0)
 				for _, project := range resBody {
 					membersURL := fmt.Sprintf("/projects/%d/members/%d", project.GitlabId, apiClient.GetData("UserId"))
@@ -118,7 +118,7 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 						return nil, err
 					}
 					// Filter out projects where the user only has Guest permission and archived projects
-					if member.AccessLevel != 10 && project.Archived == false {
+					if member.AccessLevel != 10 && !project.Archived {
 						filteredProjects = append(filteredProjects, project)
 					}
 				}

--- a/backend/plugins/gitlab/models/account.go
+++ b/backend/plugins/gitlab/models/account.go
@@ -38,3 +38,26 @@ type GitlabAccount struct {
 func (GitlabAccount) TableName() string {
 	return "_tool_gitlab_accounts"
 }
+
+type GitlabUser struct {
+	ID        int    `json:"id"`
+	Username  string `json:"username"`
+	Name      string `json:"name"`
+	State     string `json:"state"`
+	AvatarURL string `json:"avatar_url"`
+	WebURL    string `json:"web_url"`
+}
+
+type GitlabMember struct {
+	AccessLevel     int        `json:"access_level"`
+	CreatedAt       string     `json:"created_at"`
+	CreatedBy       GitlabUser `json:"created_by"`
+	ExpiresAt       string     `json:"expires_at"`
+	ID              int        `json:"id"`
+	Username        string     `json:"username"`
+	Name            string     `json:"name"`
+	State           string     `json:"state"`
+	AvatarURL       string     `json:"avatar_url"`
+	WebURL          string     `json:"web_url"`
+	MembershipState string     `json:"membership_state"`
+}

--- a/backend/plugins/gitlab/models/migrationscripts/20230712_add_archived_to_tool_gitlab_projects.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20230712_add_archived_to_tool_gitlab_projects.go
@@ -18,27 +18,28 @@ limitations under the License.
 package migrationscripts
 
 import (
-	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addGitlabCI),
-		new(addPipelineID),
-		new(addPipelineProjects),
-		new(fixDurationToFloat8),
-		new(addTransformationRule20221125),
-		new(addStdTypeToIssue221230),
-		new(addIsDetailRequired20230210),
-		new(addConnectionIdToTransformationRule),
-		new(addGitlabCommitAuthorInfo),
-		new(addTypeEnvToPipeline),
-		new(renameTr2ScopeConfig),
-		new(addGitlabIssueAssignee),
-		new(addMrCommitSha),
-		new(addRawParamTableForScope),
-		new(addProjectArchived),
-	}
+type gitlabProject20230711 struct {
+	Archived bool `json:"archived"`
+}
+
+func (gitlabProject20230711) TableName() string {
+	return "_tool_gitlab_projects"
+}
+
+type addProjectArchived struct{}
+
+func (script *addProjectArchived) Up(basicRes context.BasicRes) errors.Error {
+	return basicRes.GetDal().AutoMigrate(&gitlabProject20230711{})
+}
+
+func (*addProjectArchived) Version() uint64 {
+	return 20230712095900
+}
+
+func (*addProjectArchived) Name() string {
+	return "add archived to _tool_gitlab_projects"
 }

--- a/backend/plugins/gitlab/models/project.go
+++ b/backend/plugins/gitlab/models/project.go
@@ -30,24 +30,25 @@ import (
 var _ plugin.ToolLayerScope = (*GitlabProject)(nil)
 
 type GitlabProject struct {
-	ConnectionId            uint64 `json:"connectionId" mapstructure:"connectionId" validate:"required" gorm:"primaryKey"`
-	ScopeConfigId           uint64 `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId"`
-	GitlabId                int    `json:"gitlabId" mapstructure:"gitlabId" validate:"required" gorm:"primaryKey"`
-	Name                    string `json:"name" mapstructure:"name" gorm:"type:varchar(255)"`
-	Description             string `json:"description" mapstructure:"description"`
-	DefaultBranch           string `json:"defaultBranch" mapstructure:"defaultBranch" gorm:"type:varchar(255)"`
-	PathWithNamespace       string `json:"pathWithNamespace" mapstructure:"pathWithNamespace" gorm:"type:varchar(255)"`
-	WebUrl                  string `json:"webUrl" mapstructure:"webUrl" gorm:"type:varchar(255)"`
-	CreatorId               int    `json:"creatorId" mapstructure:"creatorId"`
-	Visibility              string `json:"visibility" mapstructure:"visibility" gorm:"type:varchar(255)"`
-	OpenIssuesCount         int    `json:"openIssuesCount" mapstructure:"openIssuesCount"`
-	StarCount               int    `json:"starCount" mapstructure:"StarCount"`
-	ForkedFromProjectId     int    `json:"forkedFromProjectId" mapstructure:"forkedFromProjectId"`
-	ForkedFromProjectWebUrl string `json:"forkedFromProjectWebUrl" mapstructure:"forkedFromProjectWebUrl" gorm:"type:varchar(255)"`
-	HttpUrlToRepo           string `json:"httpUrlToRepo" gorm:"type:varchar(255)"`
+	ConnectionId            uint64     `json:"connectionId" mapstructure:"connectionId" validate:"required" gorm:"primaryKey"`
+	ScopeConfigId           uint64     `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId"`
+	GitlabId                int        `json:"gitlabId" mapstructure:"gitlabId" validate:"required" gorm:"primaryKey"`
+	Name                    string     `json:"name" mapstructure:"name" gorm:"type:varchar(255)"`
+	Description             string     `json:"description" mapstructure:"description"`
+	DefaultBranch           string     `json:"defaultBranch" mapstructure:"defaultBranch" gorm:"type:varchar(255)"`
+	PathWithNamespace       string     `json:"pathWithNamespace" mapstructure:"pathWithNamespace" gorm:"type:varchar(255)"`
+	WebUrl                  string     `json:"webUrl" mapstructure:"webUrl" gorm:"type:varchar(255)"`
+	CreatorId               int        `json:"creatorId" mapstructure:"creatorId"`
+	Visibility              string     `json:"visibility" mapstructure:"visibility" gorm:"type:varchar(255)"`
+	OpenIssuesCount         int        `json:"openIssuesCount" mapstructure:"openIssuesCount"`
+	StarCount               int        `json:"starCount" mapstructure:"StarCount"`
+	ForkedFromProjectId     int        `json:"forkedFromProjectId" mapstructure:"forkedFromProjectId"`
+	ForkedFromProjectWebUrl string     `json:"forkedFromProjectWebUrl" mapstructure:"forkedFromProjectWebUrl" gorm:"type:varchar(255)"`
+	HttpUrlToRepo           string     `json:"httpUrlToRepo" gorm:"type:varchar(255)"`
+	CreatedDate             *time.Time `json:"createdDate" mapstructure:"-"`
+	UpdatedDate             *time.Time `json:"updatedDate" mapstructure:"-"`
+	Archived                bool       `json:"archived" mapstructure:"archived"`
 
-	CreatedDate      *time.Time `json:"createdDate" mapstructure:"-"`
-	UpdatedDate      *time.Time `json:"updatedDate" mapstructure:"-"`
 	common.NoPKModel `json:"-" mapstructure:"-"`
 }
 
@@ -84,6 +85,7 @@ func (gitlabApiProject GitlabApiProject) ConvertApiScope() plugin.ToolLayerScope
 	p.Visibility = gitlabApiProject.Visibility
 	p.OpenIssuesCount = gitlabApiProject.OpenIssuesCount
 	p.StarCount = gitlabApiProject.StarCount
+	p.Archived = gitlabApiProject.Archived
 	p.CreatedDate = gitlabApiProject.CreatedAt.ToNullableTime()
 	p.UpdatedDate = helper.Iso8601TimeToTime(gitlabApiProject.LastActivityAt)
 	if gitlabApiProject.ForkedFromProject != nil {
@@ -112,6 +114,7 @@ type GitlabApiProject struct {
 	CreatedAt         helper.Iso8601Time  `json:"created_at"`
 	LastActivityAt    *helper.Iso8601Time `json:"last_activity_at"`
 	HttpUrlToRepo     string              `json:"http_url_to_repo"`
+	Archived          bool                `json:"archived"`
 }
 
 type GroupResponse struct {

--- a/backend/plugins/gitlab/tasks/project_convertor.go
+++ b/backend/plugins/gitlab/tasks/project_convertor.go
@@ -54,6 +54,7 @@ type GitlabApiProject struct {
 	CreatedAt         helper.Iso8601Time  `json:"created_at"`
 	LastActivityAt    *helper.Iso8601Time `json:"last_activity_at"`
 	HttpUrlToRepo     string              `json:"http_url_to_repo"`
+	Archived          bool                `json:"archived"`
 }
 
 var ConvertProjectMeta = plugin.SubTaskMeta{

--- a/backend/plugins/gitlab/tasks/project_extractor.go
+++ b/backend/plugins/gitlab/tasks/project_extractor.go
@@ -38,6 +38,7 @@ func ConvertProject(gitlabApiProject *GitlabApiProject) *models.GitlabProject {
 		StarCount:         gitlabApiProject.StarCount,
 		CreatedDate:       gitlabApiProject.CreatedAt.ToNullableTime(),
 		UpdatedDate:       helper.Iso8601TimeToTime(gitlabApiProject.LastActivityAt),
+		Archived:          gitlabApiProject.Archived,
 	}
 	if gitlabApiProject.ForkedFromProject != nil {
 		gitlabProject.ForkedFromProjectId = gitlabApiProject.ForkedFromProject.GitlabId


### PR DESCRIPTION
### Summary
**don't merge after v0.18.0-beta1** 

Filter out the GitLab repos that users only have the Guest permission and archived projects

### Does this close any open issues?
Closes #5104 

### Screenshots
![28e2213d-f89f-4e52-8317-2f5a708189c8](https://github.com/apache/incubator-devlake/assets/101256042/a140c2db-1f2b-4f8e-9d66-a8445cf352ab)

![img_v2_c2a72dd2-8581-4a91-a1e1-6b596ffab9eg](https://github.com/apache/incubator-devlake/assets/101256042/e5ff84d3-93f2-48f2-818b-779c617750da)


### Other Information
Any other information that is important to this PR.
