### PR TITLE
fix: Support explicit auto-increment fields in Python

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/migrations.py
+++ b/backend/python/plugins/azuredevops/azuredevops/migrations.py
@@ -94,7 +94,7 @@ def init_schemas(b: MigrationScriptBuilder):
             PartiallySucceeded = "partiallySucceeded"
             Succeeded = "succeeded"
 
-        id: int = Field(primary_key=True)
+        id: int = Field(primary_key=True, auto_increment=False)
         name: str
         start_time: Optional[datetime.datetime]
         finish_time: Optional[datetime.datetime]

--- a/backend/python/pydevlake/pydevlake/__init__.py
+++ b/backend/python/pydevlake/pydevlake/__init__.py
@@ -16,20 +16,24 @@
 from typing import Optional
 
 import pytest
+
 pytest.register_assert_rewrite('pydevlake.testing')
 
 from sqlmodel import Field as _Field
 
 
-def Field(*args, primary_key: bool=False, source: Optional[str]=None, **kwargs):
+def Field(*args, primary_key: bool = False, auto_increment: Optional[bool] = None, source: Optional[str] = None,
+          **kwargs):
     """
     A wrapper around sqlmodel.Field that adds a source parameter.
     """
     schema_extra = kwargs.get('schema_extra', {})
-    if source:
+    if source is not None:
         schema_extra['source'] = source
     if primary_key:
         schema_extra['primaryKey'] = True
+    if auto_increment is not None:
+        schema_extra['autoIncrement'] = auto_increment
     return _Field(*args, **kwargs, primary_key=primary_key, schema_extra=schema_extra)
 
 
@@ -42,6 +46,8 @@ from .context import Context
 
 # the debugger hangs on startup during plugin registration (reason unknown), hence this workaround
 import sys
+
 if not sys.argv.__contains__('startup'):
     from pydevlake.helpers import debugger
+
     debugger.init()

--- a/backend/python/pydevlake/pydevlake/model.py
+++ b/backend/python/pydevlake/pydevlake/model.py
@@ -128,7 +128,7 @@ class NoPKModel(RawDataOrigin):
 
 
 class ToolModel(ToolTable, NoPKModel):
-    connection_id: Optional[int] = Field(primary_key=True)
+    connection_id: Optional[int] = Field(primary_key=True, auto_increment=False)
 
     def domain_id(self):
         """

--- a/backend/server/services/remote/models/conversion.go
+++ b/backend/server/services/remote/models/conversion.go
@@ -212,6 +212,10 @@ func getGormTag(schema utils.JsonObject, goType reflect.Type) string {
 	if err == nil && primaryKey {
 		gormTags = append(gormTags, "primaryKey")
 	}
+	autoIncrement, err := utils.GetProperty[bool](schema, "autoIncrement")
+	if err == nil {
+		gormTags = append(gormTags, fmt.Sprintf("autoIncrement:%v", autoIncrement))
+	}
 	if goType == stringType {
 		maxLength, err := utils.GetProperty[float64](schema, "maxLength")
 		maxLengthInt := int(maxLength)

--- a/backend/server/services/remote/models/migration.go
+++ b/backend/server/services/remote/models/migration.go
@@ -22,6 +22,7 @@ import (
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models"
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -121,6 +122,9 @@ func (o CreateTableOperation) Execute(basicRes context.BasicRes) errors.Error {
 	if err != nil {
 		return err
 	}
+	// uncomment to debug "modelDump" as needed
+	modelDump := models.DumpInfo(model.New())
+	_ = modelDump
 	err = api.CallDB(db.AutoMigrate, model.New())
 	if err != nil {
 		return err


### PR DESCRIPTION
### Summary
What does this PR do?
Adds support for user-defined auto-increment fields. Need arose from a bug caused by having composite keys with default auto-increment set to on. See https://gorm.io/docs/composite_primary_key.html.

The Builds model of AzureDevops now defines auto-inc to be False for ID. ConnectionID in all tool structs will have it set to false as well. This was the error we were getting earlier:

![image](https://github.com/apache/incubator-devlake/assets/25063936/6448c572-17c2-41bd-8583-bef49bcbcee0)



### Does this close any open issues?
Closes n/a
Caused by #5746 

### Screenshots

![image](https://github.com/apache/incubator-devlake/assets/25063936/d1a896e8-bdfb-4b9c-ad5d-930bcf2250c3)


### Other Information
Any other information that is important to this PR.
