### PR TITLE
fix: starrocks panic with new tables

### DIFF
--- a/backend/impls/dalgorm/dalgorm.go
+++ b/backend/impls/dalgorm/dalgorm.go
@@ -427,6 +427,11 @@ func (d *Dalgorm) IsJsonOrderError(err error) bool {
 	return strings.Contains(err.Error(), "identify an ordering operator for type json")
 }
 
+// IsTableExist checks if table exists
+func (d *Dalgorm) IsTableExist(err error) bool {
+	return strings.Contains(err.Error(), "Unknown table")
+}
+
 // RawCursor (Deprecated) executes raw sql query and returns a database cursor
 func (d *Dalgorm) RawCursor(query string, params ...interface{}) (*sql.Rows, errors.Error) {
 	rows, err := d.db.Raw(query, params...).Rows()
@@ -453,6 +458,9 @@ func (d *Dalgorm) convertGormError(err error) errors.Error {
 	}
 	if d.IsCachedPlanError(err) {
 		return nil
+	}
+	if d.IsTableExist(err) {
+		return errors.NotFound.WrapRaw(err)
 	}
 
 	panic(err)

--- a/backend/impls/dalgorm/dalgorm.go
+++ b/backend/impls/dalgorm/dalgorm.go
@@ -460,7 +460,7 @@ func (d *Dalgorm) convertGormError(err error) errors.Error {
 		return nil
 	}
 	if d.IsTableExist(err) {
-		return errors.NotFound.WrapRaw(err)
+		return errors.BadInput.WrapRaw(err)
 	}
 
 	panic(err)


### PR DESCRIPTION
### Summary
fix: starrocks panic with new tables, ignore the no table error in starrocks

### Does this close any open issues?
related to #5696 

### Screenshots
previous result：
![image](https://github.com/apache/incubator-devlake/assets/101256042/3502c14a-d474-435c-bc7b-788d5e5563b8)
now result：
![image](https://github.com/apache/incubator-devlake/assets/101256042/3fc1095e-9085-44b1-aaa9-cbb44c61efa9)


### Other Information
Any other information that is important to this PR.
