### PR TITLE
fix: jira epics wont be converted to domain layer during the frist run

### DIFF
--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -134,6 +134,9 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectSprintsMeta,
 		tasks.ExtractSprintsMeta,
 
+		tasks.CollectEpicsMeta,
+		tasks.ExtractEpicsMeta,
+
 		tasks.ConvertBoardMeta,
 
 		tasks.ConvertIssuesMeta,
@@ -153,9 +156,6 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 
 		tasks.ExtractAccountsMeta,
 		tasks.ConvertAccountsMeta,
-
-		tasks.CollectEpicsMeta,
-		tasks.ExtractEpicsMeta,
 	}
 }
 

--- a/config-ui/src/features/connections/name.tsx
+++ b/config-ui/src/features/connections/name.tsx
@@ -28,5 +28,5 @@ interface Props {
 
 export const ConnectionName = ({ plugin, connectionId }: Props) => {
   const connection = useAppSelector((state) => selectConnection(state, `${plugin}-${connectionId}`)) as IConnection;
-  return <span>{connection.name}</span>;
+  return <span>{connection ? connection.name : `${plugin}/connections/${connectionId}`}</span>;
 };


### PR DESCRIPTION

### Summary
fix: jira epics wont be converted to domain layer during the frist run

