### PR TITLE
feat(config-ui): add data scope search when add connection in project/bp

### DIFF
--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -27,6 +27,7 @@
     "@blueprintjs/datetime2": "^0.9.6",
     "@blueprintjs/popover2": "^1.10.2",
     "@blueprintjs/select": "^4.8.12",
+    "ahooks": "^3.7.8",
     "axios": "^0.21.4",
     "classnames": "^2.3.2",
     "cron-parser": "^4.3.0",

--- a/config-ui/src/components/selector/multi-selector/index.tsx
+++ b/config-ui/src/components/selector/multi-selector/index.tsx
@@ -100,7 +100,6 @@ export const MultiSelector = <T,>({
   return (
     <MultiSelect2
       fill
-      resetOnSelect
       placeholder={placeholder ?? 'Select...'}
       items={items}
       // https://github.com/palantir/blueprint/issues/3596

--- a/config-ui/src/plugins/components/data-scope-select/api.ts
+++ b/config-ui/src/plugins/components/data-scope-select/api.ts
@@ -18,5 +18,11 @@
 
 import { request } from '@/utils';
 
-export const getDataScope = (plugin: string, connectionId: ID) =>
-  request(`/plugins/${plugin}/connections/${connectionId}/scopes`);
+type ParamsType = {
+  searchTerm: string;
+};
+
+export const getDataScope = (plugin: string, connectionId: ID, params?: ParamsType) =>
+  request(`/plugins/${plugin}/connections/${connectionId}/scopes`, {
+    data: params,
+  });

--- a/config-ui/src/plugins/components/data-scope-select/styled.ts
+++ b/config-ui/src/plugins/components/data-scope-select/styled.ts
@@ -20,4 +20,8 @@ import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   margin-top: 24px;
+
+  .search {
+    margin-bottom: 16px;
+  }
 `;

--- a/config-ui/yarn.lock
+++ b/config-ui/yarn.lock
@@ -2419,7 +2419,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ahooks@npm:^3.4.1":
+"ahooks@npm:^3.4.1, ahooks@npm:^3.7.8":
   version: 3.7.8
   resolution: "ahooks@npm:3.7.8"
   dependencies:
@@ -3050,6 +3050,7 @@ __metadata:
     "@types/react-transition-group": ^4.4.6
     "@types/styled-components": ^5.1.26
     "@vitejs/plugin-react": ^3.1.0
+    ahooks: ^3.7.8
     axios: ^0.21.4
     classnames: ^2.3.2
     cron-parser: ^4.3.0


### PR DESCRIPTION
### Summary
1 refactor(config-ui): remove props resetOnSelect from multi-selector
2. feat(config-ui): add data scope search when add connection in project/bp

### Does this close any open issues?
Closes #5203 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/37237996/cfa3ec3e-4553-4eb4-9c63-f8c56fa5c1d2)

