### PR TITLE
fix: scope api helper should accept blueprint parameter as singular

### DIFF
--- a/backend/helpers/srvhelper/scope_service_helper.go
+++ b/backend/helpers/srvhelper/scope_service_helper.go
@@ -33,7 +33,7 @@ import (
 type ScopePagination struct {
 	Pagination   `mapstructure:",squash"`
 	ConnectionId uint64 `json:"connectionId" mapstructure:"connectionId" validate:"required"`
-	Blueprints   bool   `json:"blueprints" mapstructure:"blueprints"`
+	Blueprint    bool   `json:"blueprint" mapstructure:"blueprint"`
 }
 
 type ScopeDetail[S plugin.ToolLayerScope, SC plugin.ToolLayerScopeConfig] struct {
@@ -131,7 +131,7 @@ func (scopeSrv *ScopeSrvHelper[C, S, SC]) GetScopesPage(pagination *ScopePaginat
 			Scope:       scope,
 			ScopeConfig: scopeSrv.getScopeConfig(scope.ScopeScopeConfigId()),
 		}
-		if pagination.Blueprints {
+		if pagination.Blueprint {
 			scopeDetail.Blueprints = scopeSrv.getAllBlueprinsByScope(scope.ScopeConnectionId(), scope.ScopeId())
 		}
 		data[i] = scopeDetail


### PR DESCRIPTION
### Summary
fix: scope api helper should accept blueprint parameter as singular


![image](https://github.com/apache/incubator-devlake/assets/61080/dd931951-442d-4a39-b6db-16d9572077a1)
