### PR TITLE
fix(zentao): fix null started_date fields in sprints table

### DIFF
--- a/backend/plugins/zentao/e2e/snapshot_tables/execution_sprint.csv
+++ b/backend/plugins/zentao/e2e/snapshot_tables/execution_sprint.csv
@@ -5,5 +5,5 @@ zentao:ZentaoExecution:1:194,新建一个迭代，完成之后检查sprints表,h
 zentao:ZentaoExecution:1:266,新建迭代然后关闭,https://zentao.demo.haogs.cn/execution-view-266.html,CLOSED,2023-09-07T00:00:00.000+00:00,2023-09-13T00:00:00.000+00:00,2023-09-07T02:15:31.000+00:00,zentao:ZentaoProject:1:192
 zentao:ZentaoExecution:1:267,建一个计划未来开始迭代,https://zentao.demo.haogs.cn/execution-view-267.html,FUTURE,2023-09-09T00:00:00.000+00:00,2023-09-22T00:00:00.000+00:00,,zentao:ZentaoProject:1:192
 zentao:ZentaoExecution:1:268,起始-截止都是结束时间,https://zentao.demo.haogs.cn/execution-view-268.html,FUTURE,2023-09-04T00:00:00.000+00:00,2023-09-05T00:00:00.000+00:00,,zentao:ZentaoProject:1:192
-zentao:ZentaoExecution:1:269,把迭代挂起,https://zentao.demo.haogs.cn/execution-view-269.html,SUSPENDED,,2023-09-20T00:00:00.000+00:00,,zentao:ZentaoProject:1:192
+zentao:ZentaoExecution:1:269,把迭代挂起,https://zentao.demo.haogs.cn/execution-view-269.html,SUSPENDED,2023-09-07T00:00:00.000+00:00,2023-09-20T00:00:00.000+00:00,,zentao:ZentaoProject:1:192
 zentao:ZentaoExecution:1:270,流程扭转--挂起迭代2,https://zentao.demo.haogs.cn/execution-view-270.html,SUSPENDED,2023-09-07T00:00:00.000+00:00,2023-09-20T00:00:00.000+00:00,,zentao:ZentaoProject:1:192

--- a/backend/plugins/zentao/tasks/execution_convertor.go
+++ b/backend/plugins/zentao/tasks/execution_convertor.go
@@ -93,15 +93,14 @@ func ConvertExecutions(taskCtx plugin.SubTaskContext) errors.Error {
 				Name:            toolExecution.Name,
 				Url:             fmt.Sprintf("%s/execution-view-%d.html", homePage, toolExecution.Id),
 				Status:          domainStatus,
+				StartedDate:     toolExecution.RealBegan.ToNullableTime(),
 				EndedDate:       toolExecution.PlanEnd.ToNullableTime(),
 				CompletedDate:   toolExecution.ClosedDate.ToNullableTime(),
 				OriginalBoardID: projectIdGen.Generate(toolExecution.ConnectionId, data.Options.ProjectId),
 			}
 
-			if domainStatus == `FUTURE` || domainStatus == `` {
+			if sprint.StartedDate == nil {
 				sprint.StartedDate = toolExecution.PlanBegin.ToNullableTime()
-			} else {
-				sprint.StartedDate = toolExecution.RealBegan.ToNullableTime()
 			}
 
 			boardSprint := &ticket.BoardSprint{


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
When zentao sprints' status is "SUSPENED",  the started_date field will be null. And some other status will cause this situation. So we use sprints'  `real start date`, if it is null, then we use `plan start date`.

### Does this close any open issues?
Closes #6030 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
