### PR TITLE
fix(bamboo): keep plan name same in both /search-remote-scopes and /remote-scopes

### DIFF
--- a/backend/plugins/bamboo/api/remote.go
+++ b/backend/plugins/bamboo/api/remote.go
@@ -20,13 +20,12 @@ package api
 import (
 	gocontext "context"
 	"fmt"
-	"net/url"
-
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/bamboo/models"
+	"net/url"
 )
 
 // RemoteScopes list all available scope for users
@@ -87,7 +86,7 @@ func SearchRemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutp
 			for _, apiResult := range resBody.SearchResults {
 				bambooPlan := models.ApiBambooPlan{
 					Key:  apiResult.SearchEntity.Key,
-					Name: apiResult.SearchEntity.PlanName,
+					Name: apiResult.SearchEntity.Name(),
 				}
 				apiBambooPlans = append(apiBambooPlans, bambooPlan)
 			}

--- a/backend/plugins/bamboo/models/plan.go
+++ b/backend/plugins/bamboo/models/plan.go
@@ -20,6 +20,7 @@ package models
 import (
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"strings"
 )
 
 var _ plugin.ToolLayerScope = (*BambooPlan)(nil)
@@ -106,6 +107,12 @@ type SearchEntity struct {
 	BranchName  string `json:"branchName"`
 	Description string `json:"description"`
 	Type        string `json:"type"`
+}
+
+// Name trys to keep plan's name field the same with name in /remote-scopes.
+// In /remote-scopes, plan's name is "{projectName - planName}".
+func (entity SearchEntity) Name() string {
+	return strings.Join([]string{entity.ProjectName, entity.PlanName}, " - ")
 }
 
 type ApiSearchResult struct {


### PR DESCRIPTION

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
In bamboo, /search/plans.json return json like:
```
{
	"size": 3,
	"searchResults": [
		{
			"id": "HLW-P1",
			"type": "chain",
			"searchEntity": {
				"id": "HLW-P1",
				"key": "HLW-P1",
				"projectName": "hlw",
				"planName": "p1",
				"branchName": "Default",
				"description": "hlw plan descdddd",
				"type": "chain"
			}
		},
		{
			"id": "VDEV-HYP",
			"type": "chain",
			"searchEntity": {
				"id": "VDEV-HYP",
				"key": "VDEV-HYP",
				"projectName": "vdev",
				"planName": "hyperapi",
				"branchName": "master",
				"type": "chain"
			}
		},
		{
			"id": "VDEV-UN",
			"type": "chain",
			"searchEntity": {
				"id": "VDEV-UN",
				"key": "VDEV-UN",
				"projectName": "vdev",
				"planName": "UNITTEST",
				"branchName": "master",
				"type": "chain"
			}
		}
	],
	"start-index": 0,
	"max-result": 3
}
```
planName field is plan's pure name.
while in API /plan.json, resp is like:
```
{
	"expand": "plans",
	"link": {
		"href": "http://18.232.129.138:8085/rest/api/latest/plan",
		"rel": "self"
	},
	"plans": {
		"size": 3,
		"expand": "plan",
		"start-index": 0,
		"max-result": 3,
		"plan": [
			{
				"shortName": "p1",
				"shortKey": "P1",
				"type": "chain",
				"enabled": true,
				"link": {
					"href": "http://ip:port/rest/api/latest/plan/HLW-P1",
					"rel": "self"
				},
				"key": "HLW-P1",
				"name": "hlw - p1",
				"planKey": {
					"key": "HLW-P1"
				}
			}
                         // other elements                 
		]
	}
}
```
plan name is `{projectName} - {planPureName}`.

This PR just keep plan's name the same.

### Does this close any open issues?
Closes N/A


### Screenshots
Include any relevant screenshots here.
<img width="1109" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/6fbeb940-26b9-4057-b8c3-7d7a4b889df6">


### Other Information
Any other information that is important to this PR.
