### PR TITLE
fix tooling versions for v0.18 (beta4)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -49,7 +49,7 @@ RUN if [ "$(arch)" != "x86_64" ] ; then \
         apt-get install -y gcc-x86-64-linux-gnu binutils-x86-64-linux-gnu ; \
     fi
 
-RUN go install github.com/vektra/mockery/v2@v2.14.0
+RUN go install github.com/vektra/mockery/v2@v2.20.0
 RUN go install github.com/swaggo/swag/cmd/swag@v1.8.12
 
 COPY --from=debian-amd64 /usr/include /rootfs-amd64/usr/include
@@ -89,7 +89,6 @@ ARG TARGETPLATFORM
 ARG TAG=
 ARG SHA=
 ARG GO_PLUGINS=
-ARG DEBUG=
 
 RUN --mount=type=cache,target=/root/.cache/go-build \
     if [ "$TARGETPLATFORM" = "linux/arm64" ] ; then \
@@ -104,10 +103,6 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     export PKG_CONFIG_PATH=/usr/local/deps/target/lib/pkgconfig && \
     export CGO_ENABLED=1 &&\
     PLUGIN="$GO_PLUGINS" make all
-
-RUN if [ "$DEBUG" = "true" ]; then \
-      go install github.com/go-delve/delve/cmd/dlv@latest; \
-    fi;
 
 # remove symlink in lib, we will recreate in final image
 RUN cd /usr/local/deps/target/lib && \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -24,10 +24,10 @@ VERSION = $(TAG)@$(SHA)
 PYTHON_DIR ?= "./python"
 
 go-dep:
-	go install github.com/vektra/mockery/v2@latest
-	go install github.com/swaggo/swag/cmd/swag@v1.8.4
+	go install github.com/vektra/mockery/v2@v2.20.0
+	go install github.com/swaggo/swag/cmd/swag@v1.8.12
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@vv1.53.3
 	go install github.com/atombender/go-jsonschema/cmd/gojsonschema@latest
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
 
 python-dep:
 	pip install -r python/requirements.txt


### PR DESCRIPTION
### Summary
1. upgraded tooling versions for `make go-dep`
2. remove `dlv` from the docker image
