### PR TITLE
fix(zentao): remove unused change field

### DIFF
--- a/backend/plugins/zentao/models/bug_commits.go
+++ b/backend/plugins/zentao/models/bug_commits.go
@@ -72,9 +72,7 @@ type ZentaoBugRepoCommitsRes struct {
 		Committer string `json:"committer"`
 		Time      string `json:"time"`
 		Comment   string `json:"comment"`
-		Change    struct {
-		} `json:"change"`
-		Commit string `json:"commit"`
+		Commit    string `json:"commit"`
 	} `json:"log"`
 	Repo struct {
 		ID                 string `json:"id"`

--- a/backend/plugins/zentao/models/story_commits.go
+++ b/backend/plugins/zentao/models/story_commits.go
@@ -72,9 +72,7 @@ type ZentaoStoryRepoCommitsRes struct {
 		Committer string `json:"committer"`
 		Time      string `json:"time"`
 		Comment   string `json:"comment"`
-		Change    struct {
-		} `json:"change"`
-		Commit string `json:"commit"`
+		Commit    string `json:"commit"`
 	} `json:"log"`
 	Repo struct {
 		ID                 string `json:"id"`

--- a/backend/plugins/zentao/models/task_commits.go
+++ b/backend/plugins/zentao/models/task_commits.go
@@ -72,9 +72,7 @@ type ZentaoTaskRepoCommitsRes struct {
 		Committer string `json:"committer"`
 		Time      string `json:"time"`
 		Comment   string `json:"comment"`
-		Change    struct {
-		} `json:"change"`
-		Commit string `json:"commit"`
+		Commit    string `json:"commit"`
 	} `json:"log"`
 	Repo struct {
 		ID                 string `json:"id"`


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Remove unused field to avoid error like this:
<img width="1920" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/cd580876-1e95-45f7-b565-514e6619be44">

Because change field is a map like this
```
"change":
        {
            "/testLink616X.py":
            {
                "action": "A",
                "kind": "file",
                "oldPath": "/testLink616X.py"
            }
        },
```
So  json unmarshal will fail.

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
