### PR TITLE
cherry-pick fix(zentao): fix closed sprint's status in domain layer's sprints table

### DIFF
--- a/backend/plugins/zentao/tasks/execution_convertor.go
+++ b/backend/plugins/zentao/tasks/execution_convertor.go
@@ -81,6 +81,7 @@ func ConvertExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 			case `suspended`:
 				domainStatus = `SUSPENDED`
 			case `closed`:
+				fallthrough
 			case `done`:
 				domainStatus = `CLOSED`
 			}


### PR DESCRIPTION
cherry-pick #5984 fix(zentao): fix closed sprint's status in domain layer's sprints table