### PR TITLE
refactor: improve the bodyTamper.Write method for swagger/doc.json

### DIFF
--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -18,7 +18,7 @@ limitations under the License.
 package api
 
 import (
-	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -190,8 +190,18 @@ type bodyTamper struct {
 	gin.ResponseWriter
 }
 
+// Write intercepts the response body and modifies the base path
 func (w bodyTamper) Write(b []byte) (int, error) {
-	b = bytes.Replace(b, []byte(`"basePath": ""`), []byte(`"basePath": "/api"`), 1)
+	var m map[string]interface{}
+	err := json.Unmarshal(b, &m)
+	if err != nil {
+		return 0, err
+	}
+	m["basePath"] = "/api"
+	b, err = json.Marshal(m)
+	if err != nil {
+		return 0, err
+	}
 	return w.ResponseWriter.Write(b)
 }
 


### PR DESCRIPTION
### Summary
Improved the way to change the response body. From the original use of `bytes.Replace` to unmarshal into `map[string]interface{}` first, change the value of `basePath` and then marshal into byte array.

### Does this close any open issues?
Closes #5828 
Related to #5829 
