### PR TITLE
Added Scarf gateway to DevLake Docker Compose downloads (#5404)

### DIFF
--- a/devops/releases/lake-v0.17.0/docker-compose.yml
+++ b/devops/releases/lake-v0.17.0/docker-compose.yml
@@ -32,7 +32,7 @@ services:
       --skip-log-bin
 
   grafana:
-    image: apache/devlake-dashboard:v0.17.0
+    image: devlake.docker.scarf.sh/apache/devlake-dashboard:v0.17.0
     ports:
       - 3002:3000
     volumes:
@@ -49,7 +49,7 @@ services:
       - mysql
 
   devlake:
-    image: apache/devlake:v0.17.0
+    image: devlake.docker.scarf.sh/apache/devlake:v0.17.0
     ports:
       - 8080:8080
     restart: always
@@ -62,7 +62,7 @@ services:
       - mysql
 
   config-ui:
-    image: apache/devlake-config-ui:v0.17.0
+    image: devlake.docker.scarf.sh/apache/devlake-config-ui:v0.17.0
     ports:
       - 4000:4000
     env_file:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -46,7 +46,7 @@ services:
       POSTGRES_PASSWORD: merico
 
   grafana:
-    image: mericodev/devlake-dashboard:latest
+    image: devlake.docker.scarf.sh/mericodev/devlake-dashboard:latest
     build:
       context: grafana/
     ports:
@@ -65,7 +65,7 @@ services:
       - mysql
 
   devlake:
-    image: mericodev/devlake:latest
+    image: devlake.docker.scarf.sh/mericodev/devlake:latest
     build:
       context: backend
       args:
@@ -84,7 +84,7 @@ services:
       - mysql
 
   config-ui:
-    image: mericodev/devlake-config-ui:latest
+    image: devlake.docker.scarf.sh/mericodev/devlake-config-ui:latest
     build:
       context: "config-ui"
     ports:


### PR DESCRIPTION
* Added Scarf gateway to DevLake Docker Compose downloads

* add Scarf endpoint for v0.17.0 docker compose

---------
cherrypick https://github.com/apache/incubator-devlake/pull/5404 to release 0.18

### Summary
What does this PR do?

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
