### PR TITLE
fix(config-ui): missed namespace for data scope select

### DIFF
--- a/config-ui/src/pages/blueprint/connection-detail/index.tsx
+++ b/config-ui/src/pages/blueprint/connection-detail/index.tsx
@@ -212,8 +212,9 @@ export const BlueprintConnectionDetailPage = () => {
         columns={[
           {
             title: 'Data Scope',
-            dataIndex: 'name',
+            dataIndex: ['fullName', 'name'],
             key: 'name',
+            render: ({ fullName, name }) => fullName ?? name,
           },
           {
             title: 'Scope Config',

--- a/config-ui/src/plugins/components/data-scope-select/api.ts
+++ b/config-ui/src/plugins/components/data-scope-select/api.ts
@@ -23,7 +23,7 @@ type ParamsType = {
 } & Pagination;
 
 type ResponseType = {
-  scopes: Array<{ name: string }>;
+  scopes: Array<{ fullName?: string; name: string }>;
   count: number;
 };
 

--- a/config-ui/src/plugins/components/data-scope-select/index.tsx
+++ b/config-ui/src/plugins/components/data-scope-select/index.tsx
@@ -70,7 +70,7 @@ export const DataScopeSelect = ({
       ...res.scopes.map((sc) => ({
         parentId: null,
         id: getPluginScopeId(plugin, sc),
-        title: sc.name,
+        title: sc.fullName ?? sc.name,
         data: sc,
       })),
     ]);


### PR DESCRIPTION
### Summary
Fixed missed namespace for data scope select.

### Does this close any open issues?
Closes #6280 

