### PR TITLE
fix(gitextractor): update close function

### DIFF
--- a/backend/plugins/gitextractor/impl/impl.go
+++ b/backend/plugins/gitextractor/impl/impl.go
@@ -22,7 +22,6 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"github.com/apache/incubator-devlake/plugins/gitextractor/parser"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/tasks"
 )
 
@@ -73,12 +72,14 @@ func (p GitExtractor) PrepareTaskData(taskCtx plugin.TaskContext, options map[st
 }
 
 func (p GitExtractor) Close(taskCtx plugin.TaskContext) errors.Error {
-	if repo, ok := taskCtx.GetData().(*parser.GitRepo); ok {
-		if err := repo.Close(); err != nil {
-			return errors.Convert(err)
+	if taskData, ok := taskCtx.GetData().(*tasks.GitExtractorTaskData); ok {
+		if taskData.GitRepo != nil {
+			if err := taskData.GitRepo.Close(); err != nil {
+				return errors.Convert(err)
+			}
 		}
 	}
-	return nil
+	return errors.Default.New("task ctx is not GitExtractorTaskData which is unexpected")
 }
 
 func (p GitExtractor) RootPkgPath() string {


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
If type assertion failed, it will return nil and this causes data that less then the batch size will be ignored.
This pr just fix it.
1. return an error if type assertion fails.
2. fix the type assertion, make sure gitextractor can be closed as expected.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="836" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/9ef415a0-d29c-4521-a34f-9c731654b706">


### Other Information
Any other information that is important to this PR.
