### PR TITLE
ClickUp Support

### DIFF
--- a/backend/plugins/clickup/README.md
+++ b/backend/plugins/clickup/README.md
@@ -1,0 +1,32 @@
+ClickUp
+=======
+
+Implementation
+--------------
+
+- Spaces are mapped as "scopes".
+- Folders are not *currently* supported.
+
+Current Requirements
+--------------------
+
+### Bug and Incident Tracking
+
+- Add a custom `DropDown` field called `type` in ClickUp
+- Add at least options for `Bug` and `Incident`
+
+Manual Testing
+--------------
+
+The backend plugin can be run directly for development purposes:
+
+```
+go run ./plugins/clickup/clickup.go -c<connection id> -s<scope id>
+```
+
+Where connection ID is the ID of a `_tools_clickup_connections` (configured
+via. the GUI) and `scope id` is the space ID. For example:
+
+```
+./plugins/clickup/clickup.go -c1 -s90060207111
+```

--- a/backend/plugins/clickup/api/api_model.go
+++ b/backend/plugins/clickup/api/api_model.go
@@ -1,0 +1,6 @@
+package api
+
+type ClickupSpace struct {
+	Id   string
+	Name string
+}

--- a/backend/plugins/clickup/api/blueprint_v200.go
+++ b/backend/plugins/clickup/api/blueprint_v200.go
@@ -1,0 +1,91 @@
+package api
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/core/utils"
+
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+
+	"github.com/apache/incubator-devlake/core/errors"
+
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+func MakePipelinePlanV200(subtaskMetas []plugin.SubTaskMeta, connectionId uint64, scope []*plugin.BlueprintScopeV200, syncPolicy *plugin.BlueprintSyncPolicy) (plugin.PipelinePlan, []plugin.Scope, errors.Error) {
+	scopes, err := makeScopeV200(connectionId, scope)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	plan := make(plugin.PipelinePlan, len(scope))
+	plan, err = makePipelinePlanV200(subtaskMetas, plan, scope, connectionId, syncPolicy)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return plan, scopes, nil
+}
+
+func makeScopeV200(connectionId uint64, scopes []*plugin.BlueprintScopeV200) ([]plugin.Scope, errors.Error) {
+	sc := make([]plugin.Scope, 0, len(scopes))
+
+	for _, scope := range scopes {
+		id := didgen.NewDomainIdGenerator(&models.ClickUpSpace{}).Generate(connectionId, scope.Id)
+		clickupSpace := &models.ClickUpSpace{}
+
+		// get space from db
+		err := basicRes.GetDal().First(clickupSpace,
+			dal.Where(`connection_id = ? and id = ?`,
+				connectionId, scope.Id))
+		if err != nil {
+			return nil, errors.Default.Wrap(err, fmt.Sprintf("fail to find space %s", scope.Id))
+		}
+
+		// add board to scopes
+		if utils.StringsContains(scope.Entities, plugin.DOMAIN_TYPE_TICKET) {
+			scopeTicket := ticket.NewBoard(id, clickupSpace.Name)
+
+			sc = append(sc, scopeTicket)
+		}
+	}
+
+	return sc, nil
+}
+
+func makePipelinePlanV200(subtaskMetas []plugin.SubTaskMeta, plan plugin.PipelinePlan, scopes []*plugin.BlueprintScopeV200, connectionId uint64, syncPolicy *plugin.BlueprintSyncPolicy) (plugin.PipelinePlan, errors.Error) {
+	for i, scope := range scopes {
+		stage := plan[i]
+		if stage == nil {
+			stage = plugin.PipelineStage{}
+		}
+
+		// construct task options for clickup
+		options := make(map[string]interface{})
+		options["connectionId"] = connectionId
+		options["scopeId"] = scope.Id
+		if syncPolicy.TimeAfter != nil {
+			options["createdDateAfter"] = syncPolicy.TimeAfter.Format(time.RFC3339)
+		}
+
+		// construct subtasks
+		subtasks, err := helper.MakePipelinePlanSubtasks(subtaskMetas, scope.Entities)
+		if err != nil {
+			return nil, err
+		}
+
+		stage = append(stage, &plugin.PipelineTask{
+			Plugin:   "clickup",
+			Subtasks: subtasks,
+			Options:  options,
+		})
+
+		plan[i] = stage
+	}
+	return plan, nil
+}

--- a/backend/plugins/clickup/api/connection.go
+++ b/backend/plugins/clickup/api/connection.go
@@ -1,0 +1,170 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/server/api/shared"
+
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+type ClickupTestConnResponse struct {
+	shared.ApiBody
+	Connection *models.TestConnectionRequest
+}
+
+// @Summary test clickup connection
+// @Description Test clickup Connection. endpoint: "https://dev.clickup.com/{organization}/
+// @Tags plugins/clickup
+// @Param body body models.TestConnectionRequest true "json body"
+// @Success 200  {object} ClickupTestConnResponse "Success"
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/clickup/test [POST]
+func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	// decode
+	var err errors.Error
+	var connection models.TestConnectionRequest
+	if err = helper.Decode(input.Body, &connection, vld); err != nil {
+		return nil, err
+	}
+	// test connection
+	apiClient, err := api.NewApiClient(
+		context.TODO(),
+		connection.Endpoint,
+		map[string]string{
+			"Authorization": connection.Token,
+		},
+		3*time.Second,
+		connection.Proxy,
+		basicRes,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := apiClient.Get("v2/team", nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	resBody := &models.ApiUserResponse{}
+	err = helper.UnmarshalResponse(res, resBody)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, errors.HttpStatus(res.StatusCode).New(fmt.Sprintf("unexpected status code: %d", res.StatusCode))
+	}
+	body := ClickupTestConnResponse{}
+	body.Success = true
+	body.Message = "success"
+	body.Connection = &connection
+	// output
+	return &plugin.ApiResourceOutput{Body: body, Status: 200}, nil
+}
+
+// @Summary create clickup connection
+// @Description Create clickup connection
+// @Tags plugins/clickup
+// @Param body body models.ClickupConnection true "json body"
+// @Success 200  {object} models.ClickupConnection
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/clickup/connections [POST]
+func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	// update from request and save to database
+	connection := &models.ClickupConnection{}
+	err := connectionHelper.Create(connection, input)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connection, Status: http.StatusOK}, nil
+}
+
+// @Summary patch clickup connection
+// @Description Patch clickup connection
+// @Tags plugins/clickup
+// @Param body body models.ClickupConnection true "json body"
+// @Success 200  {object} models.ClickupConnection
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/clickup/connections/{connectionId} [PATCH]
+func PatchConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.ClickupConnection{}
+	err := connectionHelper.Patch(connection, input)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connection}, nil
+}
+
+// @Summary delete a clickup connection
+// @Description Delete a clickup connection
+// @Tags plugins/clickup
+// @Success 200  {object} models.ClickupConnection
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/clickup/connections/{connectionId} [DELETE]
+func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.ClickupConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	if err != nil {
+		return nil, err
+	}
+	err = connectionHelper.Delete(connection)
+	return &plugin.ApiResourceOutput{Body: connection}, err
+}
+
+// @Summary get all clickup connections
+// @Description Get all clickup connections
+// @Tags plugins/clickup
+// @Success 200  {object} []models.ClickupConnection
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/clickup/connections [GET]
+func ListConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	var connections []models.ClickupConnection
+	err := connectionHelper.List(&connections)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connections, Status: http.StatusOK}, nil
+}
+
+// @Summary get clickup connection detail
+// @Description Get clickup connection detail
+// @Tags plugins/clickup
+// @Success 200  {object} models.ClickupConnection
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /plugins/clickup/connections/{connectionId} [GET]
+func GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.ClickupConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	return &plugin.ApiResourceOutput{Body: connection}, err
+}

--- a/backend/plugins/clickup/api/init.go
+++ b/backend/plugins/clickup/api/init.go
@@ -1,0 +1,45 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+	"github.com/go-playground/validator/v10"
+)
+
+var vld *validator.Validate
+var connectionHelper *helper.ConnectionApiHelper
+var basicRes context.BasicRes
+var scopeHelper *api.ScopeApiHelper[models.ClickupConnection, models.ClickUpSpace, models.ClickUpTransformationRule]
+
+func Init(br context.BasicRes) {
+	basicRes = br
+	vld = validator.New()
+	connectionHelper = helper.NewConnectionHelper(
+		basicRes,
+		vld,
+	)
+	scopeHelper = api.NewScopeHelper[models.ClickupConnection, models.ClickUpSpace, models.ClickUpTransformationRule](
+		basicRes,
+		vld,
+		connectionHelper,
+	)
+}

--- a/backend/plugins/clickup/api/remote.go
+++ b/backend/plugins/clickup/api/remote.go
@@ -1,0 +1,147 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+// RemoteScopes list all available scopes (services) for this connection
+// @Summary list all available scopes (services) for this connection
+// @Description list all available scopes (services) for this connection
+// @Tags plugins/pagerduty
+// @Accept application/json
+// @Param connectionId path int false "connection ID"
+// @Param groupId query string false "group ID"
+// @Param pageToken query string false "page Token"
+// @Success 200  {object} api.RemoteScopesOutput
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/pagerduty/connections/{connectionId}/remote-scopes [GET]
+func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connectionId, _ := strconv.ParseUint(input.Params["connectionId"], 10, 64)
+	if connectionId == 0 {
+		return nil, errors.BadInput.New("invalid connectionId")
+	}
+
+	connection := &models.ClickupConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	if err != nil {
+		return nil, err
+	}
+
+	// create api client
+	apiClient, err := api.NewApiClientFromConnection(context.TODO(), basicRes, connection)
+	if err != nil {
+		return nil, err
+	}
+
+	var res *http.Response
+	path := fmt.Sprintf("/v2/team/%s/space", connection.TeamId)
+	res, err = apiClient.Get(path, nil, nil)
+	if res.StatusCode != 200 {
+		return nil, errors.Default.New(fmt.Sprintf("Got %d code for %s", res.StatusCode, path))
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	response := &struct{ Spaces []ClickupSpace }{
+		Spaces: []ClickupSpace{},
+	}
+	err = api.UnmarshalResponse(res, response)
+	if err != nil {
+		return nil, err
+	}
+
+	outputBody := &api.RemoteScopesOutput{
+		Children:      []api.RemoteScopesChild{},
+		NextPageToken: "",
+	}
+	// append service to output
+	for _, service := range response.Spaces {
+		child := api.RemoteScopesChild{
+			Type:     "scope",
+			ParentId: nil,
+			Id:       service.Id,
+			Name:     service.Name,
+			Data: models.ClickUpSpace{
+				Id:   service.Id,
+				Name: service.Name,
+			},
+		}
+		outputBody.Children = append(outputBody.Children, child)
+	}
+
+	return &plugin.ApiResourceOutput{Body: outputBody, Status: http.StatusOK}, nil
+}
+
+// GetScopeList get clickUp spaces
+// @Summary get clickUp boards
+// @Description get clickUp boards
+// @Tags plugins/clickUp
+// @Param connectionId path int false "connection ID"
+// @Param pageSize query int false "page size, default 50"
+// @Param page query int false "page size, default 1"
+// @Success 200  {object} []ScopeRes
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/clickUp/connections/{connectionId}/scopes/ [GET]
+func GetScopeList(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	return scopeHelper.GetScopeList(input)
+}
+
+type ScopeReq api.ScopeReq[models.ClickUpSpace]
+
+// PutScope create or update clickUp board
+// @Summary create or update clickUp board
+// @Description Create or update clickUp board
+// @Tags plugins/clickUp
+// @Accept application/json
+// @Param connectionId path int false "connection ID"
+// @Param scope body ScopeReq true "json"
+// @Success 200  {object} []models.ClickUpSpace
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/clickUp/connections/{connectionId}/scopes [PUT]
+func PutScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	return scopeHelper.Put(input)
+}
+
+// GetScope get one Gitlab project
+// @Summary get one Gitlab project
+// @Description get one Gitlab project
+// @Tags plugins/clickup
+// @Param connectionId path int false "connection ID"
+// @Param scopeId path int false "project ID"
+// @Param pageSize query int false "page size, default 50"
+// @Param page query int false "page size, default 1"
+// @Success 200  {object} ScopeRes
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/clickup/connections/{connectionId}/scopes/{scopeId} [GET]
+func GetScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	return scopeHelper.GetScope(input, "id")
+}
+
+// UpdateScope patch to clickup project
+// @Summary patch to clickup project
+// @Description patch to clickup project
+// @Tags plugins/clickup
+// @Accept application/json
+// @Param connectionId path int false "connection ID"
+// @Param scopeId path int false "project ID"
+// @Param scope body models.GitlabProject true "json"
+// @Success 200  {object} models.GitlabProject
+// @Failure 400  {object} shared.ApiBody "Bad Request"
+// @Failure 500  {object} shared.ApiBody "Internal Error"
+// @Router /plugins/clickup/connections/{connectionId}/scopes/{scopeId} [PATCH]
+func UpdateScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	return scopeHelper.Update(input, "id")
+}

