### PR TITLE
[fix-5689]: Python schema migrations must be fully manual

### DIFF
--- a/backend/python/README.md
+++ b/backend/python/README.md
@@ -237,23 +237,38 @@ To facilitate or even eliminate extraction, your tool models should be close to 
 #### Migration of tool models
 
 Tool models, connection, scope and scope config types are stored in the DevLake database.
-When you change the definition of one of those types, the database needs to be migrated.
-Automatic migration takes care of most modifications, but some changes require manual migration. For example, automatic migration never drops columns. Another example is adding a column to the primary key of a table, you need to write a script that remove the primary key constraint and add a new compound primary key.
+When you create or change the definition of one of those types, the database needs to be migrated. This requires that
+you write migration code for them. Important: When you write a migration for a creation operation, the model must be a SNAPSHOT of the models you're intending
+to migrate; don't directly use the actual model because that may change over time. Instead, define a model that is a copy of the main one, and use that in the
+migration - this model's code will never change (Hence, it's a snapshot).
+Also, keep in mind, that Python only supports writing schema migrations. If your flow requires data migrations as well, at this time, the code needs to
+be written in Go. See [this Go package](https://github.com/apache/incubator-devlake/tree/main/backend/server/services/remote/models/migrationscripts) for example.
 
 To declare a new migration script, you decorate a function with the `migration` decorator. The function name should describe what the script does. The `migration` decorator takes a version number that should be a 14 digits timestamp in the format `YYYYMMDDhhmmss`. The function takes a `MigrationScriptBuilder` as a parameter. This builder exposes methods to execute migration operations.
 
 ##### Migration operations
 
-The `MigrationScriptBuilder` exposes the following methods:
+The `MigrationScriptBuilder` exposes several methods. Here we list a few:
 - `execute(sql: str, dialect: Optional[Dialect])`: execute a raw SQL statement. The `dialect` parameter is used to execute the SQL statement only if the database is of the given dialect. If `dialect` is `None`, the statement is executed unconditionally.
 - `drop_column(table: str, column: str)`: drop a column from a table
 - `drop_table(table: str)`: drop a table
+
+Example of creating tables via migrations:
+```python
+
+@migration(20230501000001, name="initialize schemas for Plugin")
+def init_schemas(b: MigrationScriptBuilder):
+    class PluginConnection(Connection):
+        token: SecretStr
+        organization: Optional[str]
+    b.create_tables(PluginConnection)
+```
 
 
 ```python
 from pydevlake.migration import MigrationScriptBuilder, migration, Dialect
 
-@migration(20230524181430)
+@migration(20230524181430, name="add pk to Job table")
 def add_build_id_as_job_primary_key(b: MigrationScriptBuilder):
     table = Job.__tablename__
     b.execute(f'ALTER TABLE {table} DROP PRIMARY KEY', Dialect.MYSQL)
@@ -296,7 +311,9 @@ Most of the time, you will convert a tool model into a single domain model, but 
 
 The `collect` method takes a `state` dictionary and a context object and yields tuples of raw data and new state.
 The last state that the plugin yielded for a given connection will be reused during the next collection.
-The plugin can use this `state` to store information necessary to perform incremental collection of data.
+The plugin can use this `state` to store information necessary to perform incremental collection of data. This operates
+independently of the way Go manages state, and is tracked by the table `_pydevlake_subtask_runs`. See [this issue](https://github.com/apache/incubator-devlake/issues/4880)
+for a proposed improvement to this feature.
 
 The `extract` method takes a raw data object and returns a tool model.
 This method has a default implementation that populates an instance of the `tool_model` class with the raw data.

--- a/backend/python/plugins/azuredevops/azuredevops/migrations.py
+++ b/backend/python/plugins/azuredevops/azuredevops/migrations.py
@@ -1,0 +1,165 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import datetime
+import re
+from enum import Enum
+from typing import Optional
+
+from pydantic import SecretStr
+
+from pydevlake import ToolModel, Connection, Field
+from pydevlake.migration import migration, Dialect, MigrationScriptBuilder
+from pydevlake.model import Model, ToolTable
+from pydevlake.pipeline_tasks import RefDiffOptions
+
+
+@migration(20230501000001, name="initialize schemas for Azure Devops")
+def init_schemas(b: MigrationScriptBuilder):
+    class AzureDevOpsConnection(Connection):
+        token: SecretStr
+        organization: Optional[str]
+
+    class AzureDevopsTransformationRule(ToolTable, Model):
+        name: str = Field(default="default")
+        refdiff: Optional[RefDiffOptions]
+        deployment_pattern: Optional[re.Pattern]
+        production_pattern: Optional[re.Pattern]
+
+    class GitRepository(ToolModel):
+        id: str = Field(primary_key=True)
+        name: str
+        url: str
+        remote_url: Optional[str]
+        default_branch: Optional[str]
+        project_id: str
+        org_id: str
+        parent_repository_url: Optional[str]
+        provider: Optional[str]
+
+    class GitPullRequest(ToolModel):
+        class PRStatus(Enum):
+            Abandoned = "abandoned"
+            Active = "active"
+            Completed = "completed"
+
+        pull_request_id: int = Field(primary_key=True)
+        description: Optional[str]
+        status: PRStatus
+        created_by_id: str
+        created_by_name: str
+        creation_date: datetime.datetime
+        closed_date: Optional[datetime.datetime]
+        source_commit_sha: str
+        target_commit_sha: str
+        merge_commit_sha: Optional[str]
+        url: Optional[str]
+        type: Optional[str]
+        title: Optional[str]
+        target_ref_name: Optional[str]
+        source_ref_name: Optional[str]
+        fork_repo_id: Optional[str]
+
+    class GitPullRequestCommit(ToolModel):
+        commit_id: str = Field(primary_key=True)
+        pull_request_id: str
+        author_name: str
+        author_email: str
+        author_date: datetime.datetime
+
+    class Build(ToolModel):
+        class BuildStatus(Enum):
+            Cancelling = "cancelling"
+            Completed = "completed"
+            InProgress = "inProgress"
+            NotStarted = "notStarted"
+            Postponed = "postponed"
+
+        class BuildResult(Enum):
+            Canceled = "canceled"
+            Failed = "failed"
+            Non = "none"
+            PartiallySucceeded = "partiallySucceeded"
+            Succeeded = "succeeded"
+
+        id: int = Field(primary_key=True)
+        name: str
+        start_time: Optional[datetime.datetime]
+        finish_time: Optional[datetime.datetime]
+        status: BuildStatus
+        result: Optional[BuildResult]
+        source_branch: str
+        source_version: str
+
+    class Job(ToolModel):
+        class JobState(Enum):
+            Completed = "completed"
+            InProgress = "inProgress"
+            Pending = "pending"
+
+        class JobResult(Enum):
+            Abandoned = "abandoned"
+            Canceled = "canceled"
+            Failed = "failed"
+            Skipped = "skipped"
+            Succeeded = "succeeded"
+            SucceededWithIssues = "succeededWithIssues"
+
+        id: str = Field(primary_key=True)
+        build_id: str
+        name: str
+        start_time: Optional[datetime.datetime]
+        finish_time: Optional[datetime.datetime]
+        state: JobState
+        result: Optional[JobResult]
+
+    b.create_tables(
+        AzureDevOpsConnection,
+        AzureDevopsTransformationRule,
+        GitRepository,
+        GitPullRequestCommit,
+        GitPullRequest,
+        Build,
+        Job,
+    )
+
+
+@migration(20230524181430)
+def add_build_id_as_job_primary_key(b: MigrationScriptBuilder):
+    # NOTE: We can't add a column to the primary key of an existing table
+    # so we have to drop the primary key constraint first,
+    # which is done differently in MySQL and PostgreSQL,
+    # and then add the new composite primary key.
+    table = '_tool_azuredevops_jobs'
+    b.execute(f'ALTER TABLE {table} MODIFY COLUMN build_id VARCHAR(255)', Dialect.MYSQL)
+    b.execute(f'ALTER TABLE {table} ALTER COLUMN build_id VARCHAR(255)', Dialect.POSTGRESQL)
+    b.execute(f'ALTER TABLE {table} DROP PRIMARY KEY', Dialect.MYSQL)
+    b.execute(f'ALTER TABLE {table} DROP CONSTRAINT {table}_pkey', Dialect.POSTGRESQL)
+    b.execute(f'ALTER TABLE {table} ADD PRIMARY KEY (id, build_id)')
+
+
+@migration(20230606165630)
+def rename_tx_rule_table_to_scope_config(b: MigrationScriptBuilder):
+    b.rename_table('_tool_azuredevops_azuredevopstransformationrules', '_tool_azuredevops_gitrepositoryconfigs')
+
+
+@migration(20230607165630, name="add entities column to gitrepositoryconfig table")
+def add_entities_column_to_scope_config(b: MigrationScriptBuilder):
+    b.add_column('_tool_azuredevops_gitrepositoryconfigs', 'entities', 'json')
+
+
+@migration(20230630000001, name="populated _raw_data_table column for azuredevops git repos")
+def add_raw_data_params_table_to_scope(b: MigrationScriptBuilder):
+    b.execute(f'''UPDATE _tool_azuredevops_gitrepositories SET _raw_data_table = '_raw_azuredevops_scopes' WHERE 1=1''')

--- a/backend/python/plugins/azuredevops/azuredevops/migrations.py
+++ b/backend/python/plugins/azuredevops/azuredevops/migrations.py
@@ -144,7 +144,7 @@ def add_build_id_as_job_primary_key(b: MigrationScriptBuilder):
     # and then add the new composite primary key.
     table = '_tool_azuredevops_jobs'
     b.execute(f'ALTER TABLE {table} MODIFY COLUMN build_id VARCHAR(255)', Dialect.MYSQL)
-    b.execute(f'ALTER TABLE {table} ALTER COLUMN build_id VARCHAR(255)', Dialect.POSTGRESQL)
+    b.execute(f'ALTER TABLE {table} ALTER COLUMN build_id TYPE VARCHAR(255)', Dialect.POSTGRESQL)
     b.execute(f'ALTER TABLE {table} DROP PRIMARY KEY', Dialect.MYSQL)
     b.execute(f'ALTER TABLE {table} DROP CONSTRAINT {table}_pkey', Dialect.POSTGRESQL)
     b.execute(f'ALTER TABLE {table} ADD PRIMARY KEY (id, build_id)')

--- a/backend/python/plugins/azuredevops/azuredevops/models.py
+++ b/backend/python/plugins/azuredevops/azuredevops/models.py
@@ -14,16 +14,17 @@
 # limitations under the License.
 
 import datetime
+import re
 from enum import Enum
 from typing import Optional
-import re
 
 from pydantic import SecretStr
-
-from pydevlake import Field, Connection, ScopeConfig
-from pydevlake.model import ToolModel, ToolScope
+from pydevlake import ScopeConfig, Field
+from pydevlake.model import ToolScope, ToolModel, Connection
 from pydevlake.pipeline_tasks import RefDiffOptions
-from pydevlake.migration import migration, MigrationScriptBuilder, Dialect
+
+# needed to be able to run migrations
+import azuredevops.migrations
 
 
 class AzureDevOpsConnection(Connection):
@@ -128,30 +129,3 @@ class Job(ToolModel, table=True):
     finish_time: Optional[datetime.datetime]
     state: JobState
     result: Optional[JobResult]
-
-
-@migration(20230524181430)
-def add_build_id_as_job_primary_key(b: MigrationScriptBuilder):
-    # NOTE: We can't add a column to the primary key of an existing table
-    # so we have to drop the primary key constraint first,
-    # which is done differently in MySQL and PostgreSQL,
-    # and then add the new composite primary key.
-    table = Job.__tablename__
-    b.execute(f'ALTER TABLE {table} DROP PRIMARY KEY', Dialect.MYSQL)
-    b.execute(f'ALTER TABLE {table} DROP CONSTRAINT {table}_pkey', Dialect.POSTGRESQL)
-    b.execute(f'ALTER TABLE {table} ADD PRIMARY KEY (id, build_id)')
-
-
-@migration(20230606165630)
-def rename_tx_rule_table_to_scope_config(b: MigrationScriptBuilder):
-    b.rename_table('_tool_azuredevops_azuredevopstransformationrules', GitRepositoryConfig.__tablename__)
-
-
-@migration(20230607165630, name="add entities column to gitrepositoryconfig table")
-def add_entities_column_to_scope_config(b: MigrationScriptBuilder):
-    b.add_column(GitRepositoryConfig.__tablename__, 'entities', 'json')
-
-
-@migration(20230630000001, name="populated _raw_data_table column for azuredevops git repos")
-def add_raw_data_params_table_to_scope(b: MigrationScriptBuilder):
-    b.execute(f'''UPDATE {GitRepository.__tablename__} SET _raw_data_table = '_raw_azuredevops_scopes' WHERE 1=1''')

--- a/backend/python/pydevlake/pydevlake/__init__.py
+++ b/backend/python/pydevlake/pydevlake/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Optional
+from typing import Optional
 
 import pytest
 pytest.register_assert_rewrite('pydevlake.testing')

--- a/backend/python/pydevlake/pydevlake/message.py
+++ b/backend/python/pydevlake/pydevlake/message.py
@@ -17,11 +17,11 @@
 from typing import Optional
 
 from pydantic import BaseModel, Field
-import jsonref
 
 from pydevlake.model import ToolScope
 from pydevlake.migration import MigrationScript
 from pydevlake.api import Response
+from pydevlake.model_info import DynamicModelInfo
 
 
 class Message(BaseModel):
@@ -37,27 +37,6 @@ class SubtaskMeta(BaseModel):
     description: str
     domain_types: list[str]
     arguments: list[str] = None
-
-
-class DynamicModelInfo(Message):
-    json_schema: dict
-    table_name: str
-
-    @staticmethod
-    def from_model(model_class):
-        schema = model_class.schema(by_alias=True)
-        if 'definitions' in schema:
-            # Replace $ref with actual schema
-            schema = jsonref.replace_refs(schema, proxies=False)
-            del schema['definitions']
-        # Pydantic forgets to put type in enums
-        for prop in schema['properties'].values():
-            if 'type' not in prop and 'enum' in prop:
-                prop['type'] = 'string'
-        return DynamicModelInfo(
-            json_schema=schema,
-            table_name=model_class.__tablename__
-        )
 
 
 class PluginInfo(Message):
@@ -87,8 +66,8 @@ class PipelineTask(Message):
 
 
 class DynamicDomainScope(Message):
-	type_name: str
-	data: bytes
+    type_name: str
+    data: bytes
 
 
 class PipelineData(Message):

--- a/backend/python/pydevlake/pydevlake/migration.py
+++ b/backend/python/pydevlake/pydevlake/migration.py
@@ -18,33 +18,11 @@ from typing import List, Literal, Optional, Union, Annotated
 from enum import Enum
 from datetime import datetime
 
-import jsonref
 from pydantic import BaseModel, Field
 
+from pydevlake.model_info import DynamicModelInfo
+
 MIGRATION_SCRIPTS = []
-
-# TODO refactor this
-class DynamicModelInfo(BaseModel):
-    class Config:
-        allow_population_by_field_name = True
-    json_schema: dict
-    table_name: str
-
-    @staticmethod
-    def from_model(model_class):
-        schema = model_class.schema(by_alias=True)
-        if 'definitions' in schema:
-            # Replace $ref with actual schema
-            schema = jsonref.replace_refs(schema, proxies=False)
-            del schema['definitions']
-        # Pydantic forgets to put type in enums
-        for prop in schema['properties'].values():
-            if 'type' not in prop and 'enum' in prop:
-                prop['type'] = 'string'
-        return DynamicModelInfo(
-            json_schema=schema,
-            table_name=model_class.__tablename__
-        )
 
 
 class Dialect(Enum):

--- a/backend/python/pydevlake/pydevlake/model.py
+++ b/backend/python/pydevlake/pydevlake/model.py
@@ -87,6 +87,7 @@ class DomainType(Enum):
 class ScopeConfig(ToolTable, Model):
     name: str = Field(default="default")
     domain_types: list[DomainType] = Field(default=list(DomainType), alias="entities")
+    connection_id: Optional[int]
 
 
 class RawModel(SQLModel):
@@ -153,6 +154,7 @@ class DomainModel(NoPKModel):
 class ToolScope(ToolModel):
     id: str = Field(primary_key=True)
     name: str
+    scope_config_id: Optional[int]
 
 
 class DomainScope(DomainModel):

--- a/backend/python/pydevlake/pydevlake/model.py
+++ b/backend/python/pydevlake/pydevlake/model.py
@@ -26,7 +26,8 @@ from pydantic import AnyUrl, SecretStr, validator
 from sqlalchemy import Column, DateTime, Text
 from sqlalchemy.orm import declared_attr
 from sqlalchemy.inspection import inspect
-from sqlmodel import SQLModel, Field
+from sqlmodel import SQLModel
+from pydevlake import Field
 
 
 inflect_engine = inflect.engine()

--- a/backend/python/pydevlake/pydevlake/model_info.py
+++ b/backend/python/pydevlake/pydevlake/model_info.py
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jsonref
+from pydantic import BaseModel
+
+
+class DynamicModelInfo(BaseModel):
+    json_schema: dict
+    table_name: str
+
+    class Config:
+        allow_population_by_field_name = True
+
+    @staticmethod
+    def from_model(model_class):
+        schema = model_class.schema(by_alias=True)
+        if 'definitions' in schema:
+            # Replace $ref with actual schema
+            schema = jsonref.replace_refs(schema, proxies=False)
+            del schema['definitions']
+        # Pydantic forgets to put type in enums
+        for prop in schema['properties'].values():
+            if 'type' not in prop and 'enum' in prop:
+                prop['type'] = 'string'
+        return DynamicModelInfo(
+            json_schema=schema,
+            table_name=model_class.__tablename__
+        )

--- a/backend/python/pydevlake/pydevlake/plugin.py
+++ b/backend/python/pydevlake/pydevlake/plugin.py
@@ -22,6 +22,7 @@ import sys
 import fire
 
 import pydevlake.message as msg
+import pydevlake.model_info
 from pydevlake.subtasks import Subtask
 from pydevlake.logger import logger
 from pydevlake.ipc import PluginCommands
@@ -233,10 +234,10 @@ class Plugin(ABC):
             description=self.description,
             plugin_path=self._plugin_path(),
             extension="datasource",
-            connection_model_info=msg.DynamicModelInfo.from_model(self.connection_type),
-            scope_model_info=msg.DynamicModelInfo.from_model(self.tool_scope_type),
-            scope_config_model_info=msg.DynamicModelInfo.from_model(self.scope_config_type),
-            tool_model_infos=[msg.DynamicModelInfo.from_model(stream.tool_model) for stream in self._streams.values()],
+            connection_model_info=pydevlake.model_info.DynamicModelInfo.from_model(self.connection_type),
+            scope_model_info=pydevlake.model_info.DynamicModelInfo.from_model(self.tool_scope_type),
+            scope_config_model_info=pydevlake.model_info.DynamicModelInfo.from_model(self.scope_config_type),
+            tool_model_infos=[pydevlake.model_info.DynamicModelInfo.from_model(stream.tool_model) for stream in self._streams.values()],
             subtask_metas=subtask_metas,
             migration_scripts=MIGRATION_SCRIPTS
         )

--- a/backend/python/test/fakeplugin/fakeplugin/migrations.py
+++ b/backend/python/test/fakeplugin/fakeplugin/migrations.py
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from fakeplugin.models import FakeConnection, FakePipeline, FakeProject, FakeScopeConfig
+from pydevlake.migration import migration, MigrationScriptBuilder, Dialect
+
+
+@migration(20230530000001, name="init schemas")
+def init_schemas(b: MigrationScriptBuilder):
+    b.create_tables(FakeConnection, FakePipeline, FakeProject, FakeScopeConfig)
+
+
+# test migration
+@migration(20230630000001, name="populated _raw_data_table column for fakeproject")
+def add_raw_data_params_table_to_scope(b: MigrationScriptBuilder):
+    b.execute(f'UPDATE {FakeProject.__tablename__} SET _raw_data_table = "_raw_fakeproject_scopes" WHERE 1=1', Dialect.MYSQL) #mysql only
+    b.execute(f'''UPDATE {FakeProject.__tablename__} SET _raw_data_table = '_raw_fakeproject_scopes' WHERE 1=1''', Dialect.POSTGRESQL) #mysql and postgres

--- a/backend/python/test/fakeplugin/fakeplugin/models.py
+++ b/backend/python/test/fakeplugin/fakeplugin/models.py
@@ -1,0 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pydantic import SecretStr
+
+from pydevlake import ScopeConfig, ToolScope, Connection, ToolModel, Field
+
+
+class FakeConnection(Connection):
+    token: SecretStr
+
+
+class FakeProject(ToolScope, table=True):
+    url: str
+
+
+class FakeScopeConfig(ScopeConfig):
+    env: str
+
+
+class FakePipeline(ToolModel, table=True):
+    class State(Enum):
+        PENDING = "pending"
+        RUNNING = "running"
+        FAILURE = "failure"
+        SUCCESS = "success"
+
+    id: str = Field(primary_key=True)
+    started_at: Optional[datetime]
+    finished_at: Optional[datetime]
+    state: State

--- a/backend/server/services/remote/init.go
+++ b/backend/server/services/remote/init.go
@@ -43,10 +43,6 @@ func NewRemotePlugin(info *models.PluginInfo) (models.RemotePlugin, errors.Error
 	if err != nil {
 		return nil, err
 	}
-	err = plugin.RunAutoMigrations()
-	if err != nil {
-		return nil, err
-	}
 	err = pluginCore.RegisterPlugin(info.Name, plugin)
 	if err != nil {
 		return nil, err

--- a/backend/server/services/remote/models/conversion.go
+++ b/backend/server/services/remote/models/conversion.go
@@ -33,7 +33,11 @@ import (
 )
 
 func LoadTableModel(tableName string, schema utils.JsonObject, parentModel any) (models.DynamicTabler, errors.Error) {
-	structType, err := GenerateStructType(schema, reflect.TypeOf(parentModel))
+	var baseType reflect.Type = nil
+	if parentModel != nil {
+		baseType = reflect.TypeOf(parentModel)
+	}
+	structType, err := GenerateStructType(schema, baseType)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +64,7 @@ func GenerateStructType(schema utils.JsonObject, baseType reflect.Type) (reflect
 		structFields = append(structFields, anonymousField)
 	}
 	for k, v := range props {
-		if isBaseTypeField(k, baseType) {
+		if baseType != nil && isBaseTypeField(k, baseType) {
 			continue
 		}
 		spec := v.(utils.JsonObject)

--- a/backend/server/services/remote/models/conversion.go
+++ b/backend/server/services/remote/models/conversion.go
@@ -140,6 +140,7 @@ var (
 	stringType  = reflect.TypeOf("")
 	timeType    = reflect.TypeOf(time.Time{})
 	jsonMapType = reflect.TypeOf(datatypes.JSONMap{})
+	jsonType    = reflect.TypeOf(datatypes.JSON{})
 )
 
 func generateStructField(name string, schema utils.JsonObject, required bool) (*reflect.StructField, errors.Error) {
@@ -160,11 +161,11 @@ func generateStructField(name string, schema utils.JsonObject, required bool) (*
 }
 
 func getGoType(schema utils.JsonObject, required bool) (reflect.Type, errors.Error) {
-	jsonType, ok := schema["type"].(string)
+	rawType, ok := schema["type"].(string)
 	if !ok {
 		return nil, errors.BadInput.New("\"type\" property must be a string")
 	}
-	switch jsonType {
+	switch rawType {
 	//TODO: support more types
 	case "integer":
 		return int64Type, nil
@@ -183,10 +184,12 @@ func getGoType(schema utils.JsonObject, required bool) (reflect.Type, errors.Err
 		} else {
 			return stringType, nil
 		}
+	case "array":
+		return jsonType, nil
 	case "object":
 		return jsonMapType, nil
 	default:
-		return nil, errors.BadInput.New(fmt.Sprintf("Unsupported type %s", jsonType))
+		return nil, errors.BadInput.New(fmt.Sprintf("Unsupported type %s", rawType))
 	}
 }
 

--- a/backend/server/services/remote/models/plugin_remote.go
+++ b/backend/server/services/remote/models/plugin_remote.go
@@ -18,7 +18,6 @@ limitations under the License.
 package models
 
 import (
-	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 )
 
@@ -31,5 +30,4 @@ type RemotePlugin interface {
 	plugin.PluginModel
 	plugin.PluginMigration
 	plugin.PluginSource
-	RunAutoMigrations() errors.Error
 }

--- a/backend/server/services/remote/plugin/plugin_impl.go
+++ b/backend/server/services/remote/plugin/plugin_impl.go
@@ -230,36 +230,6 @@ func (p *remotePluginImpl) ApiResources() map[string]map[string]plugin.ApiResour
 	return p.resources
 }
 
-func (p *remotePluginImpl) RunAutoMigrations() errors.Error {
-	err := p.createTable(p.connectionTabler.New())
-	if err != nil {
-		return err
-	}
-	err = p.createTable(p.scopeTabler.New())
-	if err != nil {
-		return err
-	}
-	err = p.createTable(p.scopeConfigTabler.New())
-	if err != nil {
-		return err
-	}
-	for _, toolModelTabler := range p.toolModelTablers {
-		err = p.createTable(toolModelTabler.New())
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (p *remotePluginImpl) createTable(tbl coreModels.DynamicTabler) errors.Error {
-	db := basicRes.GetDal()
-	if db.HasTable(tbl.TableName()) {
-		return nil
-	}
-	return api.CallDB(db.AutoMigrate, tbl)
-}
-
 func (p *remotePluginImpl) OpenApiSpec() string {
 	return p.openApiSpec
 }


### PR DESCRIPTION
### Summary
What does this PR do?
1. RunAutoMigration removed - all migrations for tool tables are now manual
2. AzureDevops tool tables now created via the new CreateTable op code. Migration version set to be older than the existing Azure migrations. Framework code enhanced to support ignoring such migrations (when the newer versions have already been run)

### Does this close any open issues?
Closes #5689 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
