### PR TITLE
fix: milestone created_at and updated_at

### DIFF
--- a/backend/plugins/github/models/migrationscripts/register.go
+++ b/backend/plugins/github/models/migrationscripts/register.go
@@ -44,5 +44,6 @@ func All() []plugin.MigrationScript {
 		new(addFullName),
 		new(addRawParamTableForScope),
 		new(addDeploymentTable),
+		new(modifyGithubMilestone),
 	}
 }

--- a/backend/plugins/github/tasks/milestone_converter.go
+++ b/backend/plugins/github/tasks/milestone_converter.go
@@ -100,7 +100,7 @@ func ConvertMilestones(taskCtx plugin.SubTaskContext) errors.Error {
 				Name:            response.GithubMilestone.Title,
 				Url:             response.GithubMilestone.URL,
 				Status:          response.GithubMilestone.State,
-				StartedDate:     &response.GithubMilestone.CreatedAt, //GitHub doesn't give us a "start date"
+				StartedDate:     &response.GithubMilestone.GithubCreatedAt, //GitHub doesn't give us a "start date"
 				EndedDate:       response.GithubMilestone.ClosedAt,
 				CompletedDate:   response.GithubMilestone.ClosedAt,
 				OriginalBoardID: domainBoardId,

--- a/backend/plugins/github/tasks/milestone_extractor.go
+++ b/backend/plugins/github/tasks/milestone_extractor.go
@@ -110,18 +110,18 @@ func ExtractMilestones(taskCtx plugin.SubTaskContext) errors.Error {
 
 func convertGithubMilestone(response *MilestonesResponse, connectionId uint64, repositoryId int) *models.GithubMilestone {
 	milestone := &models.GithubMilestone{
-		ConnectionId: connectionId,
-		MilestoneId:  response.Id,
-		RepoId:       repositoryId,
-		Number:       response.Number,
-		URL:          response.Url,
-		Title:        response.Title,
-		OpenIssues:   response.OpenIssues,
-		ClosedIssues: response.ClosedIssues,
-		State:        response.State,
-		ClosedAt:     common.Iso8601TimeToTime(response.ClosedAt),
-		CreatedAt:    response.CreatedAt.ToTime(),
-		UpdatedAt:    response.UpdatedAt.ToTime(),
+		ConnectionId:    connectionId,
+		MilestoneId:     response.Id,
+		RepoId:          repositoryId,
+		Number:          response.Number,
+		URL:             response.Url,
+		Title:           response.Title,
+		OpenIssues:      response.OpenIssues,
+		ClosedIssues:    response.ClosedIssues,
+		State:           response.State,
+		ClosedAt:        common.Iso8601TimeToTime(response.ClosedAt),
+		GithubCreatedAt: response.CreatedAt.ToTime(),
+		GithubUpdatedAt: response.UpdatedAt.ToTime(),
 	}
 	return milestone
 }


### PR DESCRIPTION
### Summary
fix: milestone created_at and updated_at

The created_at of _tool_github_milestones conflicts with the created_at in NoPKModel.

### Does this close any open issues?
Closes NA

### Screenshots
![4837b79c-34ee-429b-b76e-ea2153eed0e4](https://github.com/apache/incubator-devlake/assets/101256042/f4a209c5-d2d5-49b7-8468-27c29420aa0d)

![12c99f9f-1393-42d8-a415-d7f3973e251f](https://github.com/apache/incubator-devlake/assets/101256042/ccafc73a-29a4-45f2-8590-d6e4f661e276)

![image](https://github.com/apache/incubator-devlake/assets/101256042/4778beb4-4a35-4579-b957-52054fe7b589)



### Other Information
Any other information that is important to this PR.
