### PR TITLE
fix(gitlab): _raw_gitlab_api_pipeline_details table data not collecte…

### DIFF
--- a/backend/plugins/gitlab/tasks/pipeline_extractor.go
+++ b/backend/plugins/gitlab/tasks/pipeline_extractor.go
@@ -105,7 +105,7 @@ func ExtractApiPipelines(taskCtx plugin.SubTaskContext) errors.Error {
 				IsDetailRequired: false,
 			}
 
-			if gitlabApiPipeline.CreatedAt == nil && gitlabApiPipeline.UpdatedAt == nil {
+			if gitlabApiPipeline.StartedAt == nil && gitlabApiPipeline.FinishedAt == nil {
 				gitlabPipeline.IsDetailRequired = true
 			}
 


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

CollectApiPipelineDetails task will only fetch pipeline details for _tool_gitlab_pipelines record with IsDetailRequired == true.

started_at and finished_at are two fields exist in pipeline detail api, but not in pipeline list api, I guess it's meant to check these two field to decide is detail required.

### Does this close any open issues?
Closes #6027

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
