### PR TITLE
cherry-pick #5951 fix: skip invalid account in case there were corruptted records in the db to v0.18 (beta8)

### DIFF
--- a/backend/plugins/github/tasks/account_org_collector.go
+++ b/backend/plugins/github/tasks/account_org_collector.go
@@ -48,7 +48,9 @@ func CollectAccountOrg(taskCtx plugin.SubTaskContext) errors.Error {
 			AND ga.id = _tool_github_repo_accounts.account_id
 			AND ga.type = 'User'
 		)`),
-		dal.Where("_tool_github_repo_accounts.repo_github_id = ? and _tool_github_repo_accounts.connection_id=?",
+		dal.Where(`_tool_github_repo_accounts.repo_github_id = ?
+		  AND _tool_github_repo_accounts.connection_id=?
+			AND _tool_github_repo_accounts.account_id > 0`,
 			data.Options.GithubId, data.Options.ConnectionId),
 	)
 	if err != nil {


### PR DESCRIPTION
### Summary
cherry-pick #5951 fix: skip invalid account in case there were corruptted records in the db to v0.18 (beta8)

