### PR TITLE
cherry-pick - fix: go.mod should be using golang v1.20 to v0.18(beta4)

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/apache/incubator-devlake
 
-go 1.19
+go 1.20
 
 require (
 	github.com/aws/aws-sdk-go v1.44.242


### PR DESCRIPTION
### Summary
We upgraded golang to v1.20 for docker images, but the `go.mod` was missing

