### PR TITLE
feat: adding proxy API for the zentao plugin

### DIFF
--- a/backend/plugins/zentao/api/proxy.go
+++ b/backend/plugins/zentao/api/proxy.go
@@ -1,0 +1,61 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"io"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/zentao/models"
+)
+
+// Proxy is a proxy to Zentao API
+// @Summary Proxy to Zentao API
+// @Description Proxy to Zentao API
+// @Tags plugins/zentao
+// @Param connectionId path int true "connection ID"
+// @Param path path string true "path to Zentao API"
+// @Success 200  {object} ZentaoTestConnResponse "Success"
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/zentao/connections/{connectionId}/proxy/{path} [GET]
+func Proxy(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.ZentaoConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	if err != nil {
+		return nil, err
+	}
+	apiClient, err := helper.NewApiClientFromConnection(context.TODO(), basicRes, connection)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := apiClient.Get(input.Params["path"], input.Query, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := errors.Convert01(io.ReadAll(resp.Body))
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Status: resp.StatusCode, ContentType: resp.Header.Get("Content-Type"), Body: body}, nil
+}

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -278,6 +278,9 @@ func (p Zentao) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 		"connections/:connectionId/remote-scopes": {
 			"GET": api.RemoteScopes,
 		},
+		"connections/:connectionId/proxy/*path": {
+			"GET": api.Proxy,
+		},
 	}
 }
 


### PR DESCRIPTION
### Summary
Add proxy API for the zentao plugin. Users could access the original zentao endpoints through this newly integrated API


### Screenshots
![3132c668-7fcd-42f0-b4ec-e0a024b54514](https://github.com/apache/incubator-devlake/assets/8455907/50e75461-dc3f-4750-9299-511bddfb3efd)
![img_v2_d52f2989-6c76-4cdc-8df0-618920c5c33g](https://github.com/apache/incubator-devlake/assets/8455907/41e93f80-b6dd-4706-bce3-3fa1ca9a21c3)
![img_v2_19992001-61b7-4515-aa85-1aab466d01dg](https://github.com/apache/incubator-devlake/assets/8455907/532c5e0e-61bd-4696-806d-aad998aad448)


### Other Information
Any other information that is important to this PR.
