### PR TITLE
feat(webhook): plugin webhook's detail and list api can get api key info now

### DIFF
--- a/backend/core/models/api_key.go
+++ b/backend/core/models/api_key.go
@@ -28,15 +28,19 @@ type ApiKey struct {
 	common.Creator
 	common.Updater
 	Name        string     `json:"name"`
-	ApiKey      string     `json:"apiKey"`
+	ApiKey      string     `json:"apiKey,omitempty"`
 	ExpiredAt   *time.Time `json:"expiredAt"`
 	AllowedPath string     `json:"allowedPath"`
 	Type        string     `json:"type"`
 	Extra       string     `json:"extra"`
 }
 
-func (ApiKey) TableName() string {
+func (apiKey *ApiKey) TableName() string {
 	return "_devlake_api_keys"
+}
+
+func (apiKey *ApiKey) RemoveHashedApiKey() {
+	apiKey.ApiKey = ""
 }
 
 type ApiInputApiKey struct {

--- a/backend/helpers/apikeyhelper/apikeyhelper.go
+++ b/backend/helpers/apikeyhelper/apikeyhelper.go
@@ -205,6 +205,10 @@ func (c *ApiKeyHelper) GetApiKey(tx dal.Dal, additionalClauses ...dal.Clause) (*
 	return apiKey, err
 }
 
+func (c *ApiKeyHelper) GenApiKeyNameForPlugin(pluginName string, connectionId uint64) string {
+	return fmt.Sprintf("%s-%d", pluginName, connectionId)
+}
+
 func (c *ApiKeyHelper) generateApiKey() (apiKey string, hashedApiKey string, err errors.Error) {
 	apiKey, randomLetterErr := utils.RandLetterBytes(apiKeyLen)
 	if randomLetterErr != nil {

--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -203,6 +203,7 @@ func formatConnection(connection *models.WebhookConnection, withApiKeyInfo bool)
 			}
 		} else {
 			response.ApiKey = apiKey
+			response.ApiKey.RemoveHashedApiKey() // delete the hashed api key to reduce the attack surface.
 		}
 	}
 	return response, nil

--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
+	coreModels "github.com/apache/incubator-devlake/core/models"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/plugins/webhook/models"
 	"net/http"
@@ -32,7 +33,7 @@ import (
 // @Description Create webhook connection, example: {"name":"Webhook data connection name"}
 // @Tags plugins/webhook
 // @Param body body models.WebhookConnection true "json body"
-// @Success 200  {object} models.WebhookConnection
+// @Success 200  {object} WebhookConnectionResponse
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /plugins/webhook/connections [POST]
@@ -45,7 +46,7 @@ func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 		return nil, err
 	}
 	logger.Info("connection: %+v", connection)
-	name := fmt.Sprintf("%s-%d", pluginName, connection.ID)
+	name := apiKeyHelper.GenApiKeyNameForPlugin(pluginName, connection.ID)
 	allowedPath := fmt.Sprintf("/plugins/%s/connections/%d/.*", pluginName, connection.ID)
 	extra := fmt.Sprintf("connectionId:%d", connection.ID)
 	apiKeyRecord, err := apiKeyHelper.CreateForPlugin(tx, input.User, name, pluginName, allowedPath, extra)
@@ -60,13 +61,14 @@ func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 		logger.Info("transaction commit: %s", err)
 	}
 
-	apiOutputConnection := models.ApiOutputWebhookConnection{
-		WebhookConnection: *connection,
-		ApiKey:            apiKeyRecord,
+	webhookConnectionResponse, err := formatConnection(connection, false)
+	if err != nil {
+		return nil, err
 	}
-	logger.Info("api output connection: %+v", apiOutputConnection)
+	webhookConnectionResponse.ApiKey = apiKeyRecord
+	logger.Info("api output connection: %+v", webhookConnectionResponse)
 
-	return &plugin.ApiResourceOutput{Body: apiOutputConnection, Status: http.StatusOK}, nil
+	return &plugin.ApiResourceOutput{Body: webhookConnectionResponse, Status: http.StatusOK}, nil
 }
 
 // PatchConnection
@@ -129,18 +131,19 @@ func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput
 
 type WebhookConnectionResponse struct {
 	models.WebhookConnection
-	PostIssuesEndpoint             string `json:"postIssuesEndpoint"`
-	CloseIssuesEndpoint            string `json:"closeIssuesEndpoint"`
-	PostPipelineTaskEndpoint       string `json:"postPipelineTaskEndpoint"`
-	PostPipelineDeployTaskEndpoint string `json:"postPipelineDeployTaskEndpoint"`
-	ClosePipelineEndpoint          string `json:"closePipelineEndpoint"`
+	PostIssuesEndpoint             string             `json:"postIssuesEndpoint"`
+	CloseIssuesEndpoint            string             `json:"closeIssuesEndpoint"`
+	PostPipelineTaskEndpoint       string             `json:"postPipelineTaskEndpoint"`
+	PostPipelineDeployTaskEndpoint string             `json:"postPipelineDeployTaskEndpoint"`
+	ClosePipelineEndpoint          string             `json:"closePipelineEndpoint"`
+	ApiKey                         *coreModels.ApiKey `json:"apiKey,omitempty"`
 }
 
 // ListConnections
 // @Summary get all webhook connections
 // @Description Get all webhook connections
 // @Tags plugins/webhook
-// @Success 200  {object} []WebhookConnectionResponse
+// @Success 200  {object} []*WebhookConnectionResponse
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /plugins/webhook/connections [GET]
@@ -150,9 +153,13 @@ func ListConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 	if err != nil {
 		return nil, err
 	}
