### PR TITLE
fix(zentao): fix closed sprint's status in domain layer's sprints table

### DIFF
--- a/backend/plugins/zentao/tasks/execution_convertor.go
+++ b/backend/plugins/zentao/tasks/execution_convertor.go
@@ -81,6 +81,7 @@ func ConvertExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 			case `suspended`:
 				domainStatus = `SUSPENDED`
 			case `closed`:
+				fallthrough
 			case `done`:
 				domainStatus = `CLOSED`
 			}


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
closed execution's status is empty by default, it's unexpected. This PR mark closed execution's status as "CLOSED".

### Does this close any open issues?
Closes #5982

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
