### PR TITLE
fix(bamboo): update migration script's name, avoid runtime error

### DIFF
--- a/backend/core/models/migrationscripts/20230831_add_cicd_deployments_table.go
+++ b/backend/core/models/migrationscripts/20230831_add_cicd_deployments_table.go
@@ -57,7 +57,7 @@ func (*addCICDDeploymentsTable) Up(basicRes context.BasicRes) errors.Error {
 }
 
 func (*addCICDDeploymentsTable) Version() uint64 {
-	return 202307831162403
+	return 20230831162403
 }
 
 func (*addCICDDeploymentsTable) Name() string {

--- a/backend/plugins/bamboo/models/migrationscripts/20230920_rename_raw_tables.go
+++ b/backend/plugins/bamboo/models/migrationscripts/20230920_rename_raw_tables.go
@@ -51,9 +51,5 @@ func (*renameMultiBambooRawTables20230920) Version() uint64 {
 }
 
 func (*renameMultiBambooRawTables20230920) Name() string {
-	return "rename _raw_bamboo_api_deploy_build to _raw_bamboo_api_deploy_builds," +
-		" _raw_bamboo_api_deploy to _raw_bamboo_api_deploys," +
-		" _raw_bamboo_api_job_build to _raw_bamboo_api_job_builds," +
-		" _raw_bamboo_api_job to _raw_bamboo_api_jobs," +
-		" _raw_bamboo_api_plan_build to _raw_bamboo_api_plan_builds"
+	return "rename raw tables' name to their plural form"
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Migration script's `Name` method will return its name, but the database colum's type is varchar(255), so it cannot be too long, this PR just fixes it.

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
