### PR TITLE
fix(plugins): update  connection scope config helper, set connection …

### DIFF
--- a/backend/core/models/common/base.go
+++ b/backend/core/models/common/base.go
@@ -18,6 +18,7 @@ limitations under the License.
 package common
 
 import (
+	"github.com/apache/incubator-devlake/core/dal"
 	"time"
 )
 
@@ -98,7 +99,7 @@ type ScopeConfig struct {
 	Model
 	Entities     []string `gorm:"type:json;serializer:json" json:"entities" mapstructure:"entities"`
 	ConnectionId uint64   `json:"connectionId" gorm:"index" validate:"required" mapstructure:"connectionId,omitempty"`
-	Name         string   `mapstructure:"name" json:"name" gorm:"type:varchar(255)" validate:"required"`
+	//Name         string   `mapstructure:"name" json:"name" gorm:"type:varchar(255)" validate:"required"`
 }
 
 func (s ScopeConfig) ScopeConfigConnectionId() uint64 {
@@ -106,4 +107,9 @@ func (s ScopeConfig) ScopeConfigConnectionId() uint64 {
 }
 func (s ScopeConfig) ScopeConfigId() uint64 {
 	return s.ID
+}
+
+type ScopeConfigOperator[T dal.Tabler] interface {
+	*T
+	SetConnectionId(t *T, connectionId uint64)
 }

--- a/backend/plugins/bamboo/api/init.go
+++ b/backend/plugins/bamboo/api/init.go
@@ -29,7 +29,7 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var scopeHelper *api.ScopeApiHelper[models.BambooConnection, models.BambooPlan, models.BambooScopeConfig]
 var remoteHelper *api.RemoteApiHelper[models.BambooConnection, models.BambooPlan, models.ApiBambooPlan, api.NoRemoteGroupResponse]
-var scopeConfigHelper *api.ScopeConfigHelper[models.BambooScopeConfig]
+var scopeConfigHelper *api.ScopeConfigHelper[models.BambooScopeConfig, *models.BambooScopeConfig]
 
 var basicRes context.BasicRes
 
@@ -62,7 +62,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		vld,
 		connectionHelper,
 	)
-	scopeConfigHelper = api.NewScopeConfigHelper[models.BambooScopeConfig](
+	scopeConfigHelper = api.NewScopeConfigHelper[models.BambooScopeConfig, *models.BambooScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/bamboo/models/scope_config.go
+++ b/backend/plugins/bamboo/models/scope_config.go
@@ -37,6 +37,11 @@ func (BambooScopeConfig) TableName() string {
 	return "_tool_bamboo_scope_configs"
 }
 
+func (cfg *BambooScopeConfig) SetConnectionId(c *BambooScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}
+
 func (cfg *BambooScopeConfig) GetRepoIdMap() map[int]string {
 	repoMap := make(map[int]string)
 	for k, v := range cfg.RepoMap {

--- a/backend/plugins/bitbucket/api/init.go
+++ b/backend/plugins/bitbucket/api/init.go
@@ -29,7 +29,7 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var scopeHelper *api.ScopeApiHelper[models.BitbucketConnection, models.BitbucketRepo, models.BitbucketScopeConfig]
 var remoteHelper *api.RemoteApiHelper[models.BitbucketConnection, models.BitbucketRepo, models.BitbucketApiRepo, models.GroupResponse]
-var scHelper *api.ScopeConfigHelper[models.BitbucketScopeConfig]
+var scHelper *api.ScopeConfigHelper[models.BitbucketScopeConfig, *models.BitbucketScopeConfig]
 var basicRes context.BasicRes
 
 func Init(br context.BasicRes, p plugin.PluginMeta) {
@@ -61,7 +61,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		vld,
 		connectionHelper,
 	)
-	scHelper = api.NewScopeConfigHelper[models.BitbucketScopeConfig](
+	scHelper = api.NewScopeConfigHelper[models.BitbucketScopeConfig, *models.BitbucketScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/bitbucket/models/scope_config.go
+++ b/backend/plugins/bitbucket/models/scope_config.go
@@ -40,3 +40,8 @@ type BitbucketScopeConfig struct {
 func (BitbucketScopeConfig) TableName() string {
 	return "_tool_bitbucket_scope_configs"
 }
+
+func (cfg *BitbucketScopeConfig) SetConnectionId(c *BitbucketScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}

--- a/backend/plugins/circleci/api/init.go
+++ b/backend/plugins/circleci/api/init.go
@@ -28,7 +28,7 @@ import (
 var vld *validator.Validate
 var connectionHelper *helper.ConnectionApiHelper
 var scopeHelper *helper.ScopeApiHelper[models.CircleciConnection, models.CircleciProject, models.CircleciScopeConfig]
-var scHelper *helper.ScopeConfigHelper[models.CircleciScopeConfig]
+var scHelper *helper.ScopeConfigHelper[models.CircleciScopeConfig, *models.CircleciScopeConfig]
 var remoteHelper *helper.RemoteApiHelper[models.CircleciConnection, models.CircleciProject, RemoteProject, helper.NoRemoteGroupResponse]
 var basicRes context.BasicRes
 
@@ -60,7 +60,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		vld,
 		connectionHelper,
 	)
-	scHelper = helper.NewScopeConfigHelper[models.CircleciScopeConfig](
+	scHelper = helper.NewScopeConfigHelper[models.CircleciScopeConfig, *models.CircleciScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/circleci/models/scope_config.go
+++ b/backend/plugins/circleci/models/scope_config.go
@@ -32,3 +32,8 @@ type CircleciScopeConfig struct {
 func (t CircleciScopeConfig) TableName() string {
 	return "_tool_circleci_scope_configs"
 }
+
+func (t *CircleciScopeConfig) SetConnectionId(c *CircleciScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}

--- a/backend/plugins/jenkins/api/init.go
+++ b/backend/plugins/jenkins/api/init.go
@@ -31,7 +31,7 @@ var scopeHelper *api.ScopeApiHelper[models.JenkinsConnection, models.JenkinsJob,
 var remoteHelper *api.RemoteApiHelper[models.JenkinsConnection, models.JenkinsJob, models.Job, models.Job]
 
 var basicRes context.BasicRes
-var scHelper *api.ScopeConfigHelper[models.JenkinsScopeConfig]
+var scHelper *api.ScopeConfigHelper[models.JenkinsScopeConfig, *models.JenkinsScopeConfig]
 
 func Init(br context.BasicRes, p plugin.PluginMeta) {
 
@@ -62,7 +62,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		vld,
 		connectionHelper,
 	)
-	scHelper = api.NewScopeConfigHelper[models.JenkinsScopeConfig](
+	scHelper = api.NewScopeConfigHelper[models.JenkinsScopeConfig, *models.JenkinsScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/jenkins/models/scope_config.go
+++ b/backend/plugins/jenkins/models/scope_config.go
@@ -32,3 +32,8 @@ type JenkinsScopeConfig struct {
 func (t JenkinsScopeConfig) TableName() string {
 	return "_tool_jenkins_scope_configs"
 }
+
+func (t *JenkinsScopeConfig) SetConnectionId(c *JenkinsScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}

--- a/backend/plugins/jira/api/init.go
+++ b/backend/plugins/jira/api/init.go
@@ -31,7 +31,7 @@ var connectionHelper *api.ConnectionApiHelper
 var scopeHelper *api.ScopeApiHelper[models.JiraConnection, models.JiraBoard, models.JiraScopeConfig]
 var remoteHelper *api.RemoteApiHelper[models.JiraConnection, models.JiraBoard, apiv2models.Board, api.NoRemoteGroupResponse]
 var basicRes context.BasicRes
-var scHelper *api.ScopeConfigHelper[models.JiraScopeConfig]
+var scHelper *api.ScopeConfigHelper[models.JiraScopeConfig, *models.JiraScopeConfig]
 
 func Init(br context.BasicRes, p plugin.PluginMeta) {
 
@@ -63,7 +63,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		vld,
 		connectionHelper,
 	)
-	scHelper = api.NewScopeConfigHelper[models.JiraScopeConfig](
+	scHelper = api.NewScopeConfigHelper[models.JiraScopeConfig, *models.JiraScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/jira/models/scope_config.go
+++ b/backend/plugins/jira/models/scope_config.go
@@ -52,6 +52,11 @@ type JiraScopeConfig struct {
 	ApplicationType            string                 `mapstructure:"applicationType,omitempty" json:"applicationType" gorm:"type:varchar(255)"`
 }
 
+func (r *JiraScopeConfig) SetConnectionId(c *JiraScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}
+
 func (r *JiraScopeConfig) Validate() errors.Error {
 	var err error
 	if r.RemotelinkCommitShaPattern != "" {

--- a/backend/plugins/tapd/api/init.go
+++ b/backend/plugins/tapd/api/init.go
@@ -30,7 +30,7 @@ var connectionHelper *api.ConnectionApiHelper
 var basicRes context.BasicRes
 var scopeHelper *api.ScopeApiHelper[models.TapdConnection, models.TapdWorkspace, models.TapdScopeConfig]
 var remoteHelper *api.RemoteApiHelper[models.TapdConnection, models.TapdWorkspace, models.TapdWorkspace, api.BaseRemoteGroupResponse]
-var scHelper *api.ScopeConfigHelper[models.TapdScopeConfig]
+var scHelper *api.ScopeConfigHelper[models.TapdScopeConfig, *models.TapdScopeConfig]
 
 func Init(br context.BasicRes, p plugin.PluginMeta) {
 
@@ -61,7 +61,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		vld,
 		connectionHelper,
 	)
-	scHelper = api.NewScopeConfigHelper[models.TapdScopeConfig](
+	scHelper = api.NewScopeConfigHelper[models.TapdScopeConfig, *models.TapdScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/tapd/models/scope_config.go
+++ b/backend/plugins/tapd/models/scope_config.go
@@ -32,3 +32,8 @@ type TapdScopeConfig struct {
 func (t TapdScopeConfig) TableName() string {
 	return "_tool_tapd_scope_configs"
 }
+
+func (t *TapdScopeConfig) SetConnectionId(c *TapdScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}

--- a/backend/plugins/trello/api/init.go
+++ b/backend/plugins/trello/api/init.go
@@ -29,7 +29,7 @@ var vld *validator.Validate
 var connectionHelper *api.ConnectionApiHelper
 var scopeHelper *api.ScopeApiHelper[models.TrelloConnection, models.TrelloBoard, models.TrelloScopeConfig]
 var basicRes context.BasicRes
-var scHelper *api.ScopeConfigHelper[models.TrelloScopeConfig]
+var scHelper *api.ScopeConfigHelper[models.TrelloScopeConfig, *models.TrelloScopeConfig]
 
 func Init(br context.BasicRes, p plugin.PluginMeta) {
 	basicRes = br
@@ -53,7 +53,7 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 		params,
 		nil,
 	)
-	scHelper = api.NewScopeConfigHelper[models.TrelloScopeConfig](
+	scHelper = api.NewScopeConfigHelper[models.TrelloScopeConfig, *models.TrelloScopeConfig](
 		basicRes,
 		vld,
 		p.Name(),

--- a/backend/plugins/trello/models/scope_config.go
+++ b/backend/plugins/trello/models/scope_config.go
@@ -30,3 +30,8 @@ type TrelloScopeConfig struct {
 func (TrelloScopeConfig) TableName() string {
 	return "_tool_trello_scope_configs"
 }
+
+func (t *TrelloScopeConfig) SetConnectionId(c *TrelloScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}

--- a/backend/plugins/zentao/api/init.go
+++ b/backend/plugins/zentao/api/init.go
@@ -38,7 +38,7 @@ var projectScopeHelper *api.ScopeApiHelper[models.ZentaoConnection, models.Zenta
 
 var projectRemoteHelper *api.RemoteApiHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.BaseRemoteGroupResponse]
 var basicRes context.BasicRes
-var scHelper *api.ScopeConfigHelper[models.ZentaoScopeConfig]
+var scHelper *api.ScopeConfigHelper[models.ZentaoScopeConfig, *models.ZentaoScopeConfig]
 
 func Init(br context.BasicRes, p plugin.PluginMeta) {
 
@@ -64,5 +64,5 @@ func Init(br context.BasicRes, p plugin.PluginMeta) {
 	)
 
 	projectRemoteHelper = api.NewRemoteHelper[models.ZentaoConnection, models.ZentaoProject, models.ZentaoProject, api.BaseRemoteGroupResponse](basicRes, vld, connectionHelper)
-	scHelper = api.NewScopeConfigHelper[models.ZentaoScopeConfig](basicRes, vld, p.Name())
+	scHelper = api.NewScopeConfigHelper[models.ZentaoScopeConfig, *models.ZentaoScopeConfig](basicRes, vld, p.Name())
 }

--- a/backend/plugins/zentao/models/scope_config.go
+++ b/backend/plugins/zentao/models/scope_config.go
@@ -34,3 +34,8 @@ type ZentaoScopeConfig struct {
 func (t ZentaoScopeConfig) TableName() string {
 	return "_tool_zentao_scope_configs"
 }
+
+func (t *ZentaoScopeConfig) SetConnectionId(c *ZentaoScopeConfig, connectionId uint64) {
+	c.ConnectionId = connectionId
+	c.ScopeConfig.ConnectionId = connectionId
+}


### PR DESCRIPTION
…id by default

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
`connectionId` is parsed from path parameter, and it is an required field in PluginScopeConfig struct. There must be a method to set connection id to ScopeConfig. 
This PR just fix it with golang' generic. Maybe there will be an easier way. I am not sure.
BTW, I removed duplicated field `name` in `common.ScopeConfig`.

### Does this close any open issues?
Closes None.

### Screenshots
Include any relevant screenshots here.
![image](https://github.com/apache/incubator-devlake/assets/5844806/b7f81e5d-ad6a-4f17-9988-4ca206c0e6cd)

### Other Information
Any other information that is important to this PR.
