### PR TITLE
fix: use http 1.1 for config-ui nginx proxy

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -19,6 +19,8 @@ ${SERVER_CONF}
     proxy_send_timeout 60s;
     proxy_read_timeout 60s;
     proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target;
+    proxy_http_version 1.1;
+    proxy_set_header   "Connection" "";
   }
 
   location /api/rest/ {
@@ -30,6 +32,8 @@ ${SERVER_CONF}
     proxy_send_timeout 60s;
     proxy_read_timeout 60s;
     proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target;
+    proxy_http_version 1.1;
+    proxy_set_header   "Connection" "";
   }
 
   location /grafana/ {
@@ -47,6 +51,8 @@ ${SERVER_CONF}
     proxy_send_timeout 60s;
     proxy_read_timeout 60s;
     proxy_pass ${GRAFANA_ENDPOINT_PROTO}://$target;
+    proxy_http_version 1.1;
+    proxy_set_header   "Connection" "";
   }
 
   location /health/ {


### PR DESCRIPTION

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Change config-ui nginx configuration to use http 1.1 instead of http 1.0 as 1.1 offers more compatibility with other proxies like envoy and has better performance

### Does this close any open issues?
Closes #6190 
