### PR TITLE
fix: jira epic urls look different than issues on domain layer

### DIFF
--- a/backend/plugins/jira/tasks/issue_convertor.go
+++ b/backend/plugins/jira/tasks/issue_convertor.go
@@ -150,7 +150,10 @@ func convertURL(api, issueKey string) string {
 	if err != nil {
 		return api
 	}
-	before, _, _ := strings.Cut(u.Path, "/rest/agile/1.0/issue")
+	before, _, found := strings.Cut(u.Path, "/rest/agile/1.0/issue")
+	if !found {
+		before, _, _ = strings.Cut(u.Path, "/rest/api/2/issue")
+	}
 	u.Path = filepath.Join(before, "browse", issueKey)
 	return u.String()
 }


### PR DESCRIPTION
### Summary
fix: jira epic urls look different than issues on domain layer


### Screenshots
before:
![image](https://github.com/apache/incubator-devlake/assets/61080/ac4742d7-2991-4918-85e5-09ffb6eef60a)
after:
![image](https://github.com/apache/incubator-devlake/assets/61080/ce4597ff-b725-4007-869c-9bc026549181)


