### PR TITLE
fix: unify scopeConfig field for task_data

### DIFF
--- a/backend/plugins/bitbucket/tasks/task_data.go
+++ b/backend/plugins/bitbucket/tasks/task_data.go
@@ -31,7 +31,7 @@ type BitbucketOptions struct {
 	FullName                     string   `json:"fullName" mapstructure:"fullName"`
 	TimeAfter                    string   `json:"timeAfter" mapstructure:"timeAfter,omitempty"`
 	ScopeConfigId                uint64   `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	*models.BitbucketScopeConfig `mapstructure:"scopeConfigs,omitempty" json:"scopeConfigs"`
+	*models.BitbucketScopeConfig `mapstructure:"scopeConfig,omitempty" json:"scopeConfig"`
 }
 
 type BitbucketTaskData struct {

--- a/backend/plugins/tapd/tasks/task_data.go
+++ b/backend/plugins/tapd/tasks/task_data.go
@@ -33,7 +33,7 @@ type TapdOptions struct {
 	TimeAfter     string `json:"timeAfter" mapstructure:"timeAfter,omitempty"`
 	CstZone       *time.Location
 	ScopeConfigId uint64
-	ScopeConfig   *TapdScopeConfig `json:"scopeConfigs"`
+	ScopeConfig   *TapdScopeConfig `json:"scopeConfig"`
 }
 
 func MakeScopeConfigs(rule models.TapdScopeConfig) (*TapdScopeConfig, errors.Error) {

--- a/backend/plugins/zentao/tasks/task_data.go
+++ b/backend/plugins/zentao/tasks/task_data.go
@@ -40,7 +40,7 @@ type ZentaoOptions struct {
 	// TODO not support now
 	TimeAfter     string              `json:"timeAfter" mapstructure:"timeAfter,omitempty"`
 	ScopeConfigId uint64              `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	ScopeConfigs  *ZentaoScopeConfigs `json:"scopeConfigs" mapstructure:"scopeConfigs,omitempty"`
+	ScopeConfigs  *ZentaoScopeConfigs `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
 }
 
 func (o *ZentaoOptions) GetParams() any {


### PR DESCRIPTION
### Summary
Most of the plugins use the singular form for `scopeConfig` in their `TaskOption`
![image](https://github.com/apache/incubator-devlake/assets/61080/e36fac37-5c7a-4598-9ecb-d7614a160624)
However, there are some blacksheeps:
![img_v2_63e1c175-615b-4c3c-8bb3-85e2eebefbcg](https://github.com/apache/incubator-devlake/assets/61080/f6765d83-d68b-41ae-bba7-ebc84ad531f4)


