### PR TITLE
Refactor: Database uses json type but not Golang code

### DIFF
--- a/backend/core/models/migrationscripts/20230728_tasks_use_json.go
+++ b/backend/core/models/migrationscripts/20230728_tasks_use_json.go
@@ -54,7 +54,6 @@ func (script *tasksUsesJSON) Up(basicRes context.BasicRes) errors.Error {
 			if len(src.Subtasks) == 0 {
 				return nil, nil
 			}
-			println("src.Subtask", string(src.Subtasks))
 			errors.Must(json.Unmarshal(src.Subtasks, &dst.Subtasks))
 			return dst, nil
 		},

--- a/backend/core/models/migrationscripts/20230728_tasks_use_json.go
+++ b/backend/core/models/migrationscripts/20230728_tasks_use_json.go
@@ -1,0 +1,70 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"encoding/json"
+
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+)
+
+var _ plugin.MigrationScript = (*tasksUsesJSON)(nil)
+
+type tasksUsesJSON struct{}
+
+type srcTaskSubtaskJSON20230731 struct {
+	archived.Model
+	Subtasks json.RawMessage
+}
+
+type dstTaskSubtaskJSON20230731 struct {
+	archived.Model
+	Subtasks []string `gorm:"type:json;serializer:json"`
+}
+
+func (script *tasksUsesJSON) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.TransformColumns(
+		basicRes,
+		script,
+		"_devlake_tasks",
+		[]string{"subtasks"},
+		func(src *srcTaskSubtaskJSON20230731) (*dstTaskSubtaskJSON20230731, errors.Error) {
+			dst := &dstTaskSubtaskJSON20230731{
+				Model: src.Model,
+			}
+			if len(src.Subtasks) == 0 {
+				return nil, nil
+			}
+			println("src.Subtask", string(src.Subtasks))
+			errors.Must(json.Unmarshal(src.Subtasks, &dst.Subtasks))
+			return dst, nil
+		},
+	)
+}
+
+func (*tasksUsesJSON) Version() uint64 {
+	return 20230728162121
+}
+
+func (*tasksUsesJSON) Name() string {
+	return "tasks uses json"
+}

--- a/backend/core/models/migrationscripts/register.go
+++ b/backend/core/models/migrationscripts/register.go
@@ -87,5 +87,6 @@ func All() []plugin.MigrationScript {
 		new(renameFinishedCommitsDiffs),
 		new(addUpdatedDateToIssueComments),
 		new(addIssueRelationship),
+		new(tasksUsesJSON),
 	}
 }

