### PR TITLE
fix: reporting missing scopeConfigId in pathVar when patching gitlab scopeConfig

### DIFF
--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -247,7 +247,7 @@ func (p Gitlab) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 			"POST": api.CreateScopeConfig,
 			"GET":  api.GetScopeConfigList,
 		},
-		"connections/:connectionId/scope-configs/:id": {
+		"connections/:connectionId/scope-configs/:scopeConfigId": {
 			"PATCH":  api.PatchScopeConfig,
 			"GET":    api.GetScopeConfig,
 			"DELETE": api.DeleteScopeConfig,


### PR DESCRIPTION
### Summary

This PR fixes the following error
![image](https://github.com/apache/incubator-devlake/assets/61080/27f9c469-8050-4dcd-9516-76d36ce372dc)
