### PR TITLE
fix: panic when creating webhook deployment

### DIFF
--- a/backend/server/api/router.go
+++ b/backend/server/api/router.go
@@ -114,7 +114,7 @@ func handlePluginCall(pluginName string, handler plugin.ApiResourceHandler) func
 			} else {
 				err2 := c.ShouldBindJSON(&input.Body)
 				if err2 != nil && err2.Error() != "EOF" {
-					shared.ApiOutputError(c, err)
+					shared.ApiOutputError(c, err2)
 					return
 				}
 			}


### PR DESCRIPTION
### Summary
The panic was caused by passing a nil-valued error to the function `ApiOutputError`

### Does this close any open issues?
Closes #5681 

