### PR TITLE
feat(config-ui): add healthcheck endpoint to nginx conf

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -2,6 +2,7 @@ server {
   listen 4000;
   server_name localhost;
   absolute_redirect off;
+
 ${SERVER_CONF}
 
   location / {
@@ -35,5 +36,10 @@ ${SERVER_CONF}
     proxy_send_timeout 60s;
     proxy_read_timeout 60s;
     proxy_pass ${GRAFANA_ENDPOINT_PROTO}://$target;
+  }
+
+  location /health/ {
+    auth_basic off;
+    return 200;
   }
 }


### PR DESCRIPTION
### Summary
This PR adds a healthcheck endpoint to the nginx config for the config-ui. It is particularly helpful when using basic authentication to protect access to the config UI, but when deploying to services like Kubernetes on GKE when some healthchecks cannot be configured to use basic auth (or are difficult to configure that way).

### Does this close any open issues?
N/A

### Screenshots
N/A

### Other Information
N/A
