### PR TITLE
fix(zentao): fix changelogs.date 's timezone, use csttime.

### DIFF
--- a/backend/plugins/zentao/models/changelog.go
+++ b/backend/plugins/zentao/models/changelog.go
@@ -18,28 +18,26 @@ limitations under the License.
 package models
 
 import (
-	"time"
-
 	"github.com/apache/incubator-devlake/core/models/common"
 )
 
 type ZentaoChangelog struct {
 	common.NoPKModel `json:"-"`
-	ConnectionId     uint64    `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey;type:BIGINT  NOT NULL"`
-	Id               int64     `json:"id" mapstructure:"id" gorm:"primaryKey;type:BIGINT  NOT NULL;autoIncrement:false"`
-	ObjectId         int64     `json:"objectId" mapstructure:"objectId" gorm:"index; NOT NULL"`
-	Execution        int64     `json:"execution" mapstructure:"execution" `
-	Actor            string    `json:"actor" mapstructure:"actor" `
-	Action           string    `json:"action" mapstructure:"action"`
-	Extra            string    `json:"extra" mapstructure:"extra"`
-	ObjectType       string    `json:"objectType" mapstructure:"objectType"`
-	Project          int64     `json:"project" mapstructure:"project"`
-	Product          int64     `json:"product" mapstructure:"product"`
-	Vision           string    `json:"vision" mapstructure:"vision"`
-	Comment          string    `json:"comment" mapstructure:"comment"`
-	Efforted         string    `json:"efforted" mapstructure:"efforted"`
-	Date             time.Time `json:"date" mapstructure:"date"`
-	Read             string    `json:"read" mapstructure:"read"`
+	ConnectionId     uint64          `json:"connectionId" mapstructure:"connectionId" gorm:"primaryKey;type:BIGINT  NOT NULL"`
+	Id               int64           `json:"id" mapstructure:"id" gorm:"primaryKey;type:BIGINT  NOT NULL;autoIncrement:false"`
+	ObjectId         int64           `json:"objectId" mapstructure:"objectId" gorm:"index; NOT NULL"`
+	Execution        int64           `json:"execution" mapstructure:"execution" `
+	Actor            string          `json:"actor" mapstructure:"actor" `
+	Action           string          `json:"action" mapstructure:"action"`
+	Extra            string          `json:"extra" mapstructure:"extra"`
+	ObjectType       string          `json:"objectType" mapstructure:"objectType"`
+	Project          int64           `json:"project" mapstructure:"project"`
+	Product          int64           `json:"product" mapstructure:"product"`
+	Vision           string          `json:"vision" mapstructure:"vision"`
+	Comment          string          `json:"comment" mapstructure:"comment"`
+	Efforted         string          `json:"efforted" mapstructure:"efforted"`
+	Date             *common.CSTTime `json:"date" mapstructure:"date"`
+	Read             string          `json:"read" mapstructure:"read"`
 }
 
 func (ZentaoChangelog) TableName() string {


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Set changelogs.date as csttime, to fix the wrong timezone info.

### Does this close any open issues?
Closes #6009 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
