### PR TITLE
refactor: move table_info_checker to unithelper package

### DIFF
--- a/backend/core/domain_tables_info_test.go
+++ b/backend/core/domain_tables_info_test.go
@@ -18,13 +18,14 @@ limitations under the License.
 package core
 
 import (
-	"github.com/apache/incubator-devlake/core/models/domainlayer/domaininfo"
-	"github.com/apache/incubator-devlake/core/utils"
 	"testing"
+
+	"github.com/apache/incubator-devlake/core/models/domainlayer/domaininfo"
+	"github.com/apache/incubator-devlake/helpers/unithelper"
 )
 
 func Test_GetDomainTablesInfo(t *testing.T) {
-	checker := utils.NewTableInfoChecker(utils.TableInfoCheckerConfig{})
+	checker := unithelper.NewTableInfoChecker(unithelper.TableInfoCheckerConfig{})
 	checker.FeedIn("models/domainlayer", domaininfo.GetDomainTablesInfo)
 	err := checker.Verify()
 	if err != nil {

--- a/backend/helpers/unithelper/table_info_checker.go
+++ b/backend/helpers/unithelper/table_info_checker.go
@@ -15,19 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package utils
+package unithelper
 
 import (
 	"fmt"
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"golang.org/x/exp/slices"
 	fs2 "io/fs"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"

--- a/backend/plugins/table_info_test.go
+++ b/backend/plugins/table_info_test.go
@@ -20,7 +20,7 @@ package plugins
 import (
 	"testing"
 
-	"github.com/apache/incubator-devlake/core/utils"
+	"github.com/apache/incubator-devlake/helpers/unithelper"
 	ae "github.com/apache/incubator-devlake/plugins/ae/impl"
 	bamboo "github.com/apache/incubator-devlake/plugins/bamboo/impl"
 	bitbucket "github.com/apache/incubator-devlake/plugins/bitbucket/impl"
@@ -51,7 +51,7 @@ import (
 
 func Test_GetPluginTablesInfo(t *testing.T) {
 	// Make sure EVERY Go plugin is listed here
-	checker := utils.NewTableInfoChecker(utils.TableInfoCheckerConfig{
+	checker := unithelper.NewTableInfoChecker(unithelper.TableInfoCheckerConfig{
 		ValidatePluginCount: true,
 	})
 	checker.FeedIn("ae/models", ae.AE{}.GetTablesInfo)


### PR DESCRIPTION
### Summary
According to #2078, The `core/utils` should not be importing the `dal` package which would introduce some unwanted cyclirc import, see https://github.com/apache/incubator-devlake/pull/5749#discussion_r1278841644

This PR fixes the problem by moving it to the `unithelper` package.


### Does this close any open issues?
Related to #2078
