### PR TITLE
fix: add SKIP_COMMIT_FILES enviroment variable

### DIFF
--- a/backend/plugins/gitextractor/parser/repo.go
+++ b/backend/plugins/gitextractor/parser/repo.go
@@ -25,7 +25,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/apache/incubator-devlake/core/config"
 	"github.com/apache/incubator-devlake/core/dal"
@@ -337,8 +336,8 @@ func (r *GitRepo) getDiffComparedToParent(commitSha string, commit *git.Commit, 
 		return nil, errors.Convert(err)
 	}
 	cfg := config.GetConfig()
-	skipCommitFiles := strings.TrimSpace(cfg.GetString(SkipCommitFiles))
-	if skipCommitFiles == "" {
+	skipCommitFiles := cfg.GetBool(SkipCommitFiles)
+	if !skipCommitFiles {
 		err = r.storeCommitFilesFromDiff(commitSha, diff, componentMap)
 		if err != nil {
 			return nil, errors.Convert(err)


### PR DESCRIPTION
### Summary
fix: add SKIP_COMMIT_FILES enviroment variable.

To bypass the commit file collector, you should set SKIP_COMMIT_FILES=true.

### Does this close any open issues?
Closes #5819 

### Screenshots
set SKIP_COMMIT_FILES enviroment variable, the devlake run results:
![a1bb5665-9482-4f50-91f8-4e2cbbe88f1e](https://github.com/apache/incubator-devlake/assets/101256042/14a7cb51-12f1-49c7-85b3-8903a204a722)

not set:
![9d64cffd-fccd-4e09-b71d-ab758ced8883](https://github.com/apache/incubator-devlake/assets/101256042/f09252dd-d909-4194-a222-ac4f1a6738dc)


### Other Information
Any other information that is important to this PR.
