### PR TITLE
refactor: replace datatypes.JSON with json.RawMessage for migrationscripts

### DIFF
--- a/backend/core/models/migrationscripts/20221101_add_collector_state.go
+++ b/backend/core/models/migrationscripts/20221101_add_collector_state.go
@@ -18,10 +18,11 @@ limitations under the License.
 package migrationscripts
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
 	commonArchived "github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
-	"gorm.io/datatypes"
 )
 
 type createCollectorState struct{}
@@ -29,7 +30,7 @@ type createCollectorState struct{}
 type CollectorState20221101 struct {
 	commonArchived.GenericModel[string]
 	Type  string
-	Value datatypes.JSON
+	Value json.RawMessage `gorm:"type:json"`
 }
 
 func (CollectorState20221101) TableName() string {

--- a/backend/core/models/migrationscripts/archived/blueprint.go
+++ b/backend/core/models/migrationscripts/archived/blueprint.go
@@ -18,12 +18,12 @@ limitations under the License.
 package archived
 
 import (
-	"gorm.io/datatypes"
+	"encoding/json"
 )
 
 type Blueprint struct {
 	Name       string
-	Tasks      datatypes.JSON
+	Tasks      json.RawMessage `gorm:"type:json"`
 	Enable     bool
 	CronConfig string
 	Model

--- a/backend/core/models/migrationscripts/archived/pipeline.go
+++ b/backend/core/models/migrationscripts/archived/pipeline.go
@@ -18,16 +18,15 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
 	"time"
-
-	"gorm.io/datatypes"
 )
 
 type Pipeline struct {
 	Model
 	Name        string `json:"name" gorm:"index"`
 	BlueprintId uint64
-	Tasks       datatypes.JSON
+	Tasks       json.RawMessage `gorm:"type:json"`
 	TotalTasks  int
 	// Deprecated
 	FinishedTasks int

--- a/backend/core/models/migrationscripts/archived/task.go
+++ b/backend/core/models/migrationscripts/archived/task.go
@@ -18,15 +18,14 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
 	"time"
-
-	"gorm.io/datatypes"
 )
 
 type Task struct {
 	Model
-	Plugin        string `gorm:"index"`
-	Options       datatypes.JSON
+	Plugin        string          `gorm:"index"`
+	Options       json.RawMessage `gorm:"type:json"`
 	Status        string
 	Message       string
 	Progress      float32

--- a/backend/helpers/pluginhelper/api/api_rawdata.go
+++ b/backend/helpers/pluginhelper/api/api_rawdata.go
@@ -18,14 +18,13 @@ limitations under the License.
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"time"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
-
-	"gorm.io/datatypes"
 )
 
 // RawData is raw data structure in DB storage
@@ -34,7 +33,7 @@ type RawData struct {
 	Params    string `gorm:"type:varchar(255);index"`
 	Data      []byte
 	Url       string
-	Input     datatypes.JSON
+	Input     json.RawMessage `gorm:"type:json"`
 	CreatedAt time.Time
 }
 

--- a/backend/plugins/bamboo/models/migrationscripts/archived/transformation_rule.go
+++ b/backend/plugins/bamboo/models/migrationscripts/archived/transformation_rule.go
@@ -18,17 +18,18 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
-	"gorm.io/datatypes"
 )
 
 type BambooTransformationRule struct {
 	archived.Model
 	Name string `gorm:"type:varchar(255);index:idx_name_gitlab,unique" validate:"required" mapstructure:"name" json:"name"`
 	// should be {realRepoName: [bamboo_repoId]}
-	RepoMap           datatypes.JSONMap
-	DeploymentPattern string `mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern" gorm:"type:varchar(255)"`
-	ProductionPattern string `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
+	RepoMap           json.RawMessage `gorm:"type:json"`
+	DeploymentPattern string          `mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	ProductionPattern string          `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
 }
 
 func (BambooTransformationRule) TableName() string {

--- a/backend/plugins/bitbucket/models/migrationscripts/archived/transformation_rule.go
+++ b/backend/plugins/bitbucket/models/migrationscripts/archived/transformation_rule.go
@@ -18,16 +18,17 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
-	"gorm.io/datatypes"
 )
 
 type BitbucketTransformationRule struct {
 	archived.Model
-	Name              string            `gorm:"type:varchar(255);index:idx_name_github,unique"`
-	DeploymentPattern string            `gorm:"type:varchar(255)"`
-	ProductionPattern string            `gorm:"type:varchar(255)"`
-	Refdiff           datatypes.JSONMap `format:"json"`
+	Name              string          `gorm:"type:varchar(255);index:idx_name_github,unique"`
+	DeploymentPattern string          `gorm:"type:varchar(255)"`
+	ProductionPattern string          `gorm:"type:varchar(255)"`
+	Refdiff           json.RawMessage `gorm:"type:json"`
 
 	// a string array, split by `,`.
 	IssueStatusTodo       string `gorm:"type:varchar(255)"`

--- a/backend/plugins/github/models/migrationscripts/archived/job.go
+++ b/backend/plugins/github/models/migrationscripts/archived/job.go
@@ -18,34 +18,35 @@ limitations under the License.
 package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
-	"gorm.io/datatypes"
+	"encoding/json"
 	"time"
+
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
 type GithubJob struct {
 	archived.NoPKModel
-	ConnectionId  uint64         `gorm:"primaryKey"`
-	RepoId        int            `gorm:"primaryKey"`
-	ID            int            `json:"id" gorm:"primaryKey;autoIncrement:false"`
-	RunID         int            `json:"run_id"`
-	RunURL        string         `json:"run_url" gorm:"type:varchar(255)"`
-	NodeID        string         `json:"node_id" gorm:"type:varchar(255)"`
-	HeadSha       string         `json:"head_sha" gorm:"type:varchar(255)"`
-	URL           string         `json:"url" gorm:"type:varchar(255)"`
-	HTMLURL       string         `json:"html_url" gorm:"type:varchar(255)"`
-	Status        string         `json:"status" gorm:"type:varchar(255)"`
-	Conclusion    string         `json:"conclusion" gorm:"type:varchar(255)"`
-	StartedAt     *time.Time     `json:"started_at"`
-	CompletedAt   *time.Time     `json:"completed_at"`
-	Name          string         `json:"name" gorm:"type:varchar(255)"`
-	Steps         datatypes.JSON `json:"steps"`
-	CheckRunURL   string         `json:"check_run_url" gorm:"type:varchar(255)"`
-	Labels        datatypes.JSON `json:"labels"`
-	RunnerID      int            `json:"runner_id"`
-	RunnerName    string         `json:"runner_name" gorm:"type:varchar(255)"`
-	RunnerGroupID int            `json:"runner_group_id"`
-	Type          string         `json:"type" gorm:"type:varchar(255)"`
+	ConnectionId  uint64          `gorm:"primaryKey"`
+	RepoId        int             `gorm:"primaryKey"`
+	ID            int             `json:"id" gorm:"primaryKey;autoIncrement:false"`
+	RunID         int             `json:"run_id"`
+	RunURL        string          `json:"run_url" gorm:"type:varchar(255)"`
+	NodeID        string          `json:"node_id" gorm:"type:varchar(255)"`
+	HeadSha       string          `json:"head_sha" gorm:"type:varchar(255)"`
+	URL           string          `json:"url" gorm:"type:varchar(255)"`
+	HTMLURL       string          `json:"html_url" gorm:"type:varchar(255)"`
+	Status        string          `json:"status" gorm:"type:varchar(255)"`
+	Conclusion    string          `json:"conclusion" gorm:"type:varchar(255)"`
+	StartedAt     *time.Time      `json:"started_at"`
+	CompletedAt   *time.Time      `json:"completed_at"`
+	Name          string          `json:"name" gorm:"type:varchar(255)"`
+	Steps         json.RawMessage `json:"steps" gorm:"type:json"`
+	CheckRunURL   string          `json:"check_run_url" gorm:"type:varchar(255)"`
+	Labels        json.RawMessage `json:"labels" gorm:"type:json"`
+	RunnerID      int             `json:"runner_id"`
+	RunnerName    string          `json:"runner_name" gorm:"type:varchar(255)"`
+	RunnerGroupID int             `json:"runner_group_id"`
+	Type          string          `json:"type" gorm:"type:varchar(255)"`
 }
 
 func (GithubJob) TableName() string {

--- a/backend/plugins/github/models/migrationscripts/archived/transformation_rules.go
+++ b/backend/plugins/github/models/migrationscripts/archived/transformation_rules.go
@@ -18,25 +18,26 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
-	"gorm.io/datatypes"
 )
 
 type GithubTransformationRule struct {
 	archived.Model
-	Name                 string `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_github,unique" validate:"required"`
-	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
-	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
-	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
-	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
-	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
-	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
-	DeploymentPattern    string `mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern" gorm:"type:varchar(255)"`
-	ProductionPattern    string `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
-	Refdiff              datatypes.JSONMap
+	Name                 string          `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_github,unique" validate:"required"`
+	PrType               string          `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
+	PrComponent          string          `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
+	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
+	IssueSeverity        string          `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
+	IssuePriority        string          `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
+	IssueComponent       string          `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
+	IssueTypeBug         string          `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
+	IssueTypeIncident    string          `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
+	IssueTypeRequirement string          `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
+	DeploymentPattern    string          `mapstructure:"deploymentPattern,omitempty" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	ProductionPattern    string          `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
+	Refdiff              json.RawMessage `gorm:"type:json"`
 }
 
 func (GithubTransformationRule) TableName() string {

--- a/backend/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
+++ b/backend/plugins/gitlab/models/migrationscripts/archived/transformation_rules.go
@@ -18,25 +18,26 @@ limitations under the License.
 package archived
 
 import (
+	"encoding/json"
+
 	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
-	"gorm.io/datatypes"
 )
 
 type GitlabTransformationRule struct {
 	archived.Model
-	Name                 string `gorm:"type:varchar(255);index:idx_name_gitlab,unique" validate:"required"`
-	PrType               string `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
-	PrComponent          string `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
-	PrBodyClosePattern   string `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
-	IssueSeverity        string `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
-	IssuePriority        string `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
-	IssueComponent       string `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
-	IssueTypeBug         string `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
-	IssueTypeIncident    string `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
-	IssueTypeRequirement string `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
-	DeploymentPattern    string `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
-	ProductionPattern    string `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
-	Refdiff              datatypes.JSONMap
+	Name                 string          `gorm:"type:varchar(255);index:idx_name_gitlab,unique" validate:"required"`
+	PrType               string          `mapstructure:"prType" json:"prType" gorm:"type:varchar(255)"`
+	PrComponent          string          `mapstructure:"prComponent" json:"prComponent" gorm:"type:varchar(255)"`
+	PrBodyClosePattern   string          `mapstructure:"prBodyClosePattern" json:"prBodyClosePattern" gorm:"type:varchar(255)"`
+	IssueSeverity        string          `mapstructure:"issueSeverity" json:"issueSeverity" gorm:"type:varchar(255)"`
+	IssuePriority        string          `mapstructure:"issuePriority" json:"issuePriority" gorm:"type:varchar(255)"`
+	IssueComponent       string          `mapstructure:"issueComponent" json:"issueComponent" gorm:"type:varchar(255)"`
+	IssueTypeBug         string          `mapstructure:"issueTypeBug" json:"issueTypeBug" gorm:"type:varchar(255)"`
+	IssueTypeIncident    string          `mapstructure:"issueTypeIncident" json:"issueTypeIncident" gorm:"type:varchar(255)"`
+	IssueTypeRequirement string          `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement" gorm:"type:varchar(255)"`
+	DeploymentPattern    string          `mapstructure:"deploymentPattern" json:"deploymentPattern" gorm:"type:varchar(255)"`
+	ProductionPattern    string          `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
+	Refdiff              json.RawMessage `gorm:"type:json"`
 }
 
 func (t GitlabTransformationRule) TableName() string {

--- a/backend/plugins/jira/models/migrationscripts/archived/issue.go
+++ b/backend/plugins/jira/models/migrationscripts/archived/issue.go
@@ -18,10 +18,10 @@ limitations under the License.
 package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
+	"encoding/json"
 	"time"
 
-	"gorm.io/datatypes"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
 type JiraIssue struct {
@@ -59,9 +59,9 @@ type JiraIssue struct {
 	SpentMinutes             int64
 	LeadTimeMinutes          uint
 	StdStoryPoint            int64
-	StdType                  string `gorm:"type:varchar(255)"`
-	StdStatus                string `gorm:"type:varchar(255)"`
-	AllFields                datatypes.JSONMap
+	StdType                  string          `gorm:"type:varchar(255)"`
+	StdStatus                string          `gorm:"type:varchar(255)"`
+	AllFields                json.RawMessage `gorm:"type:json"`
 	archived.NoPKModel
 }
 

--- a/backend/plugins/jira/models/migrationscripts/archived/remotelink.go
+++ b/backend/plugins/jira/models/migrationscripts/archived/remotelink.go
@@ -18,21 +18,21 @@ limitations under the License.
 package archived
 
 import (
-	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
+	"encoding/json"
 	"time"
 
-	"gorm.io/datatypes"
+	"github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
 type JiraRemotelink struct {
 	archived.NoPKModel
 
 	// collected fields
-	ConnectionId uint64 `gorm:"primaryKey"`
-	RemotelinkId uint64 `gorm:"primarykey"`
-	IssueId      uint64 `gorm:"index"`
-	RawJson      datatypes.JSON
-	Self         string `gorm:"type:varchar(255)"`
+	ConnectionId uint64          `gorm:"primaryKey"`
+	RemotelinkId uint64          `gorm:"primarykey"`
+	IssueId      uint64          `gorm:"index"`
+	RawJson      json.RawMessage `gorm:"type:json"`
+	Self         string          `gorm:"type:varchar(255)"`
 	Title        string
 	Url          string `gorm:"type:varchar(255)"`
 	IssueUpdated *time.Time


### PR DESCRIPTION
### Summary

Purpose:
1. Isolates `gorm` from our system
2. Unifying model definition style across all migration scripts so contributors would get the right idea when referencing the existing scripts

### Does this close any open issues?
Part of #3729
