### PR TITLE
fix: data too long for column file_metrics_key

### DIFF
--- a/backend/plugins/sonarqube/models/migrationscripts/20230927_modify_file_metrics_key_length.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/20230927_modify_file_metrics_key_length.go
@@ -55,23 +55,19 @@ func (script *modifyFileMetricsKeyLength) Up(basicRes context.BasicRes) errors.E
 		},
 	)
 	if err != nil {
-		tx.Rollback()
-		return err
+		return tx.Rollback()
 	}
 
 	if err = tx.Exec("ALTER TABLE _tool_sonarqube_file_metrics DROP PRIMARY KEY"); err != nil {
-		tx.Rollback()
-		return err
+		return tx.Rollback()
 	}
 
 	if err := tx.Exec("ALTER TABLE _tool_sonarqube_file_metrics ADD PRIMARY KEY (connection_id, file_metrics_key)"); err != nil {
-		tx.Rollback()
-		return err
+		return tx.Rollback()
 	}
 
 	if err := tx.Commit(); err != nil {
-		tx.Rollback()
-		return err
+		return tx.Rollback()
 	}
 
 	return nil

--- a/backend/plugins/sonarqube/models/migrationscripts/20230927_modify_file_metrics_key_length.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/20230927_modify_file_metrics_key_length.go
@@ -30,7 +30,7 @@ var _ plugin.MigrationScript = (*modifyFileMetricsKeyLength)(nil)
 type modifyFileMetricsKeyLength struct{}
 
 type fileMetricsKey20230927 struct {
-	FileMetricsKey string `gorm:"type:varchar(500);primary_key"`
+	FileMetricsKey string `gorm:"primaryKey;type:varchar(500)"`
 }
 
 func (fileMetricsKey20230927) TableName() string {
@@ -39,7 +39,7 @@ func (fileMetricsKey20230927) TableName() string {
 
 func (script *modifyFileMetricsKeyLength) Up(basicRes context.BasicRes) errors.Error {
 	db := basicRes.GetDal()
-	return migrationhelper.ChangeColumnsType[fileMetricsKey20230927](
+	err := migrationhelper.ChangeColumnsType[fileMetricsKey20230927](
 		basicRes,
 		script,
 		fileMetricsKey20230927{}.TableName(),
@@ -53,10 +53,19 @@ func (script *modifyFileMetricsKeyLength) Up(basicRes context.BasicRes) errors.E
 			)
 		},
 	)
+	if err != nil {
+		return err
+	}
+	err = db.Exec("ALTER TABLE _tool_sonarqube_file_metrics DROP PRIMARY KEY;")
+	if err != nil {
+		return err
+	}
+
+	return db.Exec("ALTER TABLE _tool_sonarqube_file_metrics ADD PRIMARY KEY (connection_id, file_metrics_key)")
 }
 
 func (*modifyFileMetricsKeyLength) Version() uint64 {
-	return 20230927145125
+	return 20230927145127
 }
 
 func (*modifyFileMetricsKeyLength) Name() string {

--- a/backend/plugins/sonarqube/models/migrationscripts/20230927_modify_file_metrics_key_length.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/20230927_modify_file_metrics_key_length.go
@@ -1,0 +1,64 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+)
+
+var _ plugin.MigrationScript = (*modifyFileMetricsKeyLength)(nil)
+
+type modifyFileMetricsKeyLength struct{}
+
+type fileMetricsKey20230927 struct {
+	FileMetricsKey string `gorm:"type:varchar(500);primary_key"`
+}
+
+func (fileMetricsKey20230927) TableName() string {
+	return "_tool_sonarqube_file_metrics"
+}
+
+func (script *modifyFileMetricsKeyLength) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	return migrationhelper.ChangeColumnsType[fileMetricsKey20230927](
+		basicRes,
+		script,
+		fileMetricsKey20230927{}.TableName(),
+		[]string{"file_metrics_key"},
+		func(tmpColumnParams []interface{}) errors.Error {
+			return db.UpdateColumn(
+				&fileMetricsKey20230927{},
+				"file_metrics_key",
+				dal.DalClause{Expr: " ? ", Params: tmpColumnParams},
+				dal.Where("? != '' ", tmpColumnParams...),
+			)
+		},
+	)
+}
+
+func (*modifyFileMetricsKeyLength) Version() uint64 {
+	return 20230927145125
+}
+
+func (*modifyFileMetricsKeyLength) Name() string {
+	return "modify _tool_sonarqube_file_metrics file_metrics_key from varchar(191) to varchar(500)"
+}

