### PR TITLE
cherry-pick fix: api stop working due to lock tables #5715 to v0.18 (beta2)

### DIFF
--- a/backend/helpers/dbhelper/txhelper.go
+++ b/backend/helpers/dbhelper/txhelper.go
@@ -80,6 +80,7 @@ func (l *TxHelper[E]) End() {
 	}
 
 	if msg == "" {
+		_ = l.tx.UnlockTables()
 		errors.Must(l.tx.Commit())
 	} else {
 		_ = l.tx.UnlockTables()


### PR DESCRIPTION

### Summary
cherry-pick fix: api stop working due to lock tables #5715 to v0.18