### PR TITLE
fix(configui): tagsLimit should be a number

### DIFF
--- a/config-ui/src/plugins/components/scope-config-form/fields/additional-settings.tsx
+++ b/config-ui/src/plugins/components/scope-config-form/fields/additional-settings.tsx
@@ -69,7 +69,7 @@ export const AdditionalSettings = ({ transformation, setTransformation }: Props)
                   ...transformation,
                   refdiff: {
                     ...transformation?.refdiff,
-                    tagsLimit: e.target.value,
+                    tagsLimit: +e.target.value,
                   },
                 })
               }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
tagsLimit should be a number https://github.com/apache/incubator-devlake/blob/main/backend/plugins/refdiff/models/refdiff_options.go#L34 , if it is a string, refdiff task will fail.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="1115" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/b06f7a82-0ee9-46c0-a58b-7784404499a9">


### Other Information
Any other information that is important to this PR.
