### PR TITLE
feat(zentao): check db url when testing connections

### DIFF
--- a/backend/core/runner/db.go
+++ b/backend/core/runner/db.go
@@ -170,7 +170,6 @@ func CheckDbConnection(dbUrl string, d time.Duration) errors.Error {
 			result <- errors.Convert(err)
 		}
 		if d > 0 {
-			fmt.Println("yyy")
 			var cancel context.CancelFunc
 			ctx, cancel = context.WithTimeout(context.Background(), d)
 			defer cancel()

--- a/backend/plugins/zentao/api/connection.go
+++ b/backend/plugins/zentao/api/connection.go
@@ -19,7 +19,6 @@ package api
 
 import (
 	"context"
-	"fmt"
 	"github.com/apache/incubator-devlake/core/runner"
 	"net/http"
 	"time"
@@ -68,9 +67,7 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		body.Message = err.Error()
 		return &plugin.ApiResourceOutput{Body: body, Status: http.StatusBadRequest}, nil
 	}
-	fmt.Printf("%+v\n", connection)
 	if connection.DbUrl != "" {
-		fmt.Println("xxxx")
 		err = runner.CheckDbConnection(connection.DbUrl, 5*time.Second)
 		if err != nil {
 			body.Success = false

--- a/backend/plugins/zentao/api/connection.go
+++ b/backend/plugins/zentao/api/connection.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"github.com/apache/incubator-devlake/core/runner"
 	"net/http"
 	"time"
@@ -67,7 +68,9 @@ func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, 
 		body.Message = err.Error()
 		return &plugin.ApiResourceOutput{Body: body, Status: http.StatusBadRequest}, nil
 	}
+	fmt.Printf("%+v\n", connection)
 	if connection.DbUrl != "" {
+		fmt.Println("xxxx")
 		err = runner.CheckDbConnection(connection.DbUrl, 5*time.Second)
 		if err != nil {
 			body.Success = false

--- a/config-ui/src/api/connection/index.ts
+++ b/config-ui/src/api/connection/index.ts
@@ -41,6 +41,6 @@ export const test = (
   plugin: string,
   payload: Pick<
     T.ConnectionForm,
-    'endpoint' | 'authMethod' | 'username' | 'password' | 'token' | 'appId' | 'secretKey' | 'proxy'
+    'endpoint' | 'authMethod' | 'username' | 'password' | 'token' | 'appId' | 'secretKey' | 'proxy' | 'dbUrl'
   >,
 ): Promise<T.ConnectionTest> => request(`/plugins/${plugin}/test`, { method: 'post', data: payload });

--- a/config-ui/src/api/connection/types.ts
+++ b/config-ui/src/api/connection/types.ts
@@ -26,6 +26,7 @@ export type Connection = {
   password?: string;
   proxy: string;
   apiKey?: string;
+  dbUrl?: string;
 };
 
 export type ConnectionForm = {
@@ -40,6 +41,7 @@ export type ConnectionForm = {
   enableGraphql?: boolean;
   proxy: string;
   rateLimitPerHour?: number;
+  dbUrl?: string;
 };
 
 export type ConnectionTest = {

--- a/config-ui/src/plugins/components/connection-form/index.tsx
+++ b/config-ui/src/plugins/components/connection-form/index.tsx
@@ -73,6 +73,7 @@ export const ConnectionForm = ({ plugin, connectionId, onSuccess }: Props) => {
             'secretKey',
             'tenantId',
             'tenantType',
+            "dbUrl",
           ]),
         ),
       {

--- a/config-ui/src/store/connections/context.tsx
+++ b/config-ui/src/store/connections/context.tsx
@@ -72,6 +72,7 @@ export const ConnectionContextProvider = ({ children, ...props }: Props) => {
     authMethod,
     secretKey,
     appId,
+    dbUrl,
   }: ConnectionItemType) => {
     try {
       const res = await API.connection.test(plugin, {
@@ -83,6 +84,7 @@ export const ConnectionContextProvider = ({ children, ...props }: Props) => {
         authMethod,
         secretKey,
         appId,
+        dbUrl,
       });
       return res.success ? ConnectionStatusEnum.ONLINE : ConnectionStatusEnum.OFFLINE;
     } catch {
@@ -109,6 +111,7 @@ export const ConnectionContextProvider = ({ children, ...props }: Props) => {
       authMethod: it.authMethod,
       secretKey: it.secretKey,
       appId: it.appId,
+      dbUrl: it.dbUrl,
     }));
   };
 

--- a/config-ui/src/store/connections/types.ts
+++ b/config-ui/src/store/connections/types.ts
@@ -41,4 +41,5 @@ export type ConnectionItemType = {
   authMethod?: string;
   appId?: string;
   secretKey?: string;
+  dbUrl?: string;
 };


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. Add db url field when testing connections for zentao plugin.
2. Fix timeout param when checking db url.

### Does this close any open issues?
Closes #5929

### Screenshots
Include any relevant screenshots here.
correct db url
<img width="1913" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/8a075a1b-6b75-48aa-a25c-e429430700b3">

wrong db url
<img width="1920" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/93f4596c-e361-4d84-84f6-7c3db180c847">



### Other Information
Any other information that is important to this PR.
