### PR TITLE
fix(tapd): workspace's id and parent_id fields are compatible with ui…

### DIFF
--- a/backend/helpers/pluginhelper/api/mapstructure.go
+++ b/backend/helpers/pluginhelper/api/mapstructure.go
@@ -67,9 +67,10 @@ func DecodeHook(f reflect.Type, t reflect.Type, data interface{}) (interface{}, 
 func DecodeMapStruct(input map[string]interface{}, result interface{}, zeroFields bool) errors.Error {
 	result = models.UnwrapObject(result)
 	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		ZeroFields: zeroFields,
-		DecodeHook: mapstructure.ComposeDecodeHookFunc(DecodeHook),
-		Result:     result,
+		ZeroFields:       zeroFields,
+		DecodeHook:       mapstructure.ComposeDecodeHookFunc(DecodeHook),
+		Result:           result,
+		WeaklyTypedInput: true,
 	})
 	if err != nil {
 		return errors.Convert(err)

--- a/backend/plugins/tapd/models/workspace.go
+++ b/backend/plugins/tapd/models/workspace.go
@@ -42,7 +42,7 @@ type WorkspaceResponse struct {
 
 type TapdWorkspace struct {
 	common.Scope `mapstructure:",squash"`
-	Id           uint64          `gorm:"primaryKey;type:BIGINT" mapstructure:"id" json:"id"`
+	Id           uint64          `gorm:"primaryKey;type:BIGINT" mapstructure:"id" json:"id,string"`
 	Name         string          `gorm:"type:varchar(255)" mapstructure:"name" json:"name"`
 	PrettyName   string          `gorm:"type:varchar(255)" mapstructure:"pretty_name" json:"pretty_name"`
 	Category     string          `gorm:"type:varchar(255)" mapstructure:"category" json:"category"`
@@ -51,7 +51,7 @@ type TapdWorkspace struct {
 	BeginDate    *common.CSTTime `mapstructure:"begin_date" json:"begin_date"`
 	EndDate      *common.CSTTime `mapstructure:"end_date" json:"end_date"`
 	ExternalOn   string          `gorm:"type:varchar(255)" mapstructure:"external_on" json:"external_on"`
-	ParentId     uint64          `gorm:"type:BIGINT" mapstructure:"parent_id,string" json:"parent_id"`
+	ParentId     uint64          `gorm:"type:BIGINT" mapstructure:"parent_id,string" json:"parent_id,string"`
 	Creator      string          `gorm:"type:varchar(255)" mapstructure:"creator" json:"creator"`
 	Created      *common.CSTTime `mapstructure:"created" json:"created"`
 }


### PR DESCRIPTION
…nt64 and string types

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
TAPD's api return something like:
```json
{
    "status": 1,
    "data":
    [
        {
            "Workspace":
            {
                "id": "55850509",
                "name": "xx",
                "pretty_name": "55850509",
                "description": "",
                "status": "normal",
                "parent_id": "1",
                "secrecy": "0",
                "created": "2020-11-15 16:34:28",
                "creator_id": "1093132487",
                "creator": "abc",
                "begin_date": null,
                "end_date": null,
                "member_count": 28
            }
        }
    ],
    "info": "success"
```
`id` and `parent_id` is a string which can be parsed to uint64.  Devlake's code regard these two fields as uint64.
This PR just make it run successfully.


### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="1481" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/c4ee6f16-33ce-4c31-97e3-be4096cbc79c">


### Other Information
Any other information that is important to this PR.