--- a/backend/plugins/sonarqube/models/migrationscripts/register.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/register.go
@@ -26,5 +26,6 @@ func All() []plugin.MigrationScript {
 		new(modifyCharacterSet),
 		new(expandProjectKey20230206),
 		new(addRawParamTableForScope),
+		new(modifyFileMetricsKeyLength),
 	}
 }

--- a/backend/plugins/sonarqube/models/sonarqube_file_metrics.go
+++ b/backend/plugins/sonarqube/models/sonarqube_file_metrics.go
@@ -23,7 +23,7 @@ import (
 
 type SonarqubeFileMetrics struct {
 	ConnectionId             uint64 `gorm:"primaryKey"`
-	FileMetricsKey           string `gorm:"primaryKey"`
+	FileMetricsKey           string `gorm:"type:varchar(500);primary_key"`
 	ProjectKey               string `gorm:"index"`
 	FileName                 string
 	FilePath                 string
@@ -51,7 +51,7 @@ func (SonarqubeFileMetrics) TableName() string {
 
 type SonarqubeAdditionalFileMetrics struct {
 	ConnectionId                        uint64 `gorm:"primaryKey"`
-	FileMetricsKey                      string `gorm:"primaryKey"`
+	FileMetricsKey                      string `gorm:"type:varchar(500);primary_key"`
 	DuplicatedFiles                     int
 	DuplicatedLines                     int
 	EffortToReachMaintainabilityRatingA int
@@ -69,7 +69,7 @@ func (SonarqubeAdditionalFileMetrics) TableName() string {
 
 type SonarqubeWholeFileMetrics struct {
 	ConnectionId                        uint64 `gorm:"primaryKey"`
-	FileMetricsKey                      string `gorm:"primaryKey"`
+	FileMetricsKey                      string `gorm:"type:varchar(500);primary_key"`
 	ProjectKey                          string `gorm:"index"`
 	FileName                            string `gorm:"type:varchar(255)"`
 	FilePath                            string

--- a/backend/plugins/sonarqube/models/sonarqube_file_metrics.go
+++ b/backend/plugins/sonarqube/models/sonarqube_file_metrics.go
@@ -23,7 +23,7 @@ import (
 
 type SonarqubeFileMetrics struct {
 	ConnectionId             uint64 `gorm:"primaryKey"`
-	FileMetricsKey           string `gorm:"type:varchar(500);primary_key"`
+	FileMetricsKey           string `gorm:"primaryKey;type:varchar(500)"`
 	ProjectKey               string `gorm:"index"`
 	FileName                 string
 	FilePath                 string
@@ -51,7 +51,7 @@ func (SonarqubeFileMetrics) TableName() string {
 
 type SonarqubeAdditionalFileMetrics struct {
 	ConnectionId                        uint64 `gorm:"primaryKey"`
-	FileMetricsKey                      string `gorm:"type:varchar(500);primary_key"`
+	FileMetricsKey                      string `gorm:"primaryKey;type:varchar(500)"`
 	DuplicatedFiles                     int
 	DuplicatedLines                     int
 	EffortToReachMaintainabilityRatingA int
@@ -69,7 +69,7 @@ func (SonarqubeAdditionalFileMetrics) TableName() string {
 
 type SonarqubeWholeFileMetrics struct {
 	ConnectionId                        uint64 `gorm:"primaryKey"`
-	FileMetricsKey                      string `gorm:"type:varchar(500);primary_key"`
+	FileMetricsKey                      string `gorm:"primaryKey;type:varchar(500)"`
 	ProjectKey                          string `gorm:"index"`
 	FileName                            string `gorm:"type:varchar(255)"`
 	FilePath                            string


### PR DESCRIPTION
### Summary
modify _tool_sonarqube_file_metrics file_metrics_key from varchar(191) to varchar(500)

### Does this close any open issues?
Closes #6150

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/7adf2ddc-53ec-4bc6-b4e0-4e3a38996eab)


### Other Information
Any other information that is important to this PR.
