### PR TITLE
fix: zentao status/type mapping

### DIFF
--- a/backend/plugins/zentao/tasks/bug_convertor.go
+++ b/backend/plugins/zentao/tasks/bug_convertor.go
@@ -79,7 +79,7 @@ func ConvertBug(taskCtx plugin.SubTaskContext) errors.Error {
 				IssueKey:        strconv.FormatInt(toolEntity.ID, 10),
 				Title:           toolEntity.Title,
 				Type:            ticket.BUG,
-				OriginalType:    toolEntity.Type,
+				OriginalType:    "bug",
 				OriginalStatus:  toolEntity.Status,
 				ResolutionDate:  toolEntity.ClosedDate.ToNullableTime(),
 				CreatedDate:     toolEntity.OpenedDate.ToNullableTime(),

--- a/backend/plugins/zentao/tasks/bug_extractor.go
+++ b/backend/plugins/zentao/tasks/bug_extractor.go
@@ -126,7 +126,11 @@ func ExtractBug(taskCtx plugin.SubTaskContext) errors.Error {
 				ProductStatus:  res.ProductStatus,
 				Url:            row.Url,
 			}
-
+			switch bug.Status {
+			case "active", "closed", "resolved":
+			default:
+				bug.Status = "active"
+			}
 			bug.StdType = stdTypeMappings[bug.Type]
 			if bug.StdType == "" {
 				bug.StdType = ticket.BUG

--- a/backend/plugins/zentao/tasks/story_convertor.go
+++ b/backend/plugins/zentao/tasks/story_convertor.go
@@ -78,7 +78,7 @@ func ConvertStory(taskCtx plugin.SubTaskContext) errors.Error {
 				IssueKey:                strconv.FormatInt(toolEntity.ID, 10),
 				Title:                   toolEntity.Title,
 				Type:                    ticket.REQUIREMENT,
-				OriginalType:            toolEntity.Type + "." + toolEntity.Category,
+				OriginalType:            toolEntity.Type,
 				OriginalStatus:          toolEntity.Status,
 				ResolutionDate:          toolEntity.ClosedDate.ToNullableTime(),
 				CreatedDate:             toolEntity.OpenedDate.ToNullableTime(),

--- a/backend/plugins/zentao/tasks/story_convertor.go
+++ b/backend/plugins/zentao/tasks/story_convertor.go
@@ -78,7 +78,7 @@ func ConvertStory(taskCtx plugin.SubTaskContext) errors.Error {
 				IssueKey:                strconv.FormatInt(toolEntity.ID, 10),
 				Title:                   toolEntity.Title,
 				Type:                    ticket.REQUIREMENT,
-				OriginalType:            toolEntity.Type,
+				OriginalType:            "story",
 				OriginalStatus:          toolEntity.Status,
 				ResolutionDate:          toolEntity.ClosedDate.ToNullableTime(),
 				CreatedDate:             toolEntity.OpenedDate.ToNullableTime(),

--- a/backend/plugins/zentao/tasks/story_extractor.go
+++ b/backend/plugins/zentao/tasks/story_extractor.go
@@ -128,13 +128,17 @@ func ExtractStory(taskCtx plugin.SubTaskContext) errors.Error {
 				Url:              row.Url,
 			}
 
-			story.StdType = stdTypeMappings[story.Type+"."+story.Category]
+			story.StdType = stdTypeMappings[story.Type]
 			if story.StdType == "" {
 				story.StdType = ticket.REQUIREMENT
 			}
-
+			switch story.Status {
+			case "active", "closed", "draft", "changing", "reviewing":
+			default:
+				story.Status = "active"
+			}
 			if len(statusMappings) != 0 {
-				story.StdStatus = statusMappings[story.Status+"-"+story.Stage]
+				story.StdStatus = statusMappings[story.Status]
 			} else {
 				story.StdStatus = ticket.GetStatus(&ticket.StatusRule{
 					Done:    []string{"closed"},

--- a/backend/plugins/zentao/tasks/task_convertor.go
+++ b/backend/plugins/zentao/tasks/task_convertor.go
@@ -77,7 +77,7 @@ func ConvertTask(taskCtx plugin.SubTaskContext) errors.Error {
 				Title:                   toolEntity.Name,
 				Description:             toolEntity.Description,
 				Type:                    ticket.TASK,
-				OriginalType:            toolEntity.Type,
+				OriginalType:            "task",
 				OriginalStatus:          toolEntity.Status,
 				ResolutionDate:          toolEntity.ClosedDate.ToNullableTime(),
 				CreatedDate:             toolEntity.OpenedDate.ToNullableTime(),

--- a/backend/plugins/zentao/tasks/task_convertor.go
+++ b/backend/plugins/zentao/tasks/task_convertor.go
@@ -77,7 +77,7 @@ func ConvertTask(taskCtx plugin.SubTaskContext) errors.Error {
 				Title:                   toolEntity.Name,
 				Description:             toolEntity.Description,
 				Type:                    ticket.TASK,
-				OriginalType:            toolEntity.Type + "." + toolEntity.Mode,
+				OriginalType:            toolEntity.Type,
 				OriginalStatus:          toolEntity.Status,
 				ResolutionDate:          toolEntity.ClosedDate.ToNullableTime(),
 				CreatedDate:             toolEntity.OpenedDate.ToNullableTime(),


### PR DESCRIPTION
### Summary
- set oriaginal_status of stories to `active` for any status other than `active`, `closed`, `draft`, `changing`, `reviewing`
- set oriaginal_status of bugs to `active` for any status other than `active`, `closed`, `resolved`
- use original_type for type mapping
- use original_status for status mapping
- set the original_type to `bug`, `story`, and `task` according to the issue type
### Does this close any open issues?
Closes #5756 #5755 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/8455907/f84ff48e-1e90-422e-b028-e64d26d24287)

