### PR TITLE
fix: check both update time and record count when judge skippable

### DIFF
--- a/backend/plugins/starrocks/tasks/tasks.go
+++ b/backend/plugins/starrocks/tasks/tasks.go
@@ -180,7 +180,19 @@ func createTmpTableInStarrocks(dc *DataConfigParams) (map[string]string, string,
 				}
 			} else {
 				if updatedFrom.Equal(updatedTo) {
-					return nil, "", true, nil
+					sourceCount, err := db.Count(dal.From(table))
+					if err != nil {
+						return nil, "", false, err
+					}
+					starrocksCount, err := starrocksDb.Count(dal.From(starrocksTable))
+					if err != nil {
+						return nil, "", false, err
+					}
+					// When updated time is equal but record count is different,
+					// need to execute the following process, not returning here
+					if sourceCount == starrocksCount {
+						return nil, "", true, nil
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Summary
add an additional condition when judge exporting to StarRocks skippable
* whether the record of source and destination is equal or not

### Does this close any open issues?
Closes #6039

### Screenshots
N/A

### Other Information
N/A
