### PR TITLE
cherry-pick: implement ApiClient reuse in RemoteApiHelper

### DIFF
--- a/backend/core/plugin/plugin_connection_abstract.go
+++ b/backend/core/plugin/plugin_connection_abstract.go
@@ -18,10 +18,11 @@ limitations under the License.
 package plugin
 
 import (
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api/apihelperabstract"
 	"github.com/go-playground/validator/v10"
-	"net/http"
 )
 
 // ApiConnection represents a API Connection
@@ -29,6 +30,11 @@ type ApiConnection interface {
 	GetEndpoint() string
 	GetProxy() string
 	GetRateLimitPerHour() int
+}
+
+type CacheableConnection interface {
+	ApiConnection
+	GetHash() string
 }
 
 // ApiAuthenticator is to be implemented by a Concreate Connection if Authorization is required

--- a/backend/helpers/pluginhelper/api/connection.go
+++ b/backend/helpers/pluginhelper/api/connection.go
@@ -18,6 +18,7 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/apache/incubator-devlake/core/models/common"
@@ -27,6 +28,10 @@ import (
 type BaseConnection struct {
 	Name string `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
 	common.Model
+}
+
+func (c BaseConnection) GetHash() string {
+	return fmt.Sprintf("%d%v", c.ID, c.UpdatedAt)
 }
 
 // RestConnection implements the ApiConnection interface

--- a/backend/plugins/gitlab/api/proxy.go
+++ b/backend/plugins/gitlab/api/proxy.go
@@ -18,14 +18,10 @@ limitations under the License.
 package api
 
 import (
-	"context"
-	"encoding/json"
-	"io"
 	"time"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
-	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 )
 
@@ -39,26 +35,5 @@ func Proxy(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Er
 	if err != nil {
 		return nil, err
 	}
-	apiClient, err := helper.NewApiClientFromConnection(context.TODO(), basicRes, connection)
-	if err != nil {
-		return nil, err
-	}
-
-	resp, err := apiClient.Get(input.Params["path"], input.Query, nil)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := errors.Convert01(io.ReadAll(resp.Body))
-	if err != nil {
-		return nil, err
-	}
-	// verify response body is json
-	var tmp interface{}
-	err = errors.Convert(json.Unmarshal(body, &tmp))
-	if err != nil {
-		return nil, err
-	}
-	return &plugin.ApiResourceOutput{Status: resp.StatusCode, Body: json.RawMessage(body)}, nil
+	return remoteHelper.ProxyApiGet(connection, input.Params["path"], input.Query)
 }

--- a/backend/plugins/gitlab/tasks/pipeline_extractor.go
+++ b/backend/plugins/gitlab/tasks/pipeline_extractor.go
@@ -106,7 +106,7 @@ func ExtractApiPipelines(taskCtx plugin.SubTaskContext) errors.Error {
 				IsDetailRequired: false,
 			}
 
-			if gitlabApiPipeline.CreatedAt == nil && gitlabApiPipeline.UpdatedAt == nil {
+			if gitlabApiPipeline.StartedAt == nil && gitlabApiPipeline.FinishedAt == nil {
 				gitlabPipeline.IsDetailRequired = true
 			}
 

--- a/backend/plugins/sonarqube/models/connection.go
+++ b/backend/plugins/sonarqube/models/connection.go
@@ -20,10 +20,11 @@ package models
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"net/http"
 )
 
 type SonarqubeAccessToken helper.AccessToken
@@ -43,17 +44,16 @@ func (sat SonarqubeAccessToken) GetEncodedToken() string {
 	return base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:", sat.Token)))
 }
 
-// This object conforms to what the frontend currently sends.
-type SonarqubeConnection struct {
-	helper.BaseConnection `mapstructure:",squash"`
-	helper.RestConnection `mapstructure:",squash"`
-	SonarqubeAccessToken  `mapstructure:",squash"`
-}
-
 // SonarqubeConn holds the essential information to connect to the sonarqube API
 type SonarqubeConn struct {
 	helper.RestConnection `mapstructure:",squash"`
 	SonarqubeAccessToken  `mapstructure:",squash"`
+}
+
+// This object conforms to what the frontend currently sends.
+type SonarqubeConnection struct {
+	helper.BaseConnection `mapstructure:",squash"`
+	SonarqubeConn         `mapstructure:",squash"`
 }
 
 // This object conforms to what the frontend currently expects.


### PR DESCRIPTION
### Summary

The following two PR was merge on release-0.18 first as main branch was broken, now need to cherry-pick back to main branch:

https://github.com/apache/incubator-devlake/pull/6025
https://github.com/apache/incubator-devlake/pull/6032


### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
