### PR TITLE
fix(zentao): update zentao project's progres field's type, make it mo…

### DIFF
--- a/backend/plugins/zentao/api/init.go
+++ b/backend/plugins/zentao/api/init.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/log"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/zentao/models"
@@ -30,6 +31,7 @@ type MixScopes struct {
 	ZentaoProject *models.ZentaoProject `json:"project"`
 }
 
+var logger log.Logger
 var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var projectScopeHelper *api.ScopeApiHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoScopeConfig]
@@ -41,12 +43,9 @@ var scHelper *api.ScopeConfigHelper[models.ZentaoScopeConfig]
 func Init(br context.BasicRes, p plugin.PluginMeta) {
 
 	basicRes = br
+	logger = basicRes.GetLogger()
 	vld = validator.New()
-	connectionHelper = api.NewConnectionHelper(
-		basicRes,
-		vld,
-		p.Name(),
-	)
+	connectionHelper = api.NewConnectionHelper(basicRes, vld, p.Name())
 
 	projectParams := &api.ReflectionParameters{
 		ScopeIdFieldName:     "Id",
@@ -64,14 +63,6 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		nil,
 	)
 
-	projectRemoteHelper = api.NewRemoteHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.BaseRemoteGroupResponse](
-		basicRes,
-		vld,
-		connectionHelper,
-	)
-	scHelper = api.NewScopeConfigHelper[models.ZentaoScopeConfig](
-		basicRes,
-		vld,
-		p.Name(),
-	)
+	projectRemoteHelper = api.NewRemoteHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.BaseRemoteGroupResponse](basicRes, vld, connectionHelper)
+	scHelper = api.NewScopeConfigHelper[models.ZentaoScopeConfig](basicRes, vld, p.Name())
 }

--- a/backend/plugins/zentao/api/remote.go
+++ b/backend/plugins/zentao/api/remote.go
@@ -90,12 +90,14 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 				// list projects part
 				res, err := apiClient.Get("/projects", query, nil)
 				if err != nil {
+					logger.Error(err, "call projects api")
 					return nil, err
 				}
 
 				resBody := &ProjectResponse{}
 				err = api.UnmarshalResponse(res, resBody)
 				if err != nil {
+					logger.Error(err, "unmarshal projects response")
 					return nil, err
 				}
 

--- a/backend/plugins/zentao/models/project.go
+++ b/backend/plugins/zentao/models/project.go
@@ -19,6 +19,7 @@ package models
 
 import (
 	"fmt"
+	"github.com/spf13/cast"
 	"strconv"
 
 	"github.com/apache/incubator-devlake/core/models/common"
@@ -88,12 +89,13 @@ type ZentaoProject struct {
 	TeamCount      int    `json:"teamCount" mapstructure:"teamCount"`
 	LeftTasks      string `json:"leftTasks" mapstructure:"leftTasks"`
 	//TeamMembers   []interface{} `json:"teamMembers" gorm:"-"`
-	TotalEstimate float64 `json:"totalEstimate" mapstructure:"totalEstimate"`
-	TotalConsumed float64 `json:"totalConsumed" mapstructure:"totalConsumed"`
-	TotalLeft     float64 `json:"totalLeft" mapstructure:"totalLeft"`
-	Progress      float64 `json:"progress" mapstructure:"progress"`
-	ScopeConfigId uint64  `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId"`
+	TotalEstimate float64     `json:"totalEstimate" mapstructure:"totalEstimate"`
+	TotalConsumed float64     `json:"totalConsumed" mapstructure:"totalConsumed"`
+	TotalLeft     float64     `json:"totalLeft" mapstructure:"totalLeft"`
+	Progress      interface{} `json:"progress" mapstructure:"progress"`
+	ScopeConfigId uint64      `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId"`
 }
+
 type PM struct {
 	PmId       int64  `json:"id" mapstructure:"id"`
 	PmAccount  string `json:"account" mapstructure:"account"`
@@ -114,7 +116,11 @@ type Hours struct {
 	HoursTotalReal     float64 `json:"totalReal" mapstructure:"totalReal"`
 }
 
-func (p *ZentaoProject) ConvertFix() {
+func (p *ZentaoProject) fixProgressField() {
+	p.Progress = cast.ToFloat64(p.Progress)
+}
+
+func (p *ZentaoProject) fixClosedByResField() {
 	switch cb := p.ClosedByRes.(type) {
 	case string:
 		p.ClosedBy = cb
@@ -126,7 +132,9 @@ func (p *ZentaoProject) ConvertFix() {
 		}
 	}
 	p.ClosedByRes = p.ClosedBy
+}
 
+func (p *ZentaoProject) fixCanceledByResField() {
 	switch cb := p.CanceledByRes.(type) {
 	case string:
 		p.CanceledBy = cb
@@ -140,7 +148,13 @@ func (p *ZentaoProject) ConvertFix() {
 	p.CanceledByRes = p.CanceledBy
 }
 
-func (ZentaoProject) TableName() string {
+func (p *ZentaoProject) ConvertFix() {
+	p.fixProgressField()
+	p.fixClosedByResField()
+	p.fixCanceledByResField()
+}
+
+func (p ZentaoProject) TableName() string {
 	return "_tool_zentao_projects"
 }
 


### PR DESCRIPTION
…re cpmpatible with zentao 18.1

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
With Zentao version 18.1, the `/projects` API returns `progress` field whose type is string. But devlake take it as float64, so an error occured. Users will get an error log like this:
<img width="934" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/28379094-9462-407d-8336-d4b5ea9934f5">

And devlake's backend API returns HTTP 500 to Config UI.

This PR fix the zentao project structure, so it can work with zentao 18.1.


### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