--- a/backend/plugins/clickup/clickup.go
+++ b/backend/plugins/clickup/clickup.go
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/apache/incubator-devlake/core/runner"
+	"github.com/apache/incubator-devlake/plugins/clickup/impl"
+	"github.com/spf13/cobra"
+)
+
+// Export a variable named PluginEntry for Framework to search and load
+var PluginEntry impl.Clickup //nolint
+
+// standalone mode for debugging
+func main() {
+	cmd := &cobra.Command{Use: "clickup"}
+
+	connectionId := cmd.Flags().Uint64P("connection", "c", 0, "clickup connection id")
+	scopeId := cmd.Flags().StringP("scope", "s", "", "scope id")
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		runner.DirectRun(cmd, args, PluginEntry, map[string]interface{}{
+			"connectionId": *connectionId,
+			"scopeId":      *scopeId,
+		})
+	}
+	runner.RunCmd(cmd)
+}

--- a/backend/plugins/clickup/impl/impl.go
+++ b/backend/plugins/clickup/impl/impl.go
@@ -1,0 +1,165 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package impl
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+	"github.com/apache/incubator-devlake/plugins/clickup/models/migrationscripts"
+	"github.com/apache/incubator-devlake/plugins/clickup/tasks"
+)
+
+// make sure interface is implemented
+var _ plugin.PluginMeta = (*Clickup)(nil)
+var _ plugin.PluginInit = (*Clickup)(nil)
+var _ plugin.PluginTask = (*Clickup)(nil)
+var _ plugin.PluginApi = (*Clickup)(nil)
+var _ plugin.CloseablePluginTask = (*Clickup)(nil)
+var _ plugin.DataSourcePluginBlueprintV200 = (*Clickup)(nil)
+
+type Clickup struct{}
+
+func (p Clickup) Description() string {
+	return "collect some Clickup data"
+}
+
+func (p Clickup) Init(br context.BasicRes) errors.Error {
+	api.Init(br)
+	return nil
+}
+
+func (p Clickup) SubTaskMetas() []plugin.SubTaskMeta {
+	return []plugin.SubTaskMeta{
+		tasks.CollectUserMeta,
+		tasks.ExtractUserMeta,
+		tasks.ConvertUsersMeta,
+		tasks.CollectIssueMeta,
+		tasks.ExtractIssueMeta,
+		tasks.ConvertIssuesMeta,
+		tasks.CollectFolderMeta,
+		tasks.ExtractFolderMeta,
+		tasks.CollectFolderlessListMeta,
+		tasks.ExtractFolderlessListMeta,
+		tasks.ConvertSprintsMeta,
+		tasks.ConvertSprintIssuesMeta,
+		tasks.CollectTaskTimeInStatusMeta,
+		tasks.ExtractTaskTimeInStatusMeta,
+	}
+}
+
+func (p Clickup) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]interface{}) (interface{}, errors.Error) {
+	var op tasks.ClickupOptions
+	var err errors.Error
+	// db := taskCtx.GetDal()
+	logger := taskCtx.GetLogger()
+	logger.Debug(fmt.Sprintf("Preparing ClickUp task data with options: %v", op))
+	err = helper.Decode(options, &op, nil)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "could not decode ClickUp options")
+	}
+	if op.ConnectionId == 0 {
+		return nil, errors.BadInput.New("ClickUp connectionId is empty")
+	}
+	connection := &models.ClickupConnection{}
+	connectionHelper := helper.NewConnectionHelper(
+		taskCtx,
+		nil,
+	)
+	err = connectionHelper.FirstById(connection, op.ConnectionId)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "unable to get clickup connection")
+	}
+	apiClient, err := tasks.NewClickupApiClient(taskCtx, connection)
+	if err != nil {
+		return nil, errors.Default.Wrap(err, "unable to get Clickup API client instance")
+	}
+	taskData := &tasks.ClickupTaskData{
+		Options:   &op,
+		ApiClient: apiClient,
+		TeamId:    connection.TeamId,
+	}
+	var createdDateAfter time.Time
+	if op.CreatedDateAfter != "" {
+		createdDateAfter, err = errors.Convert01(time.Parse(time.RFC3339, op.CreatedDateAfter))
+		if err != nil {
+			return nil, errors.BadInput.Wrap(err, "invalid value for `createdDateAfter`")
+		}
+	}
+	if !createdDateAfter.IsZero() {
+		taskData.CreatedDateAfter = &createdDateAfter
+		logger.Debug("collect data updated createdDateAfter %s", createdDateAfter)
+	}
+	return taskData, nil
+}
+
+// PkgPath information lost when compiled as plugin(.so)
+func (p Clickup) RootPkgPath() string {
+	return "github.com/apache/incubator-devlake/plugins/clickup"
+}
+
+func (p Clickup) MigrationScripts() []plugin.MigrationScript {
+	return migrationscripts.All()
+}
+
+func (p Clickup) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
+	return map[string]map[string]plugin.ApiResourceHandler{
+		"test": {
+			"POST": api.TestConnection,
+		},
+		"connections": {
+			"POST": api.PostConnections,
+			"GET":  api.ListConnections,
+		},
+		"connections/:connectionId": {
+			"GET":    api.GetConnection,
+			"PATCH":  api.PatchConnection,
+			"DELETE": api.DeleteConnection,
+		},
+		"connections/:connectionId/remote-scopes": {
+			"GET": api.RemoteScopes,
+		},
+		"connections/:connectionId/scopes/:scopeId": {
+			"GET":   api.GetScope,
+			"PATCH": api.UpdateScope,
+		},
+		"connections/:connectionId/scopes": {
+			"GET": api.GetScopeList,
+			"PUT": api.PutScope,
+		},
+	}
+}
+
+func (p Clickup) Close(taskCtx plugin.TaskContext) errors.Error {
+	data, ok := taskCtx.GetData().(*tasks.ClickupTaskData)
+	if !ok {
+		return errors.Default.New(fmt.Sprintf("GetData failed when try to close %+v", taskCtx))
+	}
+	data.ApiClient.Release()
+	return nil
+}
+
+func (p Clickup) MakeDataSourcePipelinePlanV200(connectionId uint64, scopes []*plugin.BlueprintScopeV200, syncPolicy plugin.BlueprintSyncPolicy) (plugin.PipelinePlan, []plugin.Scope, errors.Error) {
+	return api.MakePipelinePlanV200(p.SubTaskMetas(), connectionId, scopes, &syncPolicy)
+}

--- a/backend/plugins/clickup/models/connection.go
+++ b/backend/plugins/clickup/models/connection.go
@@ -1,0 +1,61 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"net/http"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+type ClickupConnection struct {
+	api.BaseConnection    `mapstructure:",squash"`
+	helper.RestConnection `mapstructure:",squash"`
+	helper.AccessToken    `mapstructure:",squash"`
+	TeamId                string `gorm:"type:varchar(255)"`
+}
+
+type TestConnectionRequest struct {
+	Endpoint           string `json:"endpoint"`
+	Proxy              string `json:"proxy"`
+	helper.AccessToken `mapstructure:",squash"`
+}
+
+// This object conforms to what the frontend currently expects.
+type ClickupResponse struct {
+	Name string `json:"name"`
+	ID   int    `json:"id"`
+	ClickupConnection
+}
+
+// Using User because it requires authentication.
+type ApiUserResponse struct {
+	Id   int
+	Name string `json:"name"`
+}
+
+func (ClickupConnection) TableName() string {
+	return "_tool_clickup_connections"
+}
+
+func (c *ClickupConnection) SetupAuthentication(req *http.Request) errors.Error {
+	req.Header.Add("Authorization", c.Token)
+	return nil
+}

--- a/backend/plugins/clickup/models/folder.go
+++ b/backend/plugins/clickup/models/folder.go
@@ -1,0 +1,15 @@
+package models
+
+import "github.com/apache/incubator-devlake/core/models/common"
+
+type ClickUpFolder struct {
+	common.RawDataOrigin `swaggerignore:"true"`
+	ConnectionId         uint64 `gorm:"primaryKey"`
+	Id                   string `gorm:"primaryKey"`
+	SpaceId              string `gorm:"primaryKey"`
+	Name                 string
+}
+
+func (ClickUpFolder) TableName() string {
+	return "_tool_clickup_folder"
+}

--- a/backend/plugins/clickup/models/list.go
+++ b/backend/plugins/clickup/models/list.go
@@ -1,0 +1,18 @@
+package models
+
+import "github.com/apache/incubator-devlake/core/models/common"
+
+type ClickUpList struct {
+	common.RawDataOrigin `swaggerignore:"true"`
+	ConnectionId         uint64 `gorm:"primaryKey"`
+	Id                   string `gorm:"primaryKey"`
+	SpaceId              string `gorm:"primaryKey"`
+	Name                 string
+	StatusName           string
+	DueDate              int64
+	StartDate            int64
+}
+
+func (ClickUpList) TableName() string {
+	return "_tool_clickup_list"
+}

--- a/backend/plugins/clickup/models/migrationscripts/20230522_add_init_tables.go
+++ b/backend/plugins/clickup/models/migrationscripts/20230522_add_init_tables.go
@@ -1,0 +1,49 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+type addInitTables struct{}
+
+func (*addInitTables) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(
+		basicRes,
+		&models.ClickUpTask{},
+		&models.ClickupConnection{},
+		&models.ClickUpSpace{},
+		&models.ClickUpUser{},
+		&models.ClickUpFolder{},
+		&models.ClickUpList{},
+		&models.ClickUpTransformationRule{},
+		&models.ClickUpTaskTimeInStatus{},
+	)
+}
+
+func (*addInitTables) Version() uint64 {
+	return 20230907262004
+}
+
+func (*addInitTables) Name() string {
+	return "clickup init schemas"
+}

--- a/backend/plugins/clickup/models/migrationscripts/register.go
+++ b/backend/plugins/clickup/models/migrationscripts/register.go
@@ -1,0 +1,27 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import "github.com/apache/incubator-devlake/core/plugin"
+
+// All return all the migration scripts
+func All() []plugin.MigrationScript {
+	return []plugin.MigrationScript{
+		new(addInitTables),
+	}
+}

--- a/backend/plugins/clickup/models/space.go
+++ b/backend/plugins/clickup/models/space.go
@@ -1,0 +1,15 @@
+package models
+
+import "github.com/apache/incubator-devlake/core/models/common"
+
+type ClickUpSpace struct {
+	common.NoPKModel
+	ConnectionId  uint64 `json:"connectionId" mapstructure:"connectionId" validate:"required" gorm:"primaryKey"`
+	ScopeConfigId uint64 `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId"`
+	Id            string `gorm:"primaryKey" json:"id"`
+	Name          string `json:"name"`
+}
+
+func (ClickUpSpace) TableName() string {
+	return "_tool_clickup_spaces"
+}

--- a/backend/plugins/clickup/models/task.go
+++ b/backend/plugins/clickup/models/task.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"github.com/apache/incubator-devlake/core/models/common"
+)
+
+type ClickUpTask struct {
+	ConnectionId          uint64 `gorm:"primaryKey"`
+	TaskId                string `gorm:"primaryKey"`
+	ListId                string
+	Priority              string
+	SpaceId               string  `gorm:"primaryKey"`
+	CustomId              *string `gorm:"type:varchar(255)"`
+	NormalizedType        string  `gorm:"type:varchar(255)"`
+	Name                  string
+	DateCreated           int64
+	Points                float64
+	DateUpdated           int64
+	DueDate               int64
+	DateDone              int64
+	DateClosed            int64
+	StartDate             int64
+	TimeSpent             string `gorm:"type:varchar(255)"`
+	Url                   string `gorm:"type:varchar(255)"`
+	Description           string
+	StatusName            string `gorm:"type:varchar(255)"`
+	StatusType            string `gorm:"type:varchar(255)"`
+	common.RawDataOrigin  `swaggerignore:"true"`
+	CreatorId             int64
+	CreatorUsername       string `gorm:"type:varchar(255)"`
+	FirstAssigneeId       *int64
+	FirstAssigneeUsername *string
+}
+
+func (ClickUpTask) TableName() string {
+	return "_tool_clickup_task"
+}

--- a/backend/plugins/clickup/models/task_time_in_status.go
+++ b/backend/plugins/clickup/models/task_time_in_status.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"github.com/apache/incubator-devlake/core/models/common"
+)
+
+type ClickUpTaskTimeInStatus struct {
+	common.RawDataOrigin `swaggerignore:"true"`
+	Id               string `gorm:"primaryKey"`
+	ConnectionId         uint64 `gorm:"primaryKey"`
+	Status               string `gorm:"primaryKey"`
+	TaskId               string
+	TotalMinutes         int
+	Since                string
+	OrderIndex           int
+}
+
+func (ClickUpTaskTimeInStatus) TableName() string {
+	return "_tool_clickup_task_time_in_status"
+}

--- a/backend/plugins/clickup/models/transformation_rules.go
+++ b/backend/plugins/clickup/models/transformation_rules.go
@@ -1,0 +1,13 @@
+package models
+
+import "github.com/apache/incubator-devlake/core/models/common"
+
+type ClickUpTransformationRule struct {
+	common.Model `mapstructure:"-"`
+	ConnectionId uint64 `mapstructure:"connectionId" json:"connectionId"`
+	Name         string `mapstructure:"name" json:"name" gorm:"type:varchar(255);index:idx_name_jira,unique" validate:"required"`
+}
+
+func (t ClickUpTransformationRule) TableName() string {
+	return "_tool_clickup_transformation_rules"
+}

--- a/backend/plugins/clickup/models/user.go
+++ b/backend/plugins/clickup/models/user.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"github.com/apache/incubator-devlake/core/models/common"
+)
+
+type ClickUpUser struct {
+	common.RawDataOrigin `swaggerignore:"true"`
+	ConnectionId         uint64 `gorm:"primaryKey"`
+	AccountId            string `gorm:"primaryKey;type:varchar(100)"`
+	AccountRole          int
+	Username             string `gorm:"type:varchar(255)"`
+	Email                string `gorm:"type:varchar(255)"`
+	Initials             string `gorm:"type:varchar(255)"`
+	ProfilePictureUrl    string `gorm:"type:varchar(255)"`
+}
+
+func (ClickUpUser) TableName() string {
+	return "_tool_clickup_user"
+}

