### PR TITLE
fix: config-ui stuck on the loading page if any connection reported 404

### DIFF
--- a/config-ui/src/features/connections/slice.ts
+++ b/config-ui/src/features/connections/slice.ts
@@ -37,7 +37,7 @@ const initialState: {
 export const init = createAsyncThunk('connections/init', async () => {
   const getConnections = async (plugin: string) => {
     try {
-      return API.connection.list(plugin);
+      return await API.connection.list(plugin);
     } catch {
       return [];
     }


### PR DESCRIPTION
### Summary
fix: config-ui stuck on the loading page if any connection reported 404

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/0a104e41-f8c3-4fe8-bec8-fb973d5eb5bc)