--- a/backend/core/models/task.go
+++ b/backend/core/models/task.go
@@ -18,12 +18,10 @@ limitations under the License.
 package models
 
 import (
-	"encoding/json"
-	"github.com/apache/incubator-devlake/core/errors"
+	"time"
+
 	"github.com/apache/incubator-devlake/core/models/common"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
-	"gorm.io/datatypes"
-	"time"
 )
 
 const (
@@ -49,14 +47,14 @@ type TaskProgressDetail struct {
 
 type Task struct {
 	common.Model
-	Plugin         string              `json:"plugin" gorm:"index"`
-	Subtasks       datatypes.JSON      `json:"subtasks"`
-	Options        string              `json:"options" gorm:"serializer:encdec"`
-	Status         string              `json:"status"`
-	Message        string              `json:"message"`
-	ErrorName      string              `json:"errorName"`
-	Progress       float32             `json:"progress"`
-	ProgressDetail *TaskProgressDetail `json:"progressDetail" gorm:"-"`
+	Plugin         string                 `json:"plugin" gorm:"index"`
+	Subtasks       []string               `json:"subtasks" gorm:"type:json;serializer:json"`
+	Options        map[string]interface{} `json:"options" gorm:"type:json;serializer:encdec"`
+	Status         string                 `json:"status"`
+	Message        string                 `json:"message"`
+	ErrorName      string                 `json:"errorName"`
+	Progress       float32                `json:"progress"`
+	ProgressDetail *TaskProgressDetail    `json:"progressDetail" gorm:"-"`
 
 	FailedSubTask string     `json:"failedSubTask"`
 	PipelineId    uint64     `json:"pipelineId" gorm:"index"`
@@ -92,16 +90,4 @@ func (Task) TableName() string {
 
 func (Subtask) TableName() string {
 	return "_devlake_subtasks"
-}
-
-func (task *Task) GetSubTasks() ([]string, errors.Error) {
-	var subtasks []string
-	err := errors.Convert(json.Unmarshal(task.Subtasks, &subtasks))
-	return subtasks, err
-}
-
-func (task *Task) GetOptions() (map[string]interface{}, errors.Error) {
-	var options map[string]interface{}
-	err := errors.Convert(json.Unmarshal([]byte(task.Options), &options))
-	return options, err
 }

--- a/backend/core/models/task.go
+++ b/backend/core/models/task.go
@@ -49,7 +49,7 @@ type Task struct {
 	common.Model
 	Plugin         string                 `json:"plugin" gorm:"index"`
 	Subtasks       []string               `json:"subtasks" gorm:"type:json;serializer:json"`
-	Options        map[string]interface{} `json:"options" gorm:"type:json;serializer:encdec"`
+	Options        map[string]interface{} `json:"options" gorm:"serializer:encdec"`
 	Status         string                 `json:"status"`
 	Message        string                 `json:"message"`
 	ErrorName      string                 `json:"errorName"`

--- a/backend/core/runner/directrun.go
+++ b/backend/core/runner/directrun.go
@@ -19,7 +19,6 @@ package runner
 
 import (
 	"context"
-	"encoding/json"
 	goerror "errors"
 	"fmt"
 	"io"
@@ -80,18 +79,10 @@ func DirectRun(cmd *cobra.Command, args []string, pluginTask plugin.PluginTask, 
 		panic(err)
 	}
 	ctx := createContext()
-	optionsJson, err := json.Marshal(options)
-	if err != nil {
-		panic(err)
-	}
-	subtasksJson, err := json.Marshal(tasks)
-	if err != nil {
-		panic(err)
-	}
 	task := &models.Task{
 		Plugin:   cmd.Use,
-		Options:  string(optionsJson),
-		Subtasks: subtasksJson,
+		Options:  options,
+		Subtasks: tasks,
 	}
 	err = RunPluginSubTasks(
 		ctx,

--- a/backend/core/runner/run_task.go
+++ b/backend/core/runner/run_task.go
@@ -189,14 +189,10 @@ func RunPluginSubTasks(
 	*/
 
 	// user specifies what subtasks to run
-	subtaskNames, err := task.GetSubTasks()
-	if err != nil {
-		return err
-	}
-	if len(subtaskNames) != 0 {
+	if len(task.Subtasks) != 0 {
 		// decode user specified subtasks
 		var specifiedTasks []string
-		err := api.Decode(subtaskNames, &specifiedTasks, nil)
+		err := api.Decode(task.Subtasks, &specifiedTasks, nil)
 		if err != nil {
 			return errors.Default.Wrap(err, "subtasks could not be decoded")
 		}
@@ -235,10 +231,7 @@ func RunPluginSubTasks(
 	if closeablePlugin, ok := pluginTask.(plugin.CloseablePluginTask); ok {
 		defer closeablePlugin.Close(taskCtx)
 	}
-	options, err := task.GetOptions()
-	if err != nil {
-		return err
-	}
+	options := task.Options
 	taskData, err := pluginTask.PrepareTaskData(taskCtx, options)
 	if err != nil {
 		return errors.Default.Wrap(err, fmt.Sprintf("error preparing task data for %s", task.Plugin))

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/incubator-devlake
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.242

--- a/backend/helpers/migrationhelper/migrationhelper.go
+++ b/backend/helpers/migrationhelper/migrationhelper.go
@@ -163,9 +163,11 @@ func TransformColumns[S any, D any](
 				}
 
 				dst, err := transform(src)
-
 				if err != nil {
 					return errors.Default.Wrap(err, fmt.Sprintf("failed to update row %v", src))
+				}
+				if dst == nil {
+					continue
 				}
 				err = batch.Add(dst)
 				if err != nil {

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -508,19 +508,11 @@ func RerunPipeline(pipelineId uint64, task *models.Task) (tasks []*models.Task, 
 			return nil, err
 		}
 		// create new task
-		subtasks, err := t.GetSubTasks()
-		if err != nil {
-			return nil, err
-		}
-		options, err := t.GetOptions()
-		if err != nil {
-			return nil, err
-		}
 		rerunTask, err := CreateTask(&models.NewTask{
 			PipelineTask: &plugin.PipelineTask{
 				Plugin:   t.Plugin,
-				Subtasks: subtasks,
-				Options:  options,
+				Subtasks: t.Subtasks,
+				Options:  t.Options,
 			},
 			PipelineId:  t.PipelineId,
 			PipelineRow: t.PipelineRow,

--- a/backend/test/helper/client.go
+++ b/backend/test/helper/client.go
@@ -229,18 +229,10 @@ func (d *DevlakeClient) RunPlugin(ctx context.Context, pluginName string, plugin
 	if len(subtaskNames) == 0 {
 		subtaskNames = GetSubtaskNames(pluginTask.SubTaskMetas()...)
 	}
-	optionsJson, err := json.Marshal(options)
-	if err != nil {
-		return errors.Convert(err)
-	}
-	subtasksJson, err := json.Marshal(subtaskNames)
-	if err != nil {
-		return errors.Convert(err)
-	}
 	task := &models.Task{
 		Plugin:   pluginName,
-		Options:  string(optionsJson),
-		Subtasks: subtasksJson,
+		Options:  options,
+		Subtasks: subtaskNames,
 	}
 	return runner.RunPluginSubTasks(
 		ctx,

--- a/config-ui/src/pages/pipeline/components/task/index.tsx
+++ b/config-ui/src/pages/pipeline/components/task/index.tsx
@@ -39,7 +39,7 @@ export const PipelineTask = ({ task }: Props) => {
 
   const [icon, name] = useMemo(() => {
     const config = getPluginConfig(task.plugin);
-    const options = JSON.parse(task.options);
+    const options = task.options;
 
     let name = config.name;
 

--- a/config-ui/src/pages/pipeline/types.ts
+++ b/config-ui/src/pages/pipeline/types.ts
@@ -47,7 +47,7 @@ export type TaskType = {
   pipelineCol: number;
   beganAt: string | null;
   finishedAt: string | null;
-  options: string;
+  options: any;
   message: string;
   progressDetail?: {
     finishedSubTasks: number;

--- a/config-ui/src/pages/project/home/index.tsx
+++ b/config-ui/src/pages/project/home/index.tsx
@@ -51,9 +51,9 @@ export const ProjectHomePage = () => {
       (data?.projects ?? []).map((it) => {
         return {
           name: it.name,
-          connections: it.blueprint.settings.connections,
-          isManual: it.blueprint.isManual,
-          cronConfig: it.blueprint.cronConfig,
+          connections: it.blueprint?.settings.connections,
+          isManual: it.blueprint?.isManual,
+          cronConfig: it.blueprint?.cronConfig,
           createdAt: it.createdAt,
           lastRunCompletedAt: it.lastPipeline?.finishedAt,
           lastRunStatus: it.lastPipeline?.status,
@@ -137,12 +137,12 @@ export const ProjectHomePage = () => {
             dataIndex: 'connections',
             key: 'connections',
             render: (val: BlueprintType['settings']['connections']) =>
-              !val.length
+              !val || !val.length
                 ? 'N/A'
                 : val
                     .map((it) => {
                       const cs = onGet(`${it.plugin}-${it.connectionId}`);
-                      return cs.name;
+                      return cs?.name;
                     })
                     .join(', '),
           },


### PR DESCRIPTION
### Summary
Currently, we tend to use `json` in the golang sourcecode while `longtext` or `longblob` in the database
![image](https://github.com/apache/incubator-devlake/assets/61080/e299a574-433e-4820-aafc-6e02f6742244)
![image](https://github.com/apache/incubator-devlake/assets/61080/177a17c8-bf0e-4b39-b83e-c3a4491460c3)
which introduces many hardcoded logic for conversion
![image](https://github.com/apache/incubator-devlake/assets/61080/132488a6-51cc-440a-9c2e-db3b1bf70527)
![image](https://github.com/apache/incubator-devlake/assets/61080/8e4cf610-64ab-4232-8894-0a98b5f3021b)

**IT IS UGLY**

By reversing the pattern, we can simplify our code base and make it easier to understand:

```golang
type Task struct {
	...
	Subtasks       []string               `json:"subtasks" gorm:"type:json;serializer:json"`  // use json in database
	Options        map[string]interface{} `json:"options" gorm:"serializer:encdec"`  // encrypted field stay as text type
	...
}
```
![image](https://github.com/apache/incubator-devlake/assets/61080/7816b969-ce1a-4770-9cf5-601566eaf8d6)
This brings the following **merits**:

1. Our Golang is more cleaner, easy to understand and maintain
2. We can use `json` query function provided by the dbs for debugging if needed to


This is the PoC and very beginning of the refactor, please feel free to comment and share your thoughts.

@keon94 @mindlesscloud @abeizn @d4x1 @likyh @chenggui53 

Thanks.



### Does this close any open issues?
Part of #3729 

### Screenshots
mysql
<img width="839" alt="Snipaste_2023-07-28_15-35-37" src="https://github.com/apache/incubator-devlake/assets/61080/4c4d9c27-e2b1-40f6-9179-41a7c234ebb8">
**postgres**
before migration
<img width="658" alt="Snipaste_2023-08-02_11-11-43" src="https://github.com/apache/incubator-devlake/assets/61080/c7f59d4e-91ec-42eb-84d9-3f14c2ce4996">
after migration
<img width="679" alt="Snipaste_2023-08-02_11-12-52" src="https://github.com/apache/incubator-devlake/assets/61080/68550247-2207-4ff6-9538-af403c3993b2">
<img width="668" alt="Snipaste_2023-08-02_11-13-13" src="https://github.com/apache/incubator-devlake/assets/61080/501d14f1-75e4-4336-b52d-133ba5ba6077">

