### PR TITLE
fix: error on deleting webhook connection

### DIFF
--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -19,7 +19,9 @@ package api
 
 import (
 	"fmt"
+	"github.com/apache/incubator-devlake/core/dal"
 	"net/http"
+	"strconv"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -73,7 +75,15 @@ func PatchConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /plugins/webhook/connections/{connectionId} [DELETE]
 func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	return connectionHelper.Delete(&models.WebhookConnection{}, input)
+	connectionId, e := strconv.ParseInt(input.Params["connectionId"], 10, 64)
+	if e != nil {
+		return nil, errors.BadInput.WrapRaw(e)
+	}
+	err := basicRes.GetDal().Delete(&models.WebhookConnection{}, dal.Where("id = ?", connectionId))
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Status: http.StatusOK}, nil
 }
 
 type WebhookConnectionResponse struct {


### PR DESCRIPTION
### Summary
Fix #5682, the plugin webhook doesn't implement the interface`PluginSource`, it cannot be deleted by the `Delete` method of `connectionHelper`

### Does this close any open issues?
Closes #5682 

### Screenshots
![20230718202846_rec_](https://github.com/apache/incubator-devlake/assets/8455907/ea5a485e-80e9-476d-84cb-7fb8c642e2ac)

### Other Information
Any other information that is important to this PR.
