### PR TITLE
fix(webhook): remove duplicated database locks

### DIFF
--- a/backend/plugins/webhook/api/deployments.go
+++ b/backend/plugins/webhook/api/deployments.go
@@ -20,7 +20,6 @@ package api
 import (
 	"crypto/md5"
 	"fmt"
-	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/helpers/dbhelper"
 	"net/http"
 	"time"
@@ -84,13 +83,8 @@ func PostDeploymentCicdTask(input *plugin.ApiResourceInput) (*plugin.ApiResource
 		return nil, errors.BadInput.Wrap(vld.Struct(request), `input json error`)
 	}
 	txHelper := dbhelper.NewTxHelper(basicRes, &err)
-	defer txHelper.End()
 	tx := txHelper.Begin()
-	err = txHelper.LockTablesTimeout(2*time.Second, dal.LockTables{{Table: "cicd_deployment_commits"}, {Table: "cicd_deployments"}})
-	if err != nil {
-		err = errors.Conflict.Wrap(err, "This CI/CD deployment cannot be post due to a table lock error. There might be running pipeline(s) or other operations in progress.")
-		return nil, err
-	}
+	defer txHelper.End()
 	urlHash16 := fmt.Sprintf("%x", md5.Sum([]byte(request.RepoUrl)))[:16]
 	scopeId := fmt.Sprintf("%s:%d", "webhook", connection.ID)
 	deploymentCommitId := fmt.Sprintf("%s:%d:%s:%s", "webhook", connection.ID, urlHash16, request.CommitSha)


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
When posting a deployment via webhook, table `cicd_deployments` and `cicd_deployment_commits` don't need to be locked. If them are locked, will return an error like:
```
{
	"success": false,
	"message": "Error 1099 (HY000): Table 'cicd_deployment_commits' was locked with a READ lock and can't be updated (500)\nWraps: (2) Error 1099 (HY000): Table 'cicd_deployment_commits' was locked with a READ lock and can't be updated\nError types: (1) *hintdetail.withDetail (2) *mysql.MySQLError",
	"causes": null,
	"data": null
}
```
So just remove `LockTablesTimeout`.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="1321" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/862cedaf-07b2-4eab-954a-a1673a3e7a74">


### Other Information
Any other information that is important to this PR.
