### PR TITLE
fix(zentao): get all exeutions(include closed) under a project

### DIFF
--- a/backend/plugins/zentao/tasks/execution_summary_collector.go
+++ b/backend/plugins/zentao/tasks/execution_summary_collector.go
@@ -46,6 +46,7 @@ func CollectExecutionSummary(taskCtx plugin.SubTaskContext) errors.Error {
 			query := url.Values{}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
 			query.Set("limit", fmt.Sprintf("%v", reqData.Pager.Size))
+			query.Set("status", "all")
 			return query, nil
 		},
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
The lack of closed executions in sprints is caused by quering all the executions under a project, only opened executions are returned from the api, add query parameter status = all  can make sure all executions will be returned.

### Does this close any open issues?
Closes #5969 

### Screenshots
Include any relevant screenshots here.
<img width="1540" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/ffe6d0d4-277f-4228-8b4b-efdc342d9ac7">
<img width="1540" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/aed3f329-cf53-4d5b-aa4d-e8ebe76beb5a">


### Other Information
Any other information that is important to this PR.
