### PR TITLE
fix(zentao): fix `completed_date` and `ended_date` fields

### DIFF
--- a/backend/plugins/zentao/e2e/snapshot_tables/execution_sprint.csv
+++ b/backend/plugins/zentao/e2e/snapshot_tables/execution_sprint.csv
@@ -1,3 +1,3 @@
 id,name,url,status,started_date,ended_date,completed_date,original_board_id
-zentao:ZentaoExecution:1:1,企业网站第一期,",7,1,",ACTIVE,,,2022-06-01T00:00:00.000+00:00,zentao:ZentaoProject:1:1
-zentao:ZentaoExecution:1:12,TR5,",1091,12,",CLOSED,2022-07-07T00:00:00.000+00:00,,2022-11-03T00:00:00.000+00:00,zentao:ZentaoProject:1:1
+zentao:ZentaoExecution:1:1,企业网站第一期,",7,1,",ACTIVE,,2022-06-01T00:00:00.000+00:00,,zentao:ZentaoProject:1:1
+zentao:ZentaoExecution:1:12,TR5,",1091,12,",CLOSED,2022-07-07T00:00:00.000+00:00,2022-11-03T00:00:00.000+00:00,,zentao:ZentaoProject:1:1

--- a/backend/plugins/zentao/tasks/execution_convertor.go
+++ b/backend/plugins/zentao/tasks/execution_convertor.go
@@ -85,8 +85,8 @@ func ConvertExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 				Url:             toolExecution.Path,
 				Status:          domainStatus,
 				StartedDate:     toolExecution.RealBegan.ToNullableTime(),
-				EndedDate:       toolExecution.RealEnd.ToNullableTime(),
-				CompletedDate:   toolExecution.PlanEnd.ToNullableTime(),
+				EndedDate:       toolExecution.PlanEnd.ToNullableTime(),
+				CompletedDate:   toolExecution.RealEnd.ToNullableTime(),
 				OriginalBoardID: projectIdGen.Generate(toolExecution.ConnectionId, data.Options.ProjectId),
 			}
 			boardSprint := &ticket.BoardSprint{


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
1. make zentao executions' plan end date as  completed_date
2. make zentao executions' plan real date as  ended_date

### Does this close any open issues?
Closes #5968

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
