### PR TITLE
fix: getscopes panic on advanced mode

### DIFF
--- a/backend/helpers/pluginhelper/services/blueprint_helper.go
+++ b/backend/helpers/pluginhelper/services/blueprint_helper.go
@@ -19,6 +19,7 @@ package services
 
 import (
 	"fmt"
+
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models"
@@ -161,6 +162,9 @@ func (b *BlueprintManager) GetBlueprintsByScopes(connectionId uint64, pluginName
 	}
 	scopeMap := map[string][]*models.Blueprint{}
 	for _, bp := range bps {
+		if bp.Mode == models.BLUEPRINT_MODE_ADVANCED {
+			continue
+		}
 		scopes, err := bp.GetScopes(connectionId, pluginName)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
### Summary
fix: getscopes panic on advanced mode, filter out the adcanced mode.

### Does this close any open issues?
Closes #5716 

### Screenshots
previous result:
![dc43b7f4-2782-4b59-97fb-66e084d9aa8e](https://github.com/apache/incubator-devlake/assets/101256042/66183fc0-d8e7-4e40-9e3d-a22213a67e58)
now results:
![image](https://github.com/apache/incubator-devlake/assets/101256042/ba1e2da4-7bc1-499d-8f2c-1c779130e077)


### Other Information
Any other information that is important to this PR.
