### PR TITLE
fix: api stop working due to lock tables

### DIFF
--- a/backend/helpers/dbhelper/txhelper.go
+++ b/backend/helpers/dbhelper/txhelper.go
@@ -80,6 +80,7 @@ func (l *TxHelper[E]) End() {
 	}
 
 	if msg == "" {
+		_ = l.tx.UnlockTables()
 		errors.Must(l.tx.Commit())
 	} else {
 		_ = l.tx.UnlockTables()


### PR DESCRIPTION
### Summary
Either the mysql manual is incorrect or the `gorm` lib doesn't handle tx correctly which causes the reused connection (previous used by the `dequeuePipeline` function to lock the pipelines table) to have some tables(mainly the pipelines table) locked unexpectedly, thus the following error showed:

![img_v2_ec1266c0-9269-4f78-ab3e-114eaaa343ag](https://github.com/apache/incubator-devlake/assets/61080/b87d3e6e-01b4-4884-a482-1bd3b229461a)

According to https://dev.mysql.com/doc/refman/8.0/en/lock-tables.html, `UNLOCK TABLES` must be called after `commi`, however, it throws an error which is contradict the manual (scroll to "Interaction of Table Locking and Transactions")

Anyway, not quiet sure but UNLOCK TABLES seems to work for both pg and MySQL and pg actually doesn't do anything because it doesn't have UNLOCK TABLES at all, pg seems to be handling the tx correctly.

I tested the pipeline dequeue and API and they are working ok on both pg and mysql