### PR TITLE
refactor: simplify tapd scope config

### DIFF
--- a/backend/plugins/tapd/e2e/bug_changelog_test.go
+++ b/backend/plugins/tapd/e2e/bug_changelog_test.go
@@ -36,13 +36,13 @@ func TestTapdBugChangelogDataFlow(t *testing.T) {
 		Options: &tasks.TapdOptions{
 			ConnectionId: 1,
 			WorkspaceId:  991,
-			ScopeConfig: &tasks.TapdScopeConfig{
-				TypeMappings: tasks.TypeMappings{
+			ScopeConfig: &models.TapdScopeConfig{
+				TypeMappings: map[string]string{
 					"Techstory": "REQUIREMENT",
 					"技术债":       "REQUIREMENT",
 					"需求":        "REQUIREMENT",
 				},
-				StatusMappings: tasks.StatusMappings{
+				StatusMappings: map[string]string{
 					"已关闭":                   "DONE",
 					"接受/处理":                 "IN_PROGRESS",
 					"开发中":                   "IN_PROGRESS",

--- a/backend/plugins/tapd/e2e/bugs_test.go
+++ b/backend/plugins/tapd/e2e/bugs_test.go
@@ -37,12 +37,12 @@ func TestTapdBugDataFlow(t *testing.T) {
 		Options: &tasks.TapdOptions{
 			ConnectionId: 1,
 			WorkspaceId:  991,
-			ScopeConfig: &tasks.TapdScopeConfig{
-				TypeMappings: tasks.TypeMappings{
+			ScopeConfig: &models.TapdScopeConfig{
+				TypeMappings: map[string]string{
 					"BUG":  "缺陷",
 					"TASK": "任务",
 				},
-				StatusMappings: tasks.StatusMappings{
+				StatusMappings: map[string]string{
 					"已关闭":   "完成",
 					"接受/处理": "处理中",
 				},

--- a/backend/plugins/tapd/e2e/stories_test.go
+++ b/backend/plugins/tapd/e2e/stories_test.go
@@ -37,8 +37,8 @@ func TestTapdStoryDataFlow(t *testing.T) {
 		Options: &tasks.TapdOptions{
 			ConnectionId: 1,
 			WorkspaceId:  991,
-			ScopeConfig: &tasks.TapdScopeConfig{
-				TypeMappings: tasks.TypeMappings{
+			ScopeConfig: &models.TapdScopeConfig{
+				TypeMappings: map[string]string{
 					"BUG":  "缺陷",
 					"TASK": "任务",
 					"需求":   "故事需求",

--- a/backend/plugins/tapd/e2e/story_changelog_test.go
+++ b/backend/plugins/tapd/e2e/story_changelog_test.go
@@ -36,13 +36,13 @@ func TestTapdStoryChangelogDataFlow(t *testing.T) {
 		Options: &tasks.TapdOptions{
 			ConnectionId: 1,
 			WorkspaceId:  991,
-			ScopeConfig: &tasks.TapdScopeConfig{
-				TypeMappings: tasks.TypeMappings{
+			ScopeConfig: &models.TapdScopeConfig{
+				TypeMappings: map[string]string{
 					"Techstory": "REQUIREMENT",
 					"技术债":       "REQUIREMENT",
 					"需求":        "REQUIREMENT",
 				},
-				StatusMappings: tasks.StatusMappings{
+				StatusMappings: map[string]string{
 					"已关闭":                   "DONE",
 					"接受/处理":                 "IN_PROGRESS",
 					"开发中":                   "IN_PROGRESS",

--- a/backend/plugins/tapd/e2e/task_changelog_test.go
+++ b/backend/plugins/tapd/e2e/task_changelog_test.go
@@ -36,13 +36,13 @@ func TestTapdTaskChangelogDataFlow(t *testing.T) {
 		Options: &tasks.TapdOptions{
 			ConnectionId: 1,
 			WorkspaceId:  991,
-			ScopeConfig: &tasks.TapdScopeConfig{
-				TypeMappings: tasks.TypeMappings{
+			ScopeConfig: &models.TapdScopeConfig{
+				TypeMappings: map[string]string{
 					"Techstory": "REQUIREMENT",
 					"技术债":       "REQUIREMENT",
 					"需求":        "REQUIREMENT",
 				},
-				StatusMappings: tasks.StatusMappings{
+				StatusMappings: map[string]string{
 					"已关闭":                   "DONE",
 					"接受/处理":                 "IN_PROGRESS",
 					"开发中":                   "IN_PROGRESS",

--- a/backend/plugins/tapd/e2e/tasks_test.go
+++ b/backend/plugins/tapd/e2e/tasks_test.go
@@ -37,8 +37,8 @@ func TestTapdTaskDataFlow(t *testing.T) {
 		Options: &tasks.TapdOptions{
 			ConnectionId: 1,
 			WorkspaceId:  991,
-			ScopeConfig: &tasks.TapdScopeConfig{
-				TypeMappings: tasks.TypeMappings{
+			ScopeConfig: &models.TapdScopeConfig{
+				TypeMappings: map[string]string{
 					"BUG":  "缺陷",
 					"TASK": "任务",
 				},

--- a/backend/plugins/tapd/impl/impl.go
+++ b/backend/plugins/tapd/impl/impl.go
@@ -236,14 +236,9 @@ func (p Tapd) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]int
 	}
 
 	if op.ScopeConfig == nil && op.ScopeConfigId != 0 {
-		var scopeConfig models.TapdScopeConfig
-		err = taskCtx.GetDal().First(&scopeConfig, dal.Where("id = ?", op.ScopeConfigId))
+		err = taskCtx.GetDal().First(&op.ScopeConfig, dal.Where("id = ?", op.ScopeConfigId))
 		if err != nil && taskCtx.GetDal().IsErrorNotFound(err) {
 			return nil, errors.BadInput.Wrap(err, "fail to get scopeConfig")
-		}
-		op.ScopeConfig, err = tasks.MakeScopeConfigs(scopeConfig)
-		if err != nil {
-			return nil, errors.BadInput.Wrap(err, "fail to make scopeConfig")
 		}
 	}
 

--- a/backend/plugins/tapd/models/scope_config.go
+++ b/backend/plugins/tapd/models/scope_config.go
@@ -18,17 +18,15 @@ limitations under the License.
 package models
 
 import (
-	"encoding/json"
-
 	"github.com/apache/incubator-devlake/core/models/common"
 )
 
 type TapdScopeConfig struct {
 	common.ScopeConfig `mapstructure:",squash" json:",inline" gorm:"embedded"`
-	ConnectionId       uint64          `mapstructure:"connectionId" json:"connectionId"`
-	Name               string          `gorm:"type:varchar(255);index:idx_name_tapd,unique" validate:"required" mapstructure:"name" json:"name"`
-	TypeMappings       json.RawMessage `mapstructure:"typeMappings,omitempty" json:"typeMappings"`
-	StatusMappings     json.RawMessage `mapstructure:"statusMappings,omitempty" json:"statusMappings"`
+	ConnectionId       uint64            `mapstructure:"connectionId" json:"connectionId"`
+	Name               string            `gorm:"type:varchar(255);index:idx_name_tapd,unique" validate:"required" mapstructure:"name" json:"name"`
+	TypeMappings       map[string]string `mapstructure:"typeMappings,omitempty" json:"typeMappings" gorm:"serializer:json"`
+	StatusMappings     map[string]string `mapstructure:"statusMappings,omitempty" json:"statusMappings" gorm:"serializer:json"`
 }
 
 func (t TapdScopeConfig) TableName() string {

--- a/backend/plugins/tapd/tasks/task_data.go
+++ b/backend/plugins/tapd/tasks/task_data.go
@@ -18,7 +18,6 @@ limitations under the License.
 package tasks
 
 import (
-	"encoding/json"
 	"time"
 
 	"github.com/apache/incubator-devlake/core/errors"
@@ -33,30 +32,7 @@ type TapdOptions struct {
 	TimeAfter     string `json:"timeAfter" mapstructure:"timeAfter,omitempty"`
 	CstZone       *time.Location
 	ScopeConfigId uint64
-	ScopeConfig   *TapdScopeConfig `json:"scopeConfig"`
-}
-
-func MakeScopeConfigs(rule models.TapdScopeConfig) (*TapdScopeConfig, errors.Error) {
-	var statusMapping StatusMappings
-	var typeMapping TypeMappings
-	var err error
-	if len(rule.TypeMappings) > 0 {
-		err = json.Unmarshal(rule.TypeMappings, &typeMapping)
-		if err != nil {
-			return nil, errors.Default.Wrap(err, "unable to unmarshal the typeMapping")
-		}
-	}
-	if len(rule.StatusMappings) > 0 {
-		err = json.Unmarshal(rule.StatusMappings, &statusMapping)
-		if err != nil {
-			return nil, errors.Default.Wrap(err, "unable to unmarshal the statusMapping")
-		}
-	}
-	result := &TapdScopeConfig{
-		StatusMappings: statusMapping,
-		TypeMappings:   typeMapping,
-	}
-	return result, nil
+	ScopeConfig   *models.TapdScopeConfig `json:"scopeConfig"`
 }
 
 type TapdTaskData struct {
@@ -96,13 +72,4 @@ func ValidateTaskOptions(op *TapdOptions) errors.Error {
 		return errors.BadInput.New("connectionId is invalid")
 	}
 	return nil
-}
-
-type StatusMappings map[string]string
-
-type TypeMappings map[string]string
-
-type TapdScopeConfig struct {
-	TypeMappings   TypeMappings   `json:"typeMappings"`
-	StatusMappings StatusMappings `json:"statusMappings"`
 }


### PR DESCRIPTION
### Summary
refactor: simplify tapd scope config


### Does this close any open issues?
Part of #3729 

### Screenshots
scope config can be created successfully
<img width="820" alt="tapd1" src="https://github.com/apache/incubator-devlake/assets/61080/bd22a023-51b2-4fef-a31c-57fad8fa98d5">

scope configs can be listed successfully
<img width="855" alt="tapd2" src="https://github.com/apache/incubator-devlake/assets/61080/3fbf6cb9-bc0f-410d-9846-8018885f63e8">

related e2e tasks work correctly
<img width="470" alt="tapd3" src="https://github.com/apache/incubator-devlake/assets/61080/4759a4be-c4ee-4e89-a5ac-d6ea6269f740">
