### PR TITLE
cherry pick #6217 fix: skipped github jobs were not handled properly to v0.19

### DIFF
--- a/backend/plugins/github/tasks/cicd_job_convertor.go
+++ b/backend/plugins/github/tasks/cicd_job_convertor.go
@@ -99,7 +99,7 @@ func ConvertJobs(taskCtx plugin.SubTaskContext) (err errors.Error) {
 				Result: devops.GetResult(&devops.ResultRule{
 					Failed:  []string{"failure"},
 					Success: []string{"success"},
-					Skipped: []string{"skipped"},
+					Skipped: []string{"skipped", "NEUTRAL"},
 				}, line.Conclusion),
 				Status: devops.GetStatus(&devops.StatusRule[string]{
 					Done:    []string{"completed", "COMPLETED"},


### PR DESCRIPTION
### Summary
cherry pick #6217 fix: skipped github jobs were not handled properly to v0.19
