### PR TITLE
fix(helper): fix api resp when getting scopes

### DIFF
--- a/backend/helpers/pluginhelper/api/scope_helper.go
+++ b/backend/helpers/pluginhelper/api/scope_helper.go
@@ -88,11 +88,11 @@ func (c *ScopeApiHelper[Conn, Scope, Tr]) GetScopeList(input *plugin.ApiResource
 }
 
 func (c *ScopeApiHelper[Conn, Scope, Tr]) GetScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	scope, err := c.GenericScopeApiHelper.GetScope(input)
+	scopeRes, err := c.GenericScopeApiHelper.GetScope(input)
 	if err != nil {
 		return nil, err
 	}
-	return &plugin.ApiResourceOutput{Body: scope, Status: http.StatusOK}, nil
+	return &plugin.ApiResourceOutput{Body: scopeRes.Scope, Status: http.StatusOK}, nil
 }
 
 func (c *ScopeApiHelper[Conn, Scope, Tr]) Delete(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
API HTTP GET /plugins/{plugin_type}/connections/{connection_id}/scopes/{scope_id} will return the detail of scope,but the `createdAd` and `updatedAt` fields are empty struct like`{}`,  and this leads to the error when accosicating scope with a scope config , cause of the lacking of `createdAt` field.
This PR just fix the response of scope detail API, and user can configurate scopes successfully.


### Does this close any open issues?
Closes none.

### Screenshots
Include any relevant screenshots here.
<img width="1122" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/73a6e5df-0a7f-4483-a01f-263b3e5713f6">


### Other Information
Any other information that is important to this PR.
