### PR TITLE
refactor: move RefdiffOptions to refdiff/models package

### DIFF
--- a/backend/plugins/refdiff/e2e/deployment_commit_diff_test.go
+++ b/backend/plugins/refdiff/e2e/deployment_commit_diff_test.go
@@ -35,7 +35,7 @@ func TestDeploymentCommitDiffDataFlow(t *testing.T) {
 	dataflowTester := e2ehelper.NewDataFlowTester(t, "refdiff", plugin)
 
 	taskData := &tasks.RefdiffTaskData{
-		Options: &tasks.RefdiffOptions{
+		Options: &models.RefdiffOptions{
 			ProjectName: "project1",
 		},
 	}

--- a/backend/plugins/refdiff/impl/impl.go
+++ b/backend/plugins/refdiff/impl/impl.go
@@ -77,7 +77,7 @@ func (p RefDiff) SubTaskMetas() []plugin.SubTaskMeta {
 }
 
 func (p RefDiff) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]interface{}) (interface{}, errors.Error) {
-	var op tasks.RefdiffOptions
+	var op models.RefdiffOptions
 	err := helper.Decode(options, &op, nil)
 	if err != nil {
 		return nil, err

--- a/backend/plugins/refdiff/models/refdiff_options.go
+++ b/backend/plugins/refdiff/models/refdiff_options.go
@@ -1,0 +1,39 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+type RefPair struct {
+	NewRef string
+	OldRef string
+}
+type RefCommitPair [4]string
+type RefPairList [2]string
+type RefCommitPairs []RefCommitPair
+
+type RefdiffOptions struct {
+	RepoId string
+	Tasks  []string `json:"tasks,omitempty"`
+	Pairs  []RefPair
+
+	TagsPattern string // The Pattern to match from all tags
+	TagsLimit   int    // How many tags be matched should be used.
+	TagsOrder   string // The Rule to Order the tag list
+
+	AllPairs    RefCommitPairs // Pairs and TagsPattern Pairs
+	ProjectName string
+}

--- a/backend/plugins/refdiff/tasks/commit_diff_calculator.go
+++ b/backend/plugins/refdiff/tasks/commit_diff_calculator.go
@@ -42,7 +42,7 @@ func CalculateCommitsDiff(taskCtx plugin.SubTaskContext) errors.Error {
 
 	// get all data from finish_commits_diffs
 	commitPairsSrc := data.Options.AllPairs
-	var commitPairs RefCommitPairs
+	var commitPairs models.RefCommitPairs
 	refCommit := &code.RefCommit{}
 	for _, pair := range commitPairsSrc {
 		newRefId := fmt.Sprintf("%s:%s", repoId, pair[2])

--- a/backend/plugins/refdiff/tasks/ref_issue_diff_calculator.go
+++ b/backend/plugins/refdiff/tasks/ref_issue_diff_calculator.go
@@ -19,12 +19,14 @@ package tasks
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/crossdomain"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"reflect"
+	"github.com/apache/incubator-devlake/plugins/refdiff/models"
 )
 
 // CaculatePairList Calculate the pair list both from Options.Pairs and TagPattern
@@ -36,7 +38,7 @@ func CaculatePairList(taskCtx plugin.SubTaskContext) (RefPairLists, errors.Error
 	pairList := make(RefPairLists, 0, len(pairs))
 
 	for _, pair := range pairs {
-		pairList = append(pairList, RefPairList{fmt.Sprintf("%s:%s", repoId, pair[2]), fmt.Sprintf("%s:%s", repoId, pair[3])})
+		pairList = append(pairList, models.RefPairList{fmt.Sprintf("%s:%s", repoId, pair[2]), fmt.Sprintf("%s:%s", repoId, pair[3])})
 	}
 
 	return pairList, nil


### PR DESCRIPTION
### Summary

In order to calculate `commits` between releases, github/gitlab would generate a `refdiff` task during `make plan` phase. In the current implementation, we rely on passing the `options map[string]interface{}` to control `refdiff` behavior. It poses a couple of drawbacks:

1. The swagger doc won't be able to display the `ScopeConfig.Refdiff` correctly, it would be displayed as `{}` which is useless
2. `map[string]interface{}` is **Untyped**, we wont be able to detect errors if `refdiff` were to change its field-naming

This PR moves RefdiffOptions to refdiff/models package

### Does this close any open issues?
Step 1 of #4852
