### PR TITLE
fix(webhook): avoid to return null when there is no webhook connections

### DIFF
--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -153,7 +153,7 @@ func ListConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 	if err != nil {
 		return nil, err
 	}
-	var responseList []*WebhookConnectionResponse
+	responseList := []*WebhookConnectionResponse{}
 	for _, connection := range connections {
 		webhookConnectionResponse, err := formatConnection(&connection, true)
 		if err != nil {


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
when no webhook connection is configurated, the api will return `null` ,which is not same with other plugins.
This pr just fix it,  return `[]`.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="815" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/580a1b24-70d5-4b37-9031-f7ae8f2420d9">


### Other Information
Any other information that is important to this PR.