-	responseList := []WebhookConnectionResponse{}
+	var responseList []*WebhookConnectionResponse
 	for _, connection := range connections {
-		responseList = append(responseList, *formatConnection(&connection))
+		webhookConnectionResponse, err := formatConnection(&connection, true)
+		if err != nil {
+			return nil, err
+		}
+		responseList = append(responseList, webhookConnectionResponse)
 	}
 	return &plugin.ApiResourceOutput{Body: responseList, Status: http.StatusOK}, nil
 }
@@ -168,16 +175,35 @@ func ListConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 func GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	connection := &models.WebhookConnection{}
 	err := connectionHelper.First(connection, input.Params)
-	response := formatConnection(connection)
+	if err != nil {
+		logger.Error(err, "query connection")
+		return nil, err
+	}
+	response, err := formatConnection(connection, true)
 	return &plugin.ApiResourceOutput{Body: response}, err
 }
 
-func formatConnection(connection *models.WebhookConnection) *WebhookConnectionResponse {
+func formatConnection(connection *models.WebhookConnection, withApiKeyInfo bool) (*WebhookConnectionResponse, errors.Error) {
 	response := &WebhookConnectionResponse{WebhookConnection: *connection}
 	response.PostIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/issues`, connection.ID)
 	response.CloseIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/issue/:issueKey/close`, connection.ID)
 	response.PostPipelineTaskEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/cicd_tasks`, connection.ID)
 	response.PostPipelineDeployTaskEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/deployments`, connection.ID)
 	response.ClosePipelineEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/cicd_pipeline/:pipelineName/finish`, connection.ID)
-	return response
+	if withApiKeyInfo {
+		db := basicRes.GetDal()
+		apiKeyName := apiKeyHelper.GenApiKeyNameForPlugin(pluginName, connection.ID)
+		apiKey, err := apiKeyHelper.GetApiKey(db, dal.Where("name = ?", apiKeyName))
+		if err != nil {
+			if db.IsErrorNotFound(err) {
+				logger.Info("api key with name: %s not found in db", apiKeyName)
+			} else {
+				logger.Error(err, "query api key from db, name: %s", apiKeyName)
+				return nil, err
+			}
+		} else {
+			response.ApiKey = apiKey
+		}
+	}
+	return response, nil
 }

--- a/backend/plugins/webhook/api/init.go
+++ b/backend/plugins/webhook/api/init.go
@@ -38,10 +38,6 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 	basicRes = br
 	logger = basicRes.GetLogger()
 	vld = validator.New()
-	connectionHelper = api.NewConnectionHelper(
-		basicRes,
-		vld,
-		p.Name(),
-	)
+	connectionHelper = api.NewConnectionHelper(basicRes, vld, p.Name())
 	apiKeyHelper = apikeyhelper.NewApiKeyHelper(basicRes, logger)
 }

--- a/backend/plugins/webhook/models/connection.go
+++ b/backend/plugins/webhook/models/connection.go
@@ -18,14 +18,8 @@ limitations under the License.
 package models
 
 import (
-	"github.com/apache/incubator-devlake/core/models"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 )
-
-type ApiOutputWebhookConnection struct {
-	WebhookConnection `mapstructure:",squash"`
-	ApiKey            *models.ApiKey `json:"apiKey,omitempty"`
-}
 
 type WebhookConnection struct {
 	helper.BaseConnection `mapstructure:",squash"`

--- a/backend/server/services/apikeys.go
+++ b/backend/server/services/apikeys.go
@@ -57,7 +57,7 @@ func GetApiKeys(query *ApiKeysQuery) ([]*models.ApiKey, int64, errors.Error) {
 	if err != nil {
 		return nil, 0, errors.Default.Wrap(err, "error finding DB api key")
 	}
-	for idx, _ := range apiKeys {
+	for idx := range apiKeys {
 		apiKeys[idx].RemoveHashedApiKey() // delete the hashed api key to reduce the attack surface.
 	}
 

--- a/backend/server/services/apikeys.go
+++ b/backend/server/services/apikeys.go
@@ -57,6 +57,9 @@ func GetApiKeys(query *ApiKeysQuery) ([]*models.ApiKey, int64, errors.Error) {
 	if err != nil {
 		return nil, 0, errors.Default.Wrap(err, "error finding DB api key")
 	}
+	for idx, _ := range apiKeys {
+		apiKeys[idx].RemoveHashedApiKey() // delete the hashed api key to reduce the attack surface.
+	}
 
 	return apiKeys, count, nil
 }


### PR DESCRIPTION


### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. add ApiKey field for plugin webhook's list and detail APIs, in order to make it possible to regenerabe webhook's api key with the api `HTTP PUT/api-keys/:apiKeyId/`.
2. Simplify the response struct to make code less.
3. add fields `postIssuesEndpoint` `closeIssuesEndpoint` `postPipelineTaskEndpoint` `postPipelineDeployTaskEndpoint` `closePipelineEndpoint`  to help to simplify the front end codes.

### Does this close any open issues?
Closes xx


### Screenshots
Include any relevant screenshots here.
1.
<img width="1414" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/c310cb9e-822c-4645-b94a-f46f9ebd6f48">
<img width="1425" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/464e3c20-5cb8-4178-8a9c-139a49b66158">


3. 
<img width="1426" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/6e303d5a-829c-471a-a37e-d4468abbaa74">



### Other Information
Any other information that is important to this PR.
