### PR TITLE
GitHub skipped jobs collected by GraphQL  is not handled properly

### DIFF
--- a/backend/plugins/github/tasks/cicd_job_convertor.go
+++ b/backend/plugins/github/tasks/cicd_job_convertor.go
@@ -99,7 +99,7 @@ func ConvertJobs(taskCtx plugin.SubTaskContext) (err errors.Error) {
 				Result: devops.GetResult(&devops.ResultRule{
 					Failed:  []string{"failure"},
 					Success: []string{"success"},
-					Skipped: []string{"skipped"},
+					Skipped: []string{"skipped", "NEUTRAL"},
 				}, line.Conclusion),
 				Status: devops.GetStatus(&devops.StatusRule[string]{
 					Done:    []string{"completed", "COMPLETED"},


### PR DESCRIPTION
### Summary

GitHub skipped jobs collected by GraphQL come with `conclusion=NEUTRAL` rather than `skipped` from the REST API 
Which causes the converted status to be incorrect.


### Does this close any open issues?
Closes #5885

### Screenshots
<img width="627" alt="Snipaste_2023-10-10_17-01-28" src="https://github.com/apache/incubator-devlake/assets/61080/ad2f95c2-eb01-487b-a35d-d05fbeadb195">
<img width="655" alt="Snipaste_2023-10-10_18-37-36" src="https://github.com/apache/incubator-devlake/assets/61080/3b9c73f7-ccd7-49a7-8fbf-ca98c23c9506">
<img width="321" alt="Snipaste_2023-10-10_18-37-49" src="https://github.com/apache/incubator-devlake/assets/61080/d6195d37-7145-4b75-9bb2-17b387a2911c">