--- a/backend/plugins/clickup/tasks/api_client.go
+++ b/backend/plugins/clickup/tasks/api_client.go
@@ -1,0 +1,104 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	api "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+const CLICKUP_ACCESS_TOKEN_ENV = "CLICKUP_ACCESS_TOKEN"
+const CLICKUP_TEAM_ID_ENV = "CLICKUP_TEAM_ID"
+
+func NewClickupConnection() *models.ClickupConnection {
+	accessToken := os.Getenv(CLICKUP_ACCESS_TOKEN_ENV)
+
+	if accessToken == "" {
+		panic(fmt.Sprintf("A personal clickup access token must be set in env var: %s", CLICKUP_ACCESS_TOKEN_ENV))
+	}
+
+	teamId := os.Getenv(CLICKUP_TEAM_ID_ENV)
+
+	if teamId == "" {
+		panic(fmt.Sprintf("Clickup team ID must be set in env var: %s", CLICKUP_TEAM_ID_ENV))
+	}
+	connection := models.ClickupConnection{
+		RestConnection: api.RestConnection{
+			Endpoint:         "https://api.clickup.com/api",
+			Proxy:            "",
+			RateLimitPerHour: 0,
+		},
+		TeamId: teamId,
+		AccessToken: api.AccessToken{
+			Token: accessToken,
+		},
+	}
+	return &connection
+}
+
+func NewClickupApiClient(taskCtx plugin.TaskContext, connection *models.ClickupConnection) (*api.ApiAsyncClient, errors.Error) {
+	// create synchronize api client so we can calculate api rate limit dynamically
+	headers := map[string]string{
+		"Authorization": connection.Token,
+	}
+	apiClient, err := api.NewApiClient(taskCtx.GetContext(), connection.Endpoint, headers, 0, connection.Proxy, taskCtx)
+	if err != nil {
+		return nil, err
+	}
+	apiClient.SetAfterFunction(func(res *http.Response) errors.Error {
+		if res.StatusCode == http.StatusUnauthorized {
+			return errors.HttpStatus(res.StatusCode).New("authentication failed, please check your AccessToken")
+		}
+		return nil
+	})
+
+	// create rate limit calculator
+	rateLimiter := &api.ApiRateLimitCalculator{
+		UserRateLimitPerHour: connection.RateLimitPerHour,
+		DynamicRateLimit: func(res *http.Response) (int, time.Duration, errors.Error) {
+			rateLimitHeader := res.Header.Get("RateLimit-Limit")
+			if rateLimitHeader == "" {
+				// use default
+				return 0, 0, nil
+			}
+			rateLimit, err := strconv.Atoi(rateLimitHeader)
+			if err != nil {
+				return 0, 0, errors.Default.Wrap(err, "failed to parse RateLimit-Limit header")
+			}
+			// seems like {{ .plugin-ame }} rate limit is on minute basis
+			return rateLimit, 1 * time.Minute, nil
+		},
+	}
+	asyncApiClient, err := api.CreateAsyncApiClient(
+		taskCtx,
+		apiClient,
+		rateLimiter,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return asyncApiClient, nil
+}

--- a/backend/plugins/clickup/tasks/api_model.go
+++ b/backend/plugins/clickup/tasks/api_model.go
@@ -1,0 +1,169 @@
+package tasks
+
+import (
+	"encoding/json"
+	"strconv"
+	"time"
+)
+
+type TaskTimeInStatus struct {
+	CurrentStatus struct {
+		Status string
+		Color string
+		TotalTime struct {
+			ByMinute int `json:"by_minute"`
+			Since string `json:"since"`
+		} `json:"total_time"`
+	} `json:"current_status"`
+	StatusHistory []struct {
+		Status string
+		Color string
+		OrderIndex int
+		TotalTime struct {
+			ByMinute int `json:"by_minute"`
+			Since string `json:"since"`
+		} `json:"total_time"`
+	} `json:"status_history"`
+}
+
+type TaskTimeInStatusEnvelope struct {
+	TaskId string
+	Data TaskTimeInStatus
+}
+
+type Task struct {
+	Id           string
+	CustomId     *string           `json:"custom_id"`
+	CustomFields []TaskCustomField `json:"custom_fields"`
+	Name         string
+	List         TaskList
+	Points       float64 `json:"points"`
+	Url          string
+	TextContent  string `json:"text_content"`
+	Priority     TaskPriority
+	Parent       *string
+	Description  string
+	Status       TaskStatus
+	Creator      User
+	Assignees    []User
+	Watchers     []User
+	Project      TaskProject
+	DateCreated  string `json:"date_created"`
+	DateUpdated  string `json:"date_updated"`
+	DateDone     string `json:"date_done"`
+	DateClosed   string `json:"date_closed"`
+	DueDate      string `json:"due_date"`
+	StartDate    string `json:"start_date"`
+	TimeSpent    string `json:"time_spent"`
+	Subtasks     []Subtask
+	Space        TaskSpace
+}
+
+type TaskPriority struct {
+	Priority string
+}
+type TaskList struct {
+	 Id string
+}
+
+type TaskCustomField struct {
+	Id         string           `json:"id"`
+	Name       string           `json:"name"`
+	Type       string           `json:"type"`
+	Value      interface{}      `json:"value"`
+	TypeConfig *json.RawMessage `json:"type_config"`
+}
+
+type TaskCustomFieldDropDown struct {
+	Default     int                             `json:"default"`
+	Placeholder *string                         `json:"placeholder"`
+	Options     []TypeCustomFieldDropDownOption `json:"options"`
+}
+
+type TypeCustomFieldDropDownOption struct {
+	Name string `json:"name"`
+}
+
+type TaskSpace struct {
+	Id string
+}
+
+type Comment struct {
+	Id          string
+	CommentText string `json:"comment_text"`
+	User        User
+	Reactions   []Reaction
+	Date        string `json:"date"`
+}
+
+func (c Comment) DateFormatted(format string) string {
+	int, err := strconv.ParseInt(c.Date, 10, 64)
+	if err != nil {
+		return "nan"
+	}
+	time := time.Unix(int, 0)
+	return time.Format(format)
+}
+
+type Comments struct {
+	Comments []Comment
+}
+
+type Reaction struct {
+	Reaction string
+	User     User
+}
+
+type TaskProject struct {
+	Id   string
+	Name string
+}
+
+type TaskStatus struct {
+	Id     string
+	Status string
+	Color  string
+	Type   string
+}
+
+type User struct {
+	Id             int
+	Username       string
+	Color          *string
+	Email          string `json:"email"`
+	Initials       *string
+	ProfilePicture *string
+	Role           *int
+}
+
+type Folder struct {
+	Id     string
+	Hidden bool
+	Lists  []List
+	Name   string
+	Space  TaskSpace
+}
+
+type List struct {
+	Id        string
+	Name      string
+	Space     TaskSpace
+	Status    ListStatus
+	DueDate   string `json:"due_date"`
+	StartDate string `json:"start_date"`
+}
+
+type ListStatus struct {
+	Status string
+	Color  string
+}
+
+type Subtask struct {
+	Id        string
+	CustomId  *string `json:"custom_id"`
+	Name      string
+	Status    TaskStatus
+	Creator   User
+	Assignees []User
+	Watchers  []User
+}

--- a/backend/plugins/clickup/tasks/folder_collector.go
+++ b/backend/plugins/clickup/tasks/folder_collector.go
@@ -1,0 +1,88 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+const RAW_FOLDER_TABLE = "clickup_folder"
+
+var _ plugin.SubTaskEntryPoint = CollectIssue
+
+func CollectFolder(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_FOLDER_TABLE)
+
+	collectorWithState, err := api.NewStatefulApiCollector(*rawDataSubTaskArgs, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
+	incremental := collectorWithState.IsIncremental()
+
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
+		Incremental: incremental,
+		ApiClient:   data.ApiClient,
+		PageSize:    100,
+		UrlTemplate: "v2/space/{{ .Params.SpaceId }}/folder",
+		GetNextPageCustomData: func(prevReqData *api.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
+			var res struct {
+				LastPage bool `json:"last_page"`
+			}
+			err := api.UnmarshalResponse(prevPageResponse, &res)
+			if err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
+			query := url.Values{}
+			query.Set("page", fmt.Sprintf("%d", reqData.Pager.Page-1))
+			return query, nil
+		},
+		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
+			body := struct {
+				Folders []json.RawMessage
+			}{}
+			err := helper.UnmarshalResponse(res, &body)
+			if err != nil {
+				return nil, err
+			}
+			return body.Folders, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return collectorWithState.Execute()
+}
+
+var CollectFolderMeta = plugin.SubTaskMeta{
+	Name:             "CollectFolder",
+	EntryPoint:       CollectFolder,
+	EnabledByDefault: true,
+	Description:      "Collect Folder data from Clickup api",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/folder_extractor.go
+++ b/backend/plugins/clickup/tasks/folder_extractor.go
@@ -1,0 +1,76 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var _ plugin.SubTaskEntryPoint = ExtractFolder
+
+func ExtractFolder(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_FOLDER_TABLE)
+
+	extractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+
+		Extract: func(resData *helper.RawData) ([]interface{}, errors.Error) {
+			folder := Folder{}
+			err := json.Unmarshal(resData.Data, &folder)
+			if err != nil {
+				panic(err)
+			}
+			extractedModels := make([]interface{}, 0)
+			extractedModels = append(extractedModels, &models.ClickUpFolder{
+				Id:           folder.Id,
+				ConnectionId: data.Options.ConnectionId,
+				SpaceId:      folder.Space.Id,
+				Name:         folder.Name,
+			})
+			for _, list := range folder.Lists {
+				extractedModels = append(extractedModels, &models.ClickUpList{
+					Id:           list.Id,
+					ConnectionId: data.Options.ConnectionId,
+					SpaceId:      folder.Space.Id,
+					Name:         list.Name,
+					StartDate:    parseDate(list.StartDate),
+					DueDate:      parseDate(list.DueDate),
+				})
+			}
+			return extractedModels, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return extractor.Execute()
+}
+
+var ExtractFolderMeta = plugin.SubTaskMeta{
+	Name:             "ExtractFolder",
+	EntryPoint:       ExtractFolder,
+	EnabledByDefault: true,
+	Description:      "Extract raw data into tool layer table clickup_issue",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/folderless_list_collector.go
+++ b/backend/plugins/clickup/tasks/folderless_list_collector.go
@@ -1,0 +1,88 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+const RAW_FOLDERLESS_TABLE = "clickup_folderless_list"
+
+var _ plugin.SubTaskEntryPoint = CollectIssue
+
+func CollectFolderlessList(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_FOLDERLESS_TABLE)
+
+	collectorWithState, err := api.NewStatefulApiCollector(*rawDataSubTaskArgs, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
+	incremental := collectorWithState.IsIncremental()
+
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
+		Incremental: incremental,
+		ApiClient:   data.ApiClient,
+		PageSize:    100,
+		UrlTemplate: "v2/space/{{ .Params.SpaceId }}/list",
+		GetNextPageCustomData: func(prevReqData *api.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
+			var res struct {
+				LastPage bool `json:"last_page"`
+			}
+			err := api.UnmarshalResponse(prevPageResponse, &res)
+			if err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
+			query := url.Values{}
+			query.Set("page", fmt.Sprintf("%d", reqData.Pager.Page-1))
+			return query, nil
+		},
+		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
+			body := struct {
+				Lists[]json.RawMessage
+			}{}
+			err := helper.UnmarshalResponse(res, &body)
+			if err != nil {
+				return nil, err
+			}
+			return body.Lists, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return collectorWithState.Execute()
+}
+
+var CollectFolderlessListMeta = plugin.SubTaskMeta{
+	Name:             "CollectFolderlessList",
+	EntryPoint:       CollectFolderlessList,
+	EnabledByDefault: true,
+	Description:      "Collect FolderlessList data from Clickup api",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/folderless_list_extractor.go
+++ b/backend/plugins/clickup/tasks/folderless_list_extractor.go
@@ -1,0 +1,68 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var _ plugin.SubTaskEntryPoint = ExtractFolderlessList
+
+func ExtractFolderlessList(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_FOLDERLESS_TABLE)
+
+	extractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+
+		Extract: func(resData *helper.RawData) ([]interface{}, errors.Error) {
+			list := List{}
+			err := json.Unmarshal(resData.Data, &list)
+			if err != nil {
+				panic(err)
+			}
+			extractedModels := make([]interface{}, 0)
+			extractedModels = append(extractedModels, &models.ClickUpList{
+				Id:           list.Id,
+				ConnectionId: data.Options.ConnectionId,
+				SpaceId:      list.Space.Id,
+				Name:         list.Name,
+				StartDate:    parseDate(list.StartDate),
+				DueDate:      parseDate(list.DueDate),
+			})
+			return extractedModels, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return extractor.Execute()
+}
+
+var ExtractFolderlessListMeta = plugin.SubTaskMeta{
+	Name:             "ExtractFolderlessList",
+	EntryPoint:       ExtractFolderlessList,
+	EnabledByDefault: true,
+	Description:      "Extract raw data into tool layer table clickup_issue",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/issue_collector.go
+++ b/backend/plugins/clickup/tasks/issue_collector.go
@@ -1,0 +1,93 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+const RAW_ISSUE_TABLE = "clickup_issue"
+
+var _ plugin.SubTaskEntryPoint = CollectIssue
+
+func CollectIssue(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_ISSUE_TABLE)
+	logger := taskCtx.GetLogger()
+	logger.Debug("Test")
+
+	collectorWithState, err := api.NewStatefulApiCollector(*rawDataSubTaskArgs, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
+	incremental := collectorWithState.IsIncremental()
+
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
+		Incremental: incremental,
+		ApiClient:   data.ApiClient,
+		PageSize:    100,
+		UrlTemplate: "v2/team/{{ .Params.TeamId }}/task",
+		GetNextPageCustomData: func(prevReqData *api.RequestData, prevPageResponse *http.Response) (interface{}, errors.Error) {
+			var res struct {
+				LastPage bool `json:"last_page"`
+			}
+			err := api.UnmarshalResponse(prevPageResponse, &res)
+			if err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
+			query := url.Values{}
+			query.Set("include_closed", "true")
+			query.Set("subtasks", "true")
+			query.Set("space_ids[]", data.Options.ScopeId)
+			query.Set("page", fmt.Sprintf("%d", reqData.Pager.Page-1))
+			return query, nil
+		},
+		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
+			body := struct {
+				Tasks []json.RawMessage
+			}{}
+			err := helper.UnmarshalResponse(res, &body)
+			if err != nil {
+				return nil, err
+			}
+			return body.Tasks, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return collectorWithState.Execute()
+}
+
+var CollectIssueMeta = plugin.SubTaskMeta{
+	Name:             "CollectIssue",
+	EntryPoint:       CollectIssue,
+	EnabledByDefault: true,
+	Description:      "Collect Issue data from Clickup api",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/issue_converter.go
+++ b/backend/plugins/clickup/tasks/issue_converter.go
@@ -1,0 +1,183 @@
+package tasks
+
+import (
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var ConvertIssuesMeta = plugin.SubTaskMeta{
+	Name:             "convertIssues",
+	EntryPoint:       ConvertIssues,
+	EnabledByDefault: true,
+	Description:      "convert clickup tasks",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}
+
+func ConvertIssues(taskCtx plugin.SubTaskContext) errors.Error {
+	db := taskCtx.GetDal()
+	data := taskCtx.GetData().(*ClickupTaskData)
+
+	clickUpTask := &models.ClickUpTask{}
+	clauses := []dal.Clause{
+		dal.Select("_tool_clickup_task.*"),
+		dal.From(clickUpTask),
+		dal.Where(
+			"_tool_clickup_task.connection_id = ? AND _tool_clickup_task.space_id = ?",
+			data.Options.ConnectionId,
+			data.Options.ScopeId,
+		),
+	}
+	cursor, err := db.Cursor(clauses...)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	issueIdGen := didgen.NewDomainIdGenerator(&models.ClickUpTask{})
+	boardIdGen := didgen.NewDomainIdGenerator(&models.ClickUpSpace{})
+	accountIdGen := didgen.NewDomainIdGenerator(&models.ClickUpUser{})
+
+	converter, err := api.NewDataConverter(api.DataConverterArgs{
+		InputRowType: reflect.TypeOf(models.ClickUpTask{}),
+		Input:        cursor,
+		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
+			Ctx: taskCtx,
+			Params: ClickupApiParams{
+				TeamId: data.TeamId,
+			},
+			Table: RAW_ISSUE_TABLE,
+		},
+		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
+			clickUpTask := inputRow.(*models.ClickUpTask)
+			fmt.Printf("%s %s\n", *clickUpTask.CustomId, clickUpTask.StatusName)
+			issue := &ticket.Issue{
+				DomainEntity: domainlayer.DomainEntity{
+					Id: issueIdGen.Generate(clickUpTask.ConnectionId, clickUpTask.TaskId),
+				},
+				Url:            clickUpTask.Url,
+				IssueKey:       stringOrEmpty(clickUpTask.CustomId),
+				Title:          clickUpTask.Name,
+				Type:           clickUpTask.NormalizedType,
+				Status:         convertStatus(clickUpTask.StatusName, clickUpTask.StatusType),
+				OriginalStatus: clickUpTask.StatusName,
+				StoryPoint:     clickUpTask.Points,
+				ResolutionDate: timestampToTime(clickUpTask.DateDone),
+				Priority:       clickUpTask.Priority,
+				CreatedDate:    timestampToTime(clickUpTask.DateCreated),
+				UpdatedDate:    timestampToTime(clickUpTask.DateUpdated),
+				CreatorId:      fmt.Sprintf("%d", clickUpTask.CreatorId),
+				CreatorName:    string(clickUpTask.CreatorUsername),
+				// LeadTimeMinutes:         int64(clickUpTask.LeadTimeMinutes),
+				// TimeSpentMinutes:        clickUpTask.SpentMinutes,
+				// OriginalProject:         clickUpTask.ProjectName,
+			}
+
+			if clickUpTask.FirstAssigneeId != nil {
+				issue.AssigneeId = accountIdGen.Generate(clickUpTask.ConnectionId, fromInt64ToStringOrEmpty(clickUpTask.FirstAssigneeId))
+				issue.AssigneeName = stringOrEmpty(clickUpTask.FirstAssigneeUsername)
+			}
+
+			if clickUpTask.DateDone != 0 {
+				// todo: LeadTimeMinutes should be calculated in extractor as
+				// with other implemnetations
+				issue.LeadTimeMinutes = int64(
+					issue.ResolutionDate.Sub(
+						*issue.CreatedDate,
+					).Minutes(),
+				)
+			}
+			// if clickUpTask.CreatorAccountId != "" {
+			// 	issue.CreatorId = accountIdGen.Generate(data.Options.ConnectionId, clickUpTask.CreatorAccountId)
+			// }
+			// if clickUpTask.CreatorDisplayName != "" {
+			// 	issue.CreatorName = clickUpTask.CreatorDisplayName
+			// }
+			// if clickUpTask.AssigneeAccountId != "" {
+			// 	issue.AssigneeId = accountIdGen.Generate(data.Options.ConnectionId, clickUpTask.AssigneeAccountId)
+			// }
+			// if clickUpTask.AssigneeDisplayName != "" {
+			// 	issue.AssigneeName = clickUpTask.AssigneeDisplayName
+			// }
+			// if clickUpTask.ParentId != 0 {
+			// 	issue.ParentIssueId = issueIdGen.Generate(data.Options.ConnectionId, clickUpTask.ParentId)
+			// }
+			// boardIssue := &ticket.BoardIssue{
+			// 	BoardId: boardId,
+			// 	IssueId: issue.Id,
+			// }
+			boardId := boardIdGen.Generate(data.Options.ConnectionId, data.Options.ScopeId)
+			boardIssue := &ticket.BoardIssue{
+				BoardId: boardId,
+				IssueId: issue.Id,
+			}
+			return []interface{}{
+				issue,
+				boardIssue,
+			}, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return converter.Execute()
+}
+
+func timestampToTime(int int64) *time.Time {
+	// convert timestamp in milliseconds to seconds
+	tm := time.Unix(int/1000, 0)
+	return &tm
+}
+
+func convertStatus(statusName, statusType string) string {
+	if statusType == "closed" {
+		return ticket.DONE
+	}
+	if statusType == "done" {
+		return ticket.DONE
+	}
+	if statusType == "open" {
+		return ticket.TODO
+	}
+
+	return ticket.IN_PROGRESS
+}
+
+func fromInt64ToStringOrEmpty(int *int64) string {
+	if nil == int {
+		return ""
+	}
+
+	return strconv.FormatUint(uint64(*int), 10)
+}
+
+func stringOrEmpty(string *string) string {
+	if string == nil {
+		return ""
+	}
+	return *string
+}
+
+func convertURL(api, issueKey string) string {
+	u, err := url.Parse(api)
+	if err != nil {
+		return api
+	}
+	before, _, _ := strings.Cut(u.Path, "/rest/agile/1.0/issue")
+	u.Path = filepath.Join(before, "browse", issueKey)
+	return u.String()
+}

--- a/backend/plugins/clickup/tasks/issue_extractor.go
+++ b/backend/plugins/clickup/tasks/issue_extractor.go
@@ -1,0 +1,147 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"strconv"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var _ plugin.SubTaskEntryPoint = ExtractIssue
+
+func ExtractIssue(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_ISSUE_TABLE)
+
+	extractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+
+		Extract: func(resData *helper.RawData) ([]interface{}, errors.Error) {
+			task := Task{}
+			err := json.Unmarshal(resData.Data, &task)
+			if err != nil {
+				panic(err)
+			}
+			extractedModels := make([]interface{}, 0)
+			extractedModels = append(extractedModels, &models.ClickUpTask{
+				ConnectionId:          data.Options.ConnectionId,
+				Points:                task.Points,
+				Priority:              task.Priority.Priority,
+				SpaceId:               task.Space.Id,
+				TaskId:                task.Id,
+				ListId:                task.List.Id,
+				NormalizedType:        determineIssueType(&task),
+				CustomId:              task.CustomId,
+				Name:                  task.Name,
+				Url:                   task.Url,
+				Description:           task.Description,
+				StatusName:            task.Status.Status,
+				StatusType:            task.Status.Type,
+				StartDate:             parseDate(task.StartDate),
+				TimeSpent:             task.TimeSpent,
+				DateCreated:           parseDate(task.DateCreated),
+				DateUpdated:           parseDate(task.DateUpdated),
+				DueDate:               parseDate(task.DueDate),
+				DateDone:              parseDate(task.DateDone),
+				DateClosed:            parseDate(task.DateClosed),
+				CreatorId:             int64(task.Creator.Id),
+				CreatorUsername:       task.Creator.Username,
+				FirstAssigneeId:       firstAssigneeId(task.Assignees),
+				FirstAssigneeUsername: firstAssigneeUsername(task.Assignees),
+			})
+			return extractedModels, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return extractor.Execute()
+}
+
+func firstAssigneeId(user []User) *int64 {
+	for _, user := range user {
+		ref := int64(user.Id)
+		return &ref
+	}
+	return nil
+}
+func firstAssigneeUsername(user []User) *string {
+	for _, user := range user {
+		ref := user.Username
+		return &ref
+	}
+	return nil
+}
+
+func determineIssueType(task *Task) string {
+	for _, field := range task.CustomFields {
+		if field.Name != "Type" || field.Type != "drop_down" {
+			continue
+		}
+		if field.Value == nil {
+			return ticket.TASK
+		}
+		dropDown := TaskCustomFieldDropDown{}
+		err := json.Unmarshal(*field.TypeConfig, &dropDown)
+		if err != nil {
+			panic(err)
+		}
+		m := map[int]string{}
+		for i, opt := range dropDown.Options {
+			m[i] = opt.Name
+		}
+		value := int(field.Value.(float64))
+		val := m[value]
+
+		// TODO: introduce transformer and map these from the DB
+		if val == "Bug" {
+			return ticket.BUG
+		}
+
+		if val == "Incident" {
+			return ticket.INCIDENT
+		}
+	}
+
+	return ticket.TASK
+}
+
+func parseDate(s string) int64 {
+	if "" == s {
+		return 0
+	}
+	i, err := strconv.ParseInt(s, 10, 64)
+	if err != nil {
+		panic(err)
+	}
+	return i
+}
+
+var ExtractIssueMeta = plugin.SubTaskMeta{
+	Name:             "ExtractIssue",
+	EntryPoint:       ExtractIssue,
+	EnabledByDefault: true,
+	Description:      "Extract raw data into tool layer table clickup_issue",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/issue_extractor_test.go
+++ b/backend/plugins/clickup/tasks/issue_extractor_test.go
@@ -1,0 +1,79 @@
+package tasks
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDetermineIssueType(t *testing.T) {
+	t.Run("no custom fileds", func(t *testing.T) {
+		task := Task{}
+		require.Equal(t, ticket.TASK, determineIssueType(&task))
+	})
+	t.Run("maps to bug", func(t *testing.T) {
+		task := Task{
+			CustomFields: []TaskCustomField{
+				{
+					Name: "Type",
+					Type: "drop_down",
+					TypeConfig: toRawJson(TaskCustomFieldDropDown{
+						Default:     0,
+						Placeholder: new(string),
+						Options: []TypeCustomFieldDropDownOption{
+							{
+								Name: "Incident",
+							},
+							{
+								Name: "Bug",
+							},
+							{
+								Name: "Improvement",
+							},
+						},
+					}),
+					Value: float64(1),
+				},
+			},
+		}
+		require.Equal(t, ticket.BUG, determineIssueType(&task))
+	})
+	t.Run("maps to incident", func(t *testing.T) {
+		task := Task{
+			CustomFields: []TaskCustomField{
+				{
+					Name: "Type",
+					Type: "drop_down",
+					TypeConfig: toRawJson(TaskCustomFieldDropDown{
+						Default:     0,
+						Placeholder: new(string),
+						Options: []TypeCustomFieldDropDownOption{
+							{
+								Name: "Incident",
+							},
+							{
+								Name: "Bug",
+							},
+							{
+								Name: "Improvement",
+							},
+						},
+					}),
+					Value: float64(0),
+				},
+			},
+		}
+		require.Equal(t, ticket.INCIDENT, determineIssueType(&task))
+	})
+}
+
+func toRawJson(taskCustomFieldDropDown TaskCustomFieldDropDown) *json.RawMessage {
+	bytes, err := json.Marshal(taskCustomFieldDropDown)
+	if err != nil {
+		panic(err)
+	}
+	raw := json.RawMessage(bytes)
+	return &raw
+}

--- a/backend/plugins/clickup/tasks/sprint_converter.go
+++ b/backend/plugins/clickup/tasks/sprint_converter.go
@@ -1,0 +1,98 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+	"reflect"
+	"strings"
+)
+
+var ConvertSprintsMeta = plugin.SubTaskMeta{
+	Name:             "convertSprints",
+	EntryPoint:       ConvertSprints,
+	EnabledByDefault: true,
+	Description:      "convert clickup lists to sprints",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}
+
+func ConvertSprints(taskCtx plugin.SubTaskContext) errors.Error {
+	data := taskCtx.GetData().(*ClickupTaskData)
+	connectionId := data.Options.ConnectionId
+	boardId := data.Options.ScopeId
+	logger := taskCtx.GetLogger()
+	db := taskCtx.GetDal()
+	logger.Info("convert sprints")
+	clauses := []dal.Clause{
+		dal.Select("tcl.*"),
+		dal.From("_tool_clickup_list tcl"),
+		dal.Where("tcl.connection_id = ? AND tcl.space_id = ?", connectionId, boardId),
+	}
+	cursor, err := db.Cursor(clauses...)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+	var converter *api.DataConverter
+	domainBoardId := didgen.NewDomainIdGenerator(&models.ClickUpSpace{}).Generate(connectionId, boardId)
+	sprintIdGen := didgen.NewDomainIdGenerator(&models.ClickUpList{})
+	boardIdGen := didgen.NewDomainIdGenerator(&models.ClickUpSpace{})
+	converter, err = api.NewDataConverter(api.DataConverterArgs{
+		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
+			Ctx: taskCtx,
+			Params: ClickupApiParams{
+				TeamId: data.TeamId,
+			},
+			Table: RAW_FOLDER_TABLE,
+		},
+		InputRowType: reflect.TypeOf(models.ClickUpList{}),
+		Input:        cursor,
+		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
+			var result []interface{}
+			clickUpList := inputRow.(*models.ClickUpList)
+			sprint := &ticket.Sprint{
+				DomainEntity:    domainlayer.DomainEntity{Id: sprintIdGen.Generate(connectionId, clickUpList.Id)},
+				Status:          strings.ToUpper(clickUpList.StatusName),
+				Name:            clickUpList.Name,
+				StartedDate:     timestampToTime(clickUpList.StartDate),
+				EndedDate:       timestampToTime(clickUpList.DueDate),
+				OriginalBoardID: boardIdGen.Generate(connectionId, boardId),
+			}
+			result = append(result, sprint)
+			boardSprint := &ticket.BoardSprint{
+				BoardId:  domainBoardId,
+				SprintId: sprint.Id,
+			}
+			result = append(result, boardSprint)
+			return result, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return converter.Execute()
+}
+

--- a/backend/plugins/clickup/tasks/sprint_issue_converter.go
+++ b/backend/plugins/clickup/tasks/sprint_issue_converter.go
@@ -1,0 +1,84 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"reflect"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var ConvertSprintIssuesMeta = plugin.SubTaskMeta{
+	Name:             "convertSprintIssues",
+	EntryPoint:       ConvertSprintIssues,
+	EnabledByDefault: true,
+	Description:      "convert Jira sprint_issues",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}
+
+func ConvertSprintIssues(taskCtx plugin.SubTaskContext) errors.Error {
+	db := taskCtx.GetDal()
+	data := taskCtx.GetData().(*ClickupTaskData)
+
+	clickUpTaskTable := &models.ClickUpTask{}
+	// select all issues belongs to the board
+	clauses := []dal.Clause{
+		dal.Select("*"),
+		dal.From(clickUpTaskTable),
+		dal.Where("_tool_clickup_task.connection_id = ? AND _tool_clickup_task.space_id = ? AND _tool_clickup_task.list_id is not null", data.Options.ConnectionId, data.Options.ScopeId),
+	}
+	cursor, err := db.Cursor(clauses...)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	issueIdGen := didgen.NewDomainIdGenerator(&models.ClickUpTask{})
+	sprintIdGen := didgen.NewDomainIdGenerator(&models.ClickUpList{})
+
+	converter, err := api.NewDataConverter(api.DataConverterArgs{
+		InputRowType: reflect.TypeOf(models.ClickUpTask{}),
+		Input:        cursor,
+		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
+			Ctx: taskCtx,
+			Params: ClickupApiParams{
+				TeamId: data.TeamId,
+			},
+			Table: RAW_ISSUE_TABLE,
+		},
+		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
+			task := inputRow.(*models.ClickUpTask)
+			sprintIssue := &ticket.SprintIssue{
+				SprintId: sprintIdGen.Generate(data.Options.ConnectionId, task.ListId),
+				IssueId:  issueIdGen.Generate(data.Options.ConnectionId, task.TaskId),
+			}
+			return []interface{}{sprintIssue}, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return converter.Execute()
+}

--- a/backend/plugins/clickup/tasks/task_data.go
+++ b/backend/plugins/clickup/tasks/task_data.go
@@ -1,0 +1,71 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"time"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	api "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+type ClickupApiParams struct {
+	TeamId  string
+	SpaceId string
+}
+
+type ClickupOptions struct {
+	ConnectionId     uint64   `json:"connectionId"`
+	ScopeId          string   `json:"scopeId"`
+	Tasks            []string `json:"tasks,omitempty"`
+	CreatedDateAfter string   `json:"createdDateAfter" mapstructure:"createdDateAfter,omitempty"`
+}
+
+type ClickupTaskData struct {
+	Options          *ClickupOptions
+	ApiClient        *api.ApiAsyncClient
+	CreatedDateAfter *time.Time
+	TeamId           string
+}
+
+func DecodeAndValidateTaskOptions(options map[string]interface{}) (*ClickupOptions, errors.Error) {
+	var op ClickupOptions
+	if err := helper.Decode(options, &op, nil); err != nil {
+		return nil, err
+	}
+	return &op, nil
+}
+
+func CreateRawDataSubTaskArgs(taskCtx plugin.SubTaskContext, rawTable string) (*api.RawDataSubTaskArgs, *ClickupTaskData) {
+	data := taskCtx.GetData().(*ClickupTaskData)
+	filteredData := *data
+	filteredData.Options = &ClickupOptions{}
+	*filteredData.Options = *data.Options
+	var params = ClickupApiParams{
+		TeamId:  data.TeamId,
+		SpaceId: data.Options.ScopeId,
+	}
+	rawDataSubTaskArgs := &api.RawDataSubTaskArgs{
+		Ctx:    taskCtx,
+		Params: params,
+		Table:  rawTable,
+	}
+	return rawDataSubTaskArgs, &filteredData
+}

--- a/backend/plugins/clickup/tasks/task_time_in_status_collector.go
+++ b/backend/plugins/clickup/tasks/task_time_in_status_collector.go
@@ -1,0 +1,140 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+const RAW_TASK_TIME_IN_STATUS_TABLE = "clickup_task_time_in_status"
+
+var _ plugin.SubTaskEntryPoint = CollectTaskTimeInStatus
+
+var CollectTaskTimeInStatusMeta = plugin.SubTaskMeta{
+	Name:             "collectTaskTimeInStatus",
+	EntryPoint:       CollectTaskTimeInStatus,
+	EnabledByDefault: true,
+	Description:      "collect clickup time in status",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}
+
+type TimeInTaskStatusInput struct {
+	TaskId      string `json:"task_id"`
+	DateUpdated uint
+}
+
+func CollectTaskTimeInStatus(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_TASK_TIME_IN_STATUS_TABLE)
+	logger := taskCtx.GetLogger()
+
+	clauses := []dal.Clause{
+		dal.Select("task_id"),
+		dal.From(&models.ClickUpTask{}),
+		dal.Where("_tool_clickup_task.connection_id = ? and _tool_clickup_task.space_id = ? ", data.Options.ConnectionId, data.Options.ScopeId),
+	}
+
+	db := taskCtx.GetDal()
+	cursor, err := db.Cursor(clauses...)
+	if err != nil {
+		return err
+	}
+	iterator, err := api.NewDalCursorIterator(db, cursor, reflect.TypeOf(TimeInTaskStatusInput{}))
+	if err != nil {
+		return err
+	}
+
+
+	batch := []string{}
+	batches := [][]string{}
+
+	for iterator.HasNext() {
+		res, err := iterator.Fetch();
+		if err != nil {
+			panic(err);
+		}
+		batch = append(batch, res.(*TimeInTaskStatusInput).TaskId)
+		if len(batch) == 100 {
+			batches = append(batches, batch)
+			batch = []string{}
+		}
+	}
+
+	if len(batch) > 0 {
+		batches = append(batches, batch)
+	}
+
+
+	incremental := false
+	for _, batch := range batches {
+		query := strings.Join(batch, "&task_ids=")
+
+		collector, err := api.NewApiCollector(api.ApiCollectorArgs{
+			RawDataSubTaskArgs: *rawDataSubTaskArgs,
+			ApiClient:          data.ApiClient,
+			Incremental: incremental,
+			UrlTemplate:  fmt.Sprintf("v2/task/bulk_time_in_status/task_ids?task_ids=%s", query),
+			ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
+				body := map[string]TaskTimeInStatus{}
+				err := api.UnmarshalResponse(res, &body)
+				rawMessages := []json.RawMessage{}
+				for taskId, taskTimeInStatus := range body {
+					if err != nil {
+						panic(err)
+					}
+					data := TaskTimeInStatusEnvelope{
+						TaskId: taskId,
+						Data: taskTimeInStatus,
+					}
+
+					new, err := json.Marshal(&data)
+					if err != nil {
+						panic(err)
+					}
+					rawMessages = append(rawMessages, json.RawMessage(new))
+				}
+
+				return rawMessages, err
+			},
+		})
+
+		// append subsequent batches
+		incremental = true
+
+		if err != nil {
+			logger.Error(err, "collect task activities error")
+			return err
+		}
+
+		errs := collector.Execute()
+		if errs != nil {
+			return errs
+		}
+	}
+
+	return nil
+}

--- a/backend/plugins/clickup/tasks/task_time_in_status_extractor.go
+++ b/backend/plugins/clickup/tasks/task_time_in_status_extractor.go
@@ -1,0 +1,81 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var _ plugin.SubTaskEntryPoint = ExtractTaskTimeInStatus
+
+func ExtractTaskTimeInStatus(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_TASK_TIME_IN_STATUS_TABLE)
+
+	extractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+
+		Extract: func(resData *helper.RawData) ([]interface{}, errors.Error) {
+			task := TaskTimeInStatusEnvelope{}
+			err := json.Unmarshal(resData.Data, &task)
+			if err != nil {
+				panic(err)
+			}
+			extractedModels := []interface{}{}
+			for _, status := range task.Data.StatusHistory {
+				extractedModels = append(extractedModels, &models.ClickUpTaskTimeInStatus{
+					Id:           fmt.Sprintf("%s%s", task.TaskId, status.Status),
+					TaskId:       task.TaskId,
+					ConnectionId: data.Options.ConnectionId,
+					Status:       status.Status,
+					TotalMinutes: status.TotalTime.ByMinute,
+					Since:        status.TotalTime.Since,
+					OrderIndex:   status.OrderIndex,
+				})
+			}
+			extractedModels = append(extractedModels, &models.ClickUpTaskTimeInStatus{
+				ConnectionId: data.Options.ConnectionId,
+				Id:           fmt.Sprintf("%s%s", task.TaskId, task.Data.CurrentStatus.Status),
+				TaskId:       task.TaskId,
+				Status:       task.Data.CurrentStatus.Status,
+				TotalMinutes: task.Data.CurrentStatus.TotalTime.ByMinute,
+				Since:        task.Data.CurrentStatus.TotalTime.Since,
+				OrderIndex:   -1,
+			})
+			return extractedModels, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return extractor.Execute()
+}
+
+var ExtractTaskTimeInStatusMeta = plugin.SubTaskMeta{
+	Name:             "ExtractTaskTimeInStatus",
+	EntryPoint:       ExtractTaskTimeInStatus,
+	EnabledByDefault: true,
+	Description:      "Extract raw data into tool layer table clickup_issue",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+}

--- a/backend/plugins/clickup/tasks/user_collector.go
+++ b/backend/plugins/clickup/tasks/user_collector.go
@@ -1,0 +1,77 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+const RAW_USER_TABLE = "clickup_user"
+
+var _ plugin.SubTaskEntryPoint = CollectUser
+
+func CollectUser(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_USER_TABLE)
+	collectorWithState, err := api.NewStatefulApiCollector(*rawDataSubTaskArgs, data.CreatedDateAfter)
+	if err != nil {
+		return err
+	}
+	incremental := collectorWithState.IsIncremental()
+
+	err = collectorWithState.InitCollector(helper.ApiCollectorArgs{
+		Incremental: incremental,
+		ApiClient:   data.ApiClient,
+		UrlTemplate: "v2/team/{{ .Params.TeamId }}",
+		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
+			query := url.Values{}
+			query.Set("space_ids[]", data.Options.ScopeId)
+			return query, nil
+		},
+		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
+			body := struct {
+				Team struct {
+					Members []json.RawMessage
+				}
+			}{}
+			err := helper.UnmarshalResponse(res, &body)
+			if err != nil {
+				return nil, err
+			}
+			return body.Team.Members, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+	return collectorWithState.Execute()
+}
+
+var CollectUserMeta = plugin.SubTaskMeta{
+	Name:             "CollectUser",
+	EntryPoint:       CollectUser,
+	EnabledByDefault: true,
+	Description:      "Collect user data from Clickup api",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CROSS},
+}

--- a/backend/plugins/clickup/tasks/user_converter.go
+++ b/backend/plugins/clickup/tasks/user_converter.go
@@ -1,0 +1,74 @@
+package tasks
+
+import (
+	"reflect"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models/domainlayer"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/crossdomain"
+	"github.com/apache/incubator-devlake/core/models/domainlayer/didgen"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var ConvertUsersMeta = plugin.SubTaskMeta{
+	Name:             "convertUsers",
+	EntryPoint:       ConvertUsers,
+	EnabledByDefault: true,
+	Description:      "convert clickup tasks",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CROSS},
+}
+
+func ConvertUsers(taskCtx plugin.SubTaskContext) errors.Error {
+	db := taskCtx.GetDal()
+	data := taskCtx.GetData().(*ClickupTaskData)
+
+	clickUpUser := &models.ClickUpUser{}
+	clauses := []dal.Clause{
+		dal.Select("_tool_clickup_user.*"),
+		dal.From(clickUpUser),
+		dal.Where(
+			"_tool_clickup_user.connection_id = ?",
+			data.Options.ConnectionId,
+		),
+	}
+	cursor, err := db.Cursor(clauses...)
+	if err != nil {
+		return err
+	}
+	defer cursor.Close()
+
+	accountIdGen := didgen.NewDomainIdGenerator(&models.ClickUpUser{})
+	converter, err := api.NewDataConverter(api.DataConverterArgs{
+		RawDataSubTaskArgs: api.RawDataSubTaskArgs{
+			Ctx: taskCtx,
+			Params: ClickupApiParams{
+				TeamId: data.TeamId,
+			},
+			Table: RAW_USER_TABLE,
+		},
+		InputRowType: reflect.TypeOf(models.ClickUpUser{}),
+		Input:        cursor,
+		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
+			user := inputRow.(*models.ClickUpUser)
+			u := &crossdomain.Account{
+				DomainEntity: domainlayer.DomainEntity{
+					Id: accountIdGen.Generate(data.Options.ConnectionId, user.AccountId),
+				},
+				FullName:  user.Username,
+				UserName:  user.Username,
+				Email:     user.Email,
+				AvatarUrl: user.ProfilePictureUrl,
+			}
+			return []interface{}{u}, nil
+		},
+	})
+
+	if err != nil {
+		return err
+	}
+
+	return converter.Execute()
+}

--- a/backend/plugins/clickup/tasks/user_extractor.go
+++ b/backend/plugins/clickup/tasks/user_extractor.go
@@ -1,0 +1,71 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/clickup/models"
+)
+
+var _ plugin.SubTaskEntryPoint = ExtractUser
+
+func ExtractUser(taskCtx plugin.SubTaskContext) errors.Error {
+	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_USER_TABLE)
+
+	extractor, err := helper.NewApiExtractor(helper.ApiExtractorArgs{
+		RawDataSubTaskArgs: *rawDataSubTaskArgs,
+
+		Extract: func(resData *helper.RawData) ([]interface{}, errors.Error) {
+			user := struct {
+				User User
+			}{}
+			err := json.Unmarshal(resData.Data, &user)
+			if err != nil {
+				panic(err)
+			}
+			extractedModels := make([]interface{}, 0)
+			extractedModels = append(extractedModels, &models.ClickUpUser{
+				ConnectionId:      data.Options.ConnectionId,
+				AccountId:         fmt.Sprintf("%d", user.User.Id),
+				Username:          user.User.Username,
+				Email:             user.User.Email,
+				Initials:          stringOrEmpty(user.User.Initials),
+				ProfilePictureUrl: stringOrEmpty(user.User.ProfilePicture),
+			})
+			return extractedModels, nil
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return extractor.Execute()
+}
+
+var ExtractUserMeta = plugin.SubTaskMeta{
+	Name:             "ExtractUser",
+	EntryPoint:       ExtractUser,
+	EnabledByDefault: true,
+	Description:      "Extract raw data into tool layer table clickup_user",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CROSS},
+}

--- a/backend/plugins/jira/models/issue.go
+++ b/backend/plugins/jira/models/issue.go
@@ -37,7 +37,7 @@ type JiraIssue struct {
 	Summary                  string
 	Type                     string `gorm:"type:varchar(255)"`
 	EpicKey                  string `gorm:"type:varchar(255)"`
-	StatusName               string `gorm:"type:varchar(255)"`
+	StatusName               string `gorm:"type:varchar(256)"`
 	StatusKey                string `gorm:"type:varchar(255)"`
 	StoryPoint               float64
 	OriginalEstimateMinutes  int64  // user input?

--- a/backend/plugins/jira/tasks/issue_collector.go
+++ b/backend/plugins/jira/tasks/issue_collector.go
@@ -137,6 +137,7 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			return data.Issues, nil
 		},
 	})
+
 	if err != nil {
 		return err
 	}

--- a/backend/plugins/tapd/e2e/stories_test.go
+++ b/backend/plugins/tapd/e2e/stories_test.go
@@ -38,10 +38,10 @@ func TestTapdStoryDataFlow(t *testing.T) {
 			WorkspaceId:  991,
 			TransformationRules: &tasks.TransformationRules{
 				TypeMappings: tasks.TypeMappings{
-					"BUG":      "缺陷",
-					"TASK":     "任务",
-					"需求":     "故事需求",
-					"技术债":   "技术需求债务",
+					"BUG":  "缺陷",
+					"TASK": "任务",
+					"需求":   "故事需求",
+					"技术债":  "技术需求债务",
 					"长篇故事": "Epic需求",
 				},
 			},

--- a/config-ui/src/plugins/components/data-scope-form/index.tsx
+++ b/config-ui/src/plugins/components/data-scope-form/index.tsx
@@ -36,6 +36,7 @@ import { ZentaoDataScope } from '@/plugins/register/zentao';
 import * as API from './api';
 import * as S from './styled';
 import { TapdDataScope } from '@/plugins/register/tapd';
+import { ClickUpDataScope } from '@/plugins/register/clickup/data-scope';
 
 interface Props {
   plugin: string;
@@ -162,6 +163,9 @@ export const DataScopeForm = ({
 
           {plugin === 'zentao' && (
             <ZentaoDataScope connectionId={connectionId} selectedItems={scope} onChangeItems={setScope} />
+          )}
+          {plugin === 'clickup' && (
+            <ClickUpDataScope connectionId={connectionId} selectedItems={scope} onChangeItems={setScope} />
           )}
         </div>
 

--- a/config-ui/src/plugins/config.ts
+++ b/config-ui/src/plugins/config.ts
@@ -41,12 +41,14 @@ import { WebhookConfig } from './register/webook';
 import { ZenTaoConfig } from './register/zentao';
 import { TeambitionConfig } from './register/teambition';
 import { BasePipelineConfig } from '@/plugins/register/base';
+import { ClickUpConfig } from './register/clickup/config';
 
 export const PluginConfig: PluginConfigType[] = [
   AEConfig,
   AzureConfig,
   BitBucketConfig,
   CustomizeConfig,
+  ClickUpConfig,
   DBTConfig,
   DORAConfig,
   FeiShuConfig,

--- a/config-ui/src/plugins/register/clickup/assets/icon.svg
+++ b/config-ui/src/plugins/register/clickup/assets/icon.svg
@@ -1,0 +1,27 @@
+<svg width="185" height="185" viewBox="0 0 185 185" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d)">
+<rect x="30" y="20" width="125" height="125" rx="62.5" fill="white"/>
+<rect x="30" y="20" width="125" height="125" rx="62.5" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M55.8789 105.714L69.3974 95.3593C76.5762 104.732 84.1998 109.051 92.6948 109.051C101.143 109.051 108.557 104.781 115.414 95.4832L129.119 105.59C119.232 118.996 106.932 126.079 92.6948 126.079C78.5049 126.079 66.0907 119.046 55.8789 105.714Z" fill="url(#paint0_linear)"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M92.6491 60.7078L68.5883 81.4406L57.4727 68.5407L92.6969 38.1885L127.647 68.5644L116.477 81.417L92.6491 60.7078Z" fill="url(#paint1_linear)"/>
+</g>
+<defs>
+<filter id="filter0_d" x="0" y="0" width="185" height="185" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0"/>
+<feOffset dy="10"/>
+<feGaussianBlur stdDeviation="15"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.0627451 0 0 0 0 0.117647 0 0 0 0 0.211765 0 0 0 0.1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow" result="shape"/>
+</filter>
+<linearGradient id="paint0_linear" x1="55.8789" y1="116.251" x2="129.119" y2="116.251" gradientUnits="userSpaceOnUse">
+<stop stop-color="#8930FD"/>
+<stop offset="1" stop-color="#49CCF9"/>
+</linearGradient>
+<linearGradient id="paint1_linear" x1="57.4727" y1="67.6025" x2="127.647" y2="67.6025" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF02F0"/>
+<stop offset="1" stop-color="#FFC800"/>
+</linearGradient>
+</defs>
+</svg>

--- a/config-ui/src/plugins/register/clickup/config.tsx
+++ b/config-ui/src/plugins/register/clickup/config.tsx
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import type { PluginConfigType } from '../../types';
+import { PluginType } from '../../types';
+
+import Icon from './assets/icon.svg';
+import { Auth } from './connection-fields';
+
+export const ClickUpConfig: PluginConfigType = {
+  type: PluginType.Connection,
+  plugin: 'clickup',
+  name: 'ClickUp',
+  icon: Icon,
+  sort: 3,
+  connection: {
+    docLink: 'https://devlake.apache.org/docs/Configuration/ClickUp',
+    fields: [
+      'name',
+      ({ initialValues, values, errors, setValues, setErrors }: any) => (
+        <Auth
+          key="token"
+          initialValues={initialValues}
+          values={values}
+          errors={errors}
+          setValues={setValues}
+          setErrors={setErrors}
+        />
+      ),
+      'endpoint',
+      'proxy',
+      {
+        key: 'rateLimitPerHour',
+        subLabel:
+          'By default, DevLake uses dynamic rate limit for optimized data collection for ClickUp. But you can adjust the collection speed by setting up your desirable rate limit.',
+        learnMore: 'https://devlake.apache.org/docs/Configuration/ClickUp/#fixed-rate-limit-optional',
+        defaultValue: 10000,
+      },
+    ],
+  },
+  entities: ['TICKET','CROSS'],
+  transformation: {
+    storyPointField: '',
+    typeMappings: {},
+    remotelinkCommitShaPattern: '',
+    remotelinkRepoPattern: [''],
+  },
+};

--- a/config-ui/src/plugins/register/clickup/connection-fields/auth.tsx
+++ b/config-ui/src/plugins/register/clickup/connection-fields/auth.tsx
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import React, { useState, useEffect } from 'react';
+import { FormGroup, RadioGroup, Radio, InputGroup } from '@blueprintjs/core';
+
+import { ExternalLink } from '@/components';
+
+import * as S from './styled';
+
+interface Props {
+  initialValues: any;
+  values: any;
+  errors: any;
+  setValues: (value: any) => void;
+  setErrors: (value: any) => void;
+}
+
+export const Auth = ({ initialValues, values, setValues, setErrors }: Props) => {
+  useEffect(() => {
+    setValues({
+      token: initialValues.token,
+      teamId: initialValues.teamId,
+    });
+  }, [
+    initialValues.token,
+    initialValues.teamId ? '' : 'https://api.clickup.com/api/',
+  ]);
+
+  useEffect(() => {
+    setErrors({
+      token: values.token ? '' : 'token is required',
+      teamId: values.teamId ? '' : 'teamId is required',
+    });
+  }, [values]);
+
+  const handleChangeToken = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({
+      token: e.target.value,
+    });
+  };
+
+  const handleChangeEndpoint = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({
+      endpoint: e.target.value,
+    });
+  };
+  const handleTeamIdChanged = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValues({
+      teamId: e.target.value,
+    });
+  };
+
+  return (
+    <>
+        <FormGroup
+          style={{ marginTop: 8, marginBottom: 0 }}
+          label={<S.Label>Endpoint URL</S.Label>}
+          labelInfo={<S.LabelInfo>*</S.LabelInfo>}
+          subLabel={
+            <S.LabelDescription>
+                Provide the ClickUp instance API endpoint. e.g. https://api.clickup.com/api/
+            </S.LabelDescription>
+          }
+        >
+          <InputGroup placeholder="Your Endpoint URL" value={values.endpoint} onChange={handleChangeEndpoint} />
+        </FormGroup>
+        <FormGroup
+          style={{ marginTop: 8, marginBottom: 0 }}
+          label={<S.Label>Team ID</S.Label>}
+          labelInfo={<S.LabelInfo>*</S.LabelInfo>}
+          subLabel={
+            <S.LabelDescription>
+                Provide the ClickUp TeamUp/Workspace ID
+            </S.LabelDescription>
+          }
+        >
+          <InputGroup placeholder="Team ID" value={values.teamId} onChange={handleTeamIdChanged} />
+        </FormGroup>
+        <FormGroup
+          label={<S.Label>Personal Access Token</S.Label>}
+          labelInfo={<S.LabelInfo>*</S.LabelInfo>}
+          subLabel={
+            <S.LabelDescription>
+              <ExternalLink link="https://devlake.apache.org/docs/Configuration/Jira#personal-access-token">
+                Learn about how to create a PAT
+              </ExternalLink>
+            </S.LabelDescription>
+          }
+        >
+          <InputGroup type="password" placeholder="Your PAT" value={values.token} onChange={handleChangeToken} />
+        </FormGroup>
+    </>
+  );
+};

--- a/config-ui/src/plugins/register/clickup/connection-fields/index.ts
+++ b/config-ui/src/plugins/register/clickup/connection-fields/index.ts
@@ -16,26 +16,4 @@
  *
  */
 
-export const getPluginId = (plugin: string) => {
-  switch (plugin) {
-    case 'github':
-      return 'githubId';
-    case 'jira':
-      return 'boardId';
-    case 'gitlab':
-      return 'gitlabId';
-
-    // TODO: this should be just id... or similar
-    case 'clickup':
-      return 'Id';
-
-    case 'jenkins':
-      return 'jobFullName';
-    case 'bitbucket':
-      return 'bitbucketId';
-    case 'sonarqube':
-      return 'projectKey';
-    default:
-      return 'id';
-  }
-};
+export * from './auth';

--- a/config-ui/src/plugins/register/clickup/connection-fields/styled.ts
+++ b/config-ui/src/plugins/register/clickup/connection-fields/styled.ts
@@ -16,26 +16,18 @@
  *
  */
 
-export const getPluginId = (plugin: string) => {
-  switch (plugin) {
-    case 'github':
-      return 'githubId';
-    case 'jira':
-      return 'boardId';
-    case 'gitlab':
-      return 'gitlabId';
+import { Colors } from '@blueprintjs/core';
+import styled from 'styled-components';
 
-    // TODO: this should be just id... or similar
-    case 'clickup':
-      return 'Id';
+export const Label = styled.label`
+  font-size: 16px;
+  font-weight: 600;
+`;
 
-    case 'jenkins':
-      return 'jobFullName';
-    case 'bitbucket':
-      return 'bitbucketId';
-    case 'sonarqube':
-      return 'projectKey';
-    default:
-      return 'id';
-  }
-};
+export const LabelInfo = styled.i`
+  color: #ff8b8b;
+`;
+
+export const LabelDescription = styled.p`
+  margin: 0;
+`;

--- a/config-ui/src/plugins/register/clickup/data-scope.tsx
+++ b/config-ui/src/plugins/register/clickup/data-scope.tsx
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { useMemo } from 'react';
+
+import { DataScopeMillerColumns } from '@/plugins';
+
+import type { ScopeItemType } from './types';
+import * as S from './styled';
+
+interface Props {
+  connectionId: ID;
+  disabledItems?: ScopeItemType[];
+  selectedItems: ScopeItemType[];
+  onChangeItems: (selectedItems: ScopeItemType[]) => void;
+}
+
+export const ClickUpDataScope = ({ connectionId, onChangeItems, ...props }: Props) => {
+  const selectedItems = useMemo(
+    () => props.selectedItems.map((it) => ({ id: `${it.id}`, name: it.name, data: it })),
+    [props.selectedItems],
+  );
+
+  const disabledItems = useMemo(
+    () => (props.disabledItems ?? []).map((it) => ({ id: `${it.id}`, name: it.name, data: it })),
+    [props.disabledItems],
+  );
+
+  return (
+    <S.DataScope>
+      <h3>ClickUp Scopes*</h3>
+      <DataScopeMillerColumns
+        title="Spaces"
+        columnCount={1}
+        plugin="clickup"
+        connectionId={connectionId}
+        selectedItems={selectedItems}
+        onChangeItems={onChangeItems}
+      />
+    </S.DataScope>
+  );
+};

--- a/config-ui/src/plugins/register/clickup/styled.ts
+++ b/config-ui/src/plugins/register/clickup/styled.ts
@@ -16,26 +16,6 @@
  *
  */
 
-export const getPluginId = (plugin: string) => {
-  switch (plugin) {
-    case 'github':
-      return 'githubId';
-    case 'jira':
-      return 'boardId';
-    case 'gitlab':
-      return 'gitlabId';
+import styled from 'styled-components';
 
-    // TODO: this should be just id... or similar
-    case 'clickup':
-      return 'Id';
-
-    case 'jenkins':
-      return 'jobFullName';
-    case 'bitbucket':
-      return 'bitbucketId';
-    case 'sonarqube':
-      return 'projectKey';
-    default:
-      return 'id';
-  }
-};
+export const DataScope = styled.div``;

--- a/config-ui/src/plugins/register/clickup/types.ts
+++ b/config-ui/src/plugins/register/clickup/types.ts
@@ -16,26 +16,8 @@
  *
  */
 
-export const getPluginId = (plugin: string) => {
-  switch (plugin) {
-    case 'github':
-      return 'githubId';
-    case 'jira':
-      return 'boardId';
-    case 'gitlab':
-      return 'gitlabId';
-
-    // TODO: this should be just id... or similar
-    case 'clickup':
-      return 'Id';
-
-    case 'jenkins':
-      return 'jobFullName';
-    case 'bitbucket':
-      return 'bitbucketId';
-    case 'sonarqube':
-      return 'projectKey';
-    default:
-      return 'id';
-  }
+export type ScopeItemType = {
+  connectionId: ID;
+  id: ID;
+  name: string;
 };


### PR DESCRIPTION
:wave: This is a (working :tm: ) WIP for ClickUp Support based on my on-and-off work on this for the past months.

First of all:

- This is targeted on 0.17 as I didn't have time to update to the UI changes.
- There are no tests (:open_mouth: )
- ClickUp doesn't natively support task types (:open_mouth: ) so we've added a custom field

Supported entities:

- Tasks (issues)
- Folders/Lists (sprints)
- Users
- Spaces (boards - see below)
- Task time in status

Opinions (which should be configuration options)

- [ ] We map the clickup "custom id" (e.g. `PRJ-1234`) as `issue_key` instead of the default ID `#8ndsdc_123`. Custom IDs need to be enabled in ClickUp.
- [ ] Spaces are mapped to "boards", but a "board" in ClickUp is more like a "list" and a space maps to the concept of "project" in JIRA. So this is probably a mis-mapping.
- [ ] Custom field for type is `Type` and needs to be configurable (or a hard opinion)

Hopefully I get time to work on this PR further, but wanted to share the WIP.

