### PR TITLE
fix(helper): update `ScopeRes` struct, fix empty time field when deco…

### DIFF
--- a/.github/workflows/grafana-dashboards-check.yml
+++ b/.github/workflows/grafana-dashboards-check.yml
@@ -1,3 +1,19 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: check-grafana-dashboards
 
 on:

--- a/backend/helpers/pluginhelper/api/scope_helper.go
+++ b/backend/helpers/pluginhelper/api/scope_helper.go
@@ -88,11 +88,11 @@ func (c *ScopeApiHelper[Conn, Scope, Tr]) GetScopeList(input *plugin.ApiResource
 }
 
 func (c *ScopeApiHelper[Conn, Scope, Tr]) GetScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	scopeRes, err := c.GenericScopeApiHelper.GetScope(input)
+	scope, err := c.GenericScopeApiHelper.GetScope(input)
 	if err != nil {
 		return nil, err
 	}
-	return &plugin.ApiResourceOutput{Body: scopeRes.Scope, Status: http.StatusOK}, nil
+	return &plugin.ApiResourceOutput{Body: scope, Status: http.StatusOK}, nil
 }
 
 func (c *ScopeApiHelper[Conn, Scope, Tr]) Delete(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {

--- a/backend/server/services/remote/plugin/scope_api.go
+++ b/backend/server/services/remote/plugin/scope_api.go
@@ -115,7 +115,7 @@ func convertScopeResponse(scopes ...*api.ScopeRes[models.DynamicScopeModel, mode
 	responses := make([]map[string]any, len(scopes))
 	for i, scope := range scopes {
 		resMap := map[string]any{}
-		err := models.MapTo(scope.ScopeResDoc, &resMap)
+		err := models.MapTo(scope, &resMap)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
…ding by mapstructure

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
`ScopeRes` implement json.Marshaler by`MarshalJSON`. In `MarshalJSON `, it use `github.com/mitchellh/mapstructure`, decode to struct to byte array, and this leads to field like time.Time becomes `{}`, root cause it here: https://github.com/mitchellh/mapstructure/issues/191 mapstructure cannot handle time.Time correctly when decoding something into a flat map.
This PR try to avoid it by updating the struct of `ScopeRes`, it's a follow up of PR #6223 which is not a right way to fix the api resp.

And please notice that: this PR will effect all plugin's scope API resp(screenshot). 

### Does this close any open issues?
Closes none

### Screenshots
Include any relevant screenshots here.
<img width="1128" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/f760103f-c83d-449e-b2b7-231c4216da69">


### Other Information
Any other information that is important to this PR.
