### PR TITLE
fix(zentao): fix progress field when configurating scopes

### DIFF
--- a/backend/plugins/zentao/models/project.go
+++ b/backend/plugins/zentao/models/project.go
@@ -89,10 +89,11 @@ type ZentaoProject struct {
 	TeamCount      int    `json:"teamCount" mapstructure:"teamCount"`
 	LeftTasks      string `json:"leftTasks" mapstructure:"leftTasks"`
 	//TeamMembers   []interface{} `json:"teamMembers" gorm:"-"`
-	TotalEstimate float64     `json:"totalEstimate" mapstructure:"totalEstimate"`
-	TotalConsumed float64     `json:"totalConsumed" mapstructure:"totalConsumed"`
-	TotalLeft     float64     `json:"totalLeft" mapstructure:"totalLeft"`
-	Progress      interface{} `json:"progress" mapstructure:"progress"`
+	TotalEstimate float64 `json:"totalEstimate" mapstructure:"totalEstimate"`
+	TotalConsumed float64 `json:"totalConsumed" mapstructure:"totalConsumed"`
+	TotalLeft     float64 `json:"totalLeft" mapstructure:"totalLeft"`
+	Progress      float64
+	ProgressRes   interface{} `json:"progress" mapstructure:"progress" gorm:"-"`
 	ScopeConfigId uint64      `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId"`
 }
 
@@ -117,7 +118,7 @@ type Hours struct {
 }
 
 func (p *ZentaoProject) fixProgressField() {
-	p.Progress = cast.ToFloat64(p.Progress)
+	p.Progress = cast.ToFloat64(p.ProgressRes)
 }
 
 func (p *ZentaoProject) fixClosedByResField() {


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
The `progress` field in response of zentao's api is a string or a float, so make we need a progressRes field to receive this field and convert it into progress(float64), otherwise error will occur when it is stored to database.

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
