### PR TITLE
fix: the error caused by empty response body

### DIFF
--- a/backend/helpers/pluginhelper/api/api_client.go
+++ b/backend/helpers/pluginhelper/api/api_client.go
@@ -43,7 +43,10 @@ import (
 )
 
 // ErrIgnoreAndContinue is a error which should be ignored
-var ErrIgnoreAndContinue = errors.Default.New("ignore and continue")
+var (
+	ErrIgnoreAndContinue = errors.Default.New("ignore and continue")
+	ErrEmptyResponse     = errors.Default.New("empty response")
+)
 
 // ApiClient is designed for simple api requests
 type ApiClient struct {
@@ -372,6 +375,9 @@ func UnmarshalResponse(res *http.Response, v interface{}) errors.Error {
 	resBody, err := io.ReadAll(res.Body)
 	if err != nil {
 		return errors.Default.Wrap(err, fmt.Sprintf("error reading response from %s", res.Request.URL.String()))
+	}
+	if len(resBody) == 0 {
+		return ErrEmptyResponse
 	}
 	err = errors.Convert(json.Unmarshal(resBody, &v))
 	if err != nil {

--- a/backend/plugins/zentao/tasks/account_collector.go
+++ b/backend/plugins/zentao/tasks/account_collector.go
@@ -55,6 +55,9 @@ func CollectAccount(taskCtx plugin.SubTaskContext) errors.Error {
 				Users []json.RawMessage `json:"users"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
 			}

--- a/backend/plugins/zentao/tasks/bug_collector.go
+++ b/backend/plugins/zentao/tasks/bug_collector.go
@@ -61,6 +61,9 @@ func CollectBug(taskCtx plugin.SubTaskContext) errors.Error {
 				Bugs []json.RawMessage `json:"bugs"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
 			}

--- a/backend/plugins/zentao/tasks/bug_commits_collector.go
+++ b/backend/plugins/zentao/tasks/bug_commits_collector.go
@@ -101,6 +101,9 @@ func CollectBugCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				Actions []json.RawMessage `json:"actions"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/backend/plugins/zentao/tasks/bug_repo_commits_collector.go
+++ b/backend/plugins/zentao/tasks/bug_repo_commits_collector.go
@@ -81,6 +81,9 @@ func CollectBugRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 			if err != nil {
 				return nil, err
 			}
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			byteData := []byte(result.Data)
 			return []json.RawMessage{byteData}, nil
 

--- a/backend/plugins/zentao/tasks/department_collector.go
+++ b/backend/plugins/zentao/tasks/department_collector.go
@@ -44,6 +44,9 @@ func CollectDepartment(taskCtx plugin.SubTaskContext) errors.Error {
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
 			var data []json.RawMessage
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao departments collector")
 			}

--- a/backend/plugins/zentao/tasks/execution_collector.go
+++ b/backend/plugins/zentao/tasks/execution_collector.go
@@ -56,6 +56,9 @@ func CollectExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
 			var data json.RawMessage
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/backend/plugins/zentao/tasks/execution_story_collector.go
+++ b/backend/plugins/zentao/tasks/execution_story_collector.go
@@ -59,6 +59,9 @@ func CollectExecutionStory(taskCtx plugin.SubTaskContext) errors.Error {
 				Story []json.RawMessage `json:"stories"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/backend/plugins/zentao/tasks/execution_summary_collector.go
+++ b/backend/plugins/zentao/tasks/execution_summary_collector.go
@@ -53,6 +53,9 @@ func CollectExecutionSummary(taskCtx plugin.SubTaskContext) errors.Error {
 				Executions []json.RawMessage `json:"executions"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
 			}

--- a/backend/plugins/zentao/tasks/story_collector.go
+++ b/backend/plugins/zentao/tasks/story_collector.go
@@ -87,6 +87,9 @@ func CollectStory(taskCtx plugin.SubTaskContext) errors.Error {
 				Story []json.RawMessage `json:"stories"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
 			}

--- a/backend/plugins/zentao/tasks/story_commits_collector.go
+++ b/backend/plugins/zentao/tasks/story_commits_collector.go
@@ -99,6 +99,9 @@ func CollectStoryCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				Actions []json.RawMessage `json:"actions"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/backend/plugins/zentao/tasks/story_repo_commits_collector.go
+++ b/backend/plugins/zentao/tasks/story_repo_commits_collector.go
@@ -78,6 +78,9 @@ func CollectStoryRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
 			var result RepoRevisionResponse
 			err := api.UnmarshalResponse(res, &result)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/backend/plugins/zentao/tasks/task_collector.go
+++ b/backend/plugins/zentao/tasks/task_collector.go
@@ -75,6 +75,9 @@ func CollectTask(taskCtx plugin.SubTaskContext) errors.Error {
 				Task []json.RawMessage `json:"tasks"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, errors.Default.Wrap(err, "error reading endpoint response by Zentao bug collector")
 			}

--- a/backend/plugins/zentao/tasks/task_commits_collector.go
+++ b/backend/plugins/zentao/tasks/task_commits_collector.go
@@ -98,6 +98,9 @@ func CollectTaskCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				Actions []json.RawMessage `json:"actions"`
 			}
 			err := api.UnmarshalResponse(res, &data)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}

--- a/backend/plugins/zentao/tasks/task_repo_commits_collector.go
+++ b/backend/plugins/zentao/tasks/task_repo_commits_collector.go
@@ -78,6 +78,9 @@ func CollectTaskRepoCommits(taskCtx plugin.SubTaskContext) errors.Error {
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
 			var result RepoRevisionResponse
 			err := api.UnmarshalResponse(res, &result)
+			if errors.Is(err, api.ErrEmptyResponse) {
+				return nil, nil
+			}
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
### Summary
- fix https://github.com/apache/incubator-devlake/issues/5758
The error is caused by empty response body returned from zentao. In this PR, we introduce a new error `ErrEmptyResponse`, the `api.UnmarshalResponse` will return this error when the response body is empty, therefore, the collector gets the chance to check the error type and handle it properly

### Does this close any open issues?
Closes #5758 

