### PR TITLE
GitHub fails after upgrade to v0.18

### DIFF
--- a/backend/core/plugin/plugin_blueprint.go
+++ b/backend/core/plugin/plugin_blueprint.go
@@ -87,8 +87,6 @@ type BlueprintConnectionV200 struct {
 type BlueprintScopeV200 struct {
 	Id   string `json:"id"`
 	Name string `json:"name"`
-	// Deprecated: Entities is moved to the ScopeConfig struct
-	Entities []string `json:"entities"`
 }
 
 // MetricPluginBlueprintV200 is similar to the DataSourcePluginBlueprintV200


### PR DESCRIPTION
### Summary
GitHub fails after upgrade to v0.18

### Does this close any open issues?
Closes #5945 

Tested
![image](https://github.com/apache/incubator-devlake/assets/61080/863f067d-86dc-4933-973b-bb2cc593be25)
