### PR TITLE
feat: add full name to remote api

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -109,11 +109,12 @@ unit-test: mock unit-test-only python-unit-test
 
 unit-test-only:
 	set -e;\
-	exit_code=0;\
 	for m in $$(go list ./... | egrep -v 'test|models|e2e'); do \
-  		echo $$m; go test -timeout 60s -v $$m || exit_code=$$?; \
+  		echo $$m; \
+			if ! go test -timeout 60s -v $$m; then \
+				exit $$?; \
+			fi \
 	done; \
-	exit $$exit_code
 
 build-pydevlake:
 	poetry install -C python/pydevlake

--- a/backend/core/plugin/plugin_scope_abstract.go
+++ b/backend/core/plugin/plugin_scope_abstract.go
@@ -36,6 +36,7 @@ type Scope interface {
 
 type ToolLayerScope interface {
 	Scope
+	ScopeFullName() string
 	ScopeParams() interface{}
 }
 

--- a/backend/helpers/pluginhelper/api/remote_api_helper.go
+++ b/backend/helpers/pluginhelper/api/remote_api_helper.go
@@ -35,6 +35,7 @@ type RemoteScopesChild struct {
 	ParentId *string     `json:"parentId"`
 	Id       string      `json:"id"`
 	Name     string      `json:"name"`
+	FullName string      `json:"fullName"`
 	Data     interface{} `json:"data"`
 }
 
@@ -211,10 +212,11 @@ func (r *RemoteApiHelper[Conn, Scope, ApiScope, Group]) GetScopesFromRemote(inpu
 		for _, project := range resBody {
 			scope := project.ConvertApiScope()
 			child := RemoteScopesChild{
-				Type: TypeProject,
-				Id:   scope.ScopeId(),
-				Name: scope.ScopeName(),
-				Data: &scope,
+				Type:     TypeProject,
+				Id:       scope.ScopeId(),
+				Name:     scope.ScopeName(),
+				FullName: scope.ScopeFullName(),
+				Data:     &scope,
 			}
 			child.ParentId = &gid
 			if *child.ParentId == "" {
@@ -307,6 +309,7 @@ func (r *RemoteApiHelper[Conn, Scope, ApiScope, Group]) SearchRemoteScopes(input
 			Id:       scope.ScopeId(),
 			ParentId: nil,
 			Name:     scope.ScopeName(),
+			FullName: scope.ScopeFullName(),
 			Data:     scope,
 		}
 

--- a/backend/helpers/pluginhelper/api/scope_helper_test.go
+++ b/backend/helpers/pluginhelper/api/scope_helper_test.go
@@ -56,6 +56,10 @@ func (t TestFakeGitlabRepo) ScopeName() string {
 	return ""
 }
 
+func (t TestFakeGitlabRepo) ScopeFullName() string {
+	return ""
+}
+
 func (t TestFakeGitlabRepo) TableName() string {
 	return ""
 }
@@ -86,6 +90,10 @@ func (r TestFakeGithubRepo) ScopeId() string {
 }
 
 func (r TestFakeGithubRepo) ScopeName() string {
+	return r.Name
+}
+
+func (r TestFakeGithubRepo) ScopeFullName() string {
 	return r.Name
 }
 

--- a/backend/plugins/bamboo/models/project.go
+++ b/backend/plugins/bamboo/models/project.go
@@ -48,6 +48,10 @@ func (p BambooProject) ScopeName() string {
 	return p.Name
 }
 
+func (p BambooProject) ScopeFullName() string {
+	return p.Name
+}
+
 func (p BambooProject) ScopeParams() interface{} {
 	return &BambooApiParams{
 		ConnectionId: p.ConnectionId,

--- a/backend/plugins/bitbucket/models/repo.go
+++ b/backend/plugins/bitbucket/models/repo.go
@@ -55,6 +55,10 @@ func (p BitbucketRepo) ScopeName() string {
 	return p.Name
 }
 
+func (p BitbucketRepo) ScopeFullName() string {
+	return p.BitbucketId
+}
+
 func (p BitbucketRepo) ScopeParams() interface{} {
 	return &BitbucketApiParams{
 		ConnectionId: p.ConnectionId,

--- a/backend/plugins/gitee/models/repo.go
+++ b/backend/plugins/gitee/models/repo.go
@@ -18,6 +18,7 @@ limitations under the License.
 package models
 
 import (
+	"fmt"
 	"strconv"
 	"time"
 
@@ -49,6 +50,10 @@ func (r GiteeRepo) ScopeId() string {
 
 func (r GiteeRepo) ScopeName() string {
 	return r.Name
+}
+
+func (r GiteeRepo) ScopeFullName() string {
+	return fmt.Sprintf("%v/%v", r.OwnerLogin, r.Name)
 }
 
 func (r GiteeRepo) ScopeParams() interface{} {

--- a/backend/plugins/github/models/repo.go
+++ b/backend/plugins/github/models/repo.go
@@ -53,6 +53,10 @@ func (r GithubRepo) ScopeName() string {
 	return r.Name
 }
 
+func (r GithubRepo) ScopeFullName() string {
+	return r.FullName
+}
+
 func (r GithubRepo) ScopeParams() interface{} {
 	return &GithubApiParams{
 		ConnectionId: r.ConnectionId,

--- a/backend/plugins/gitlab/models/project.go
+++ b/backend/plugins/gitlab/models/project.go
@@ -63,6 +63,10 @@ func (p GitlabProject) ScopeName() string {
 	return p.Name
 }
 
+func (p GitlabProject) ScopeFullName() string {
+	return p.PathWithNamespace
+}
+
 func (p GitlabProject) ScopeParams() interface{} {
 	return &GitlabApiParams{
 		ConnectionId: p.ConnectionId,

--- a/backend/plugins/jenkins/models/job.go
+++ b/backend/plugins/jenkins/models/job.go
@@ -51,6 +51,9 @@ func (j JenkinsJob) ScopeId() string {
 func (j JenkinsJob) ScopeName() string {
 	return j.Name
 }
+func (j JenkinsJob) ScopeFullName() string {
+	return j.FullName
+}
 
 func (j JenkinsJob) ScopeParams() interface{} {
 	return &JenkinsApiParams{

--- a/backend/plugins/jira/models/board.go
+++ b/backend/plugins/jira/models/board.go
@@ -45,6 +45,10 @@ func (b JiraBoard) ScopeName() string {
 	return b.Name
 }
 
+func (b JiraBoard) ScopeFullName() string {
+	return b.Name
+}
+
 func (b JiraBoard) ScopeParams() interface{} {
 	return &JiraApiParams{
 		ConnectionId: b.ConnectionId,

--- a/backend/plugins/pagerduty/models/service.go
+++ b/backend/plugins/pagerduty/models/service.go
@@ -43,6 +43,10 @@ func (s Service) ScopeName() string {
 	return s.Name
 }
 
+func (s Service) ScopeFullName() string {
+	return s.Name
+}
+
 func (s Service) ScopeParams() interface{} {
 	return &PagerDutyParams{
 		ConnectionId: s.ConnectionId,

--- a/backend/plugins/sonarqube/models/sonarqube_project.go
+++ b/backend/plugins/sonarqube/models/sonarqube_project.go
@@ -49,6 +49,10 @@ func (p SonarqubeProject) ScopeName() string {
 	return p.Name
 }
 
+func (p SonarqubeProject) ScopeFullName() string {
+	return p.Name
+}
+
 func (p SonarqubeProject) ScopeParams() interface{} {
 	return SonarqubeApiParams{
 		ConnectionId: p.ConnectionId,

--- a/backend/plugins/tapd/models/workspace.go
+++ b/backend/plugins/tapd/models/workspace.go
@@ -89,6 +89,10 @@ func (w TapdWorkspace) ScopeName() string {
 	return w.Name
 }
 
+func (w TapdWorkspace) ScopeFullName() string {
+	return w.Name
+}
+
 func (w TapdWorkspace) ScopeParams() interface{} {
 	return &TapdApiParams{
 		ConnectionId: w.ConnectionId,

--- a/backend/plugins/trello/models/board.go
+++ b/backend/plugins/trello/models/board.go
@@ -40,6 +40,10 @@ func (b TrelloBoard) ScopeName() string {
 	return b.Name
 }
 
+func (b TrelloBoard) ScopeFullName() string {
+	return b.Name
+}
+
 func (b TrelloBoard) ScopeParams() interface{} {
 	return &TrelloApiParams{
 		ConnectionId: b.ConnectionId,

--- a/backend/plugins/zentao/models/project.go
+++ b/backend/plugins/zentao/models/project.go
@@ -154,6 +154,10 @@ func (p ZentaoProject) ScopeName() string {
 	return p.Name
 }
 
+func (p ZentaoProject) ScopeFullName() string {
+	return p.Name
+}
+
 func (p ZentaoProject) ScopeParams() interface{} {
 	return &ZentaoApiParams{
 		ConnectionId: p.ConnectionId,

--- a/backend/server/services/remote/models/models.go
+++ b/backend/server/services/remote/models/models.go
@@ -97,6 +97,10 @@ func (d DynamicScopeModel) ScopeName() string {
 	return reflect.ValueOf(d.DynamicTabler.Unwrap()).Elem().FieldByName("Name").String()
 }
 
+func (d DynamicScopeModel) ScopeFullName() string {
+	return d.ScopeName()
+}
+
 func (d DynamicScopeModel) ScopeParams() interface{} {
 	return &ApiParams{
 		ConnectionId: d.ConnectionId(),


### PR DESCRIPTION
### Summary
it is basically unusable when trying to search github repos and add them

![5426a33c-3d99-4b4d-aa0e-0d3cf499962c](https://github.com/apache/incubator-devlake/assets/61080/1b01e2bb-6459-45ec-8570-521a00d6a7a9)

This PR add a new field named `fullName` to deal with the situation.

for plugins that don't have **parent folders**, `fullName = name`, like sonarqube, jira, etc
for plugins that have **parent folders**, `fullName = parent folders / name`, like github, gitlab, jenkins, etcs

### Self test
I tested on most of the data source that I have access to. bitbucket, jira , gitlab, github, jenkins

### Screenshots

<img width="941" alt="Snipaste_2023-07-21_17-00-04" src="https://github.com/apache/incubator-devlake/assets/61080/85f539ae-3656-4353-b1d2-1d09a9c789ab">
<img width="958" alt="Snipaste_2023-07-21_17-26-23" src="https://github.com/apache/incubator-devlake/assets/61080/a671b80e-60ad-42dc-a306-1ca4bf3df7dc">
<img width="930" alt="Snipaste_2023-07-21_17-35-48" src="https://github.com/apache/incubator-devlake/assets/61080/539d76d7-2e63-4dfc-9d12-1b524887a3c2">
<img width="946" alt="Snipaste_2023-07-21_17-42-15" src="https://github.com/apache/incubator-devlake/assets/61080/c3ceaf3c-473a-4367-9ca9-21c56f80bc12">
<img width="943" alt="Snipaste_2023-07-21_17-54-45" src="https://github.com/apache/incubator-devlake/assets/61080/18a7939a-2881-491c-97bd-f1a7da4494a4">
<img width="945" alt="Snipaste_2023-07-21_17-58-30" src="https://github.com/apache/incubator-devlake/assets/61080/40b60fd8-f2ff-4d02-b8c3-ef7e0dd199af">
