### PR TITLE
fix: skip invalid account in case there were corrupted records in the database

### DIFF
--- a/backend/plugins/github/tasks/account_org_collector.go
+++ b/backend/plugins/github/tasks/account_org_collector.go
@@ -66,7 +66,9 @@ func CollectAccountOrg(taskCtx plugin.SubTaskContext) errors.Error {
 			AND ga.id = _tool_github_repo_accounts.account_id
 			AND ga.type = 'User'
 		)`),
-		dal.Where("_tool_github_repo_accounts.repo_github_id = ? and _tool_github_repo_accounts.connection_id=?",
+		dal.Where(`_tool_github_repo_accounts.repo_github_id = ?
+		  AND _tool_github_repo_accounts.connection_id=?
+			AND _tool_github_repo_accounts.account_id > 0`,
 			data.Options.GithubId, data.Options.ConnectionId),
 	)
 	if err != nil {


### PR DESCRIPTION
### Summary

In #5900 , I fixed the bug by skipping records during the Extraction(raw layer to tool layer) phase, it works only when it is a clean slate.
However, for users that ran extraction before, the corrupted records already exist on the tool layer which would lead to the same error.
This PR fixes the latter situation as well


### Does this close any open issues?
Related to #5899 
