### PR TITLE
cherry-pick fix(zentao): get all tasks ignore task's status

### DIFF
--- a/backend/plugins/zentao/tasks/task_collector.go
+++ b/backend/plugins/zentao/tasks/task_collector.go
@@ -67,6 +67,7 @@ func CollectTask(taskCtx plugin.SubTaskContext) errors.Error {
 			query := url.Values{}
 			query.Set("page", fmt.Sprintf("%v", reqData.Pager.Page))
 			query.Set("limit", fmt.Sprintf("%v", reqData.Pager.Size))
+			query.Set("status", "all")
 			return query, nil
 		},
 		GetTotalPages: GetTotalPagesFromResponse,


### PR DESCRIPTION
cherry-pick #6003  fix(zentao): get all tasks ignore task's status