### PR TITLE
fix: gitlab group projects

### DIFF
--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -104,7 +104,6 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 						resBody = append(resBody, project)
 					}
 				}
-				return resBody, nil
 			} else {
 				if gid[:6] == "group:" {
 					gid = gid[6:]

--- a/backend/plugins/gitlab/api/remote.go
+++ b/backend/plugins/gitlab/api/remote.go
@@ -43,6 +43,7 @@ import (
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/gitlab/connections/{connectionId}/remote-scopes [GET]
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	var resGroup []models.GroupResponse
 	return remoteHelper.GetScopesFromRemote(input,
 		func(basicRes context.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.GitlabConnection) ([]models.GroupResponse, errors.Error) {
 			apiClient, err := api.NewApiClientFromConnection(gocontext.TODO(), basicRes, &connection)
@@ -66,13 +67,11 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 					return nil, err
 				}
 			}
-			var resBody []models.GroupResponse
-			err = api.UnmarshalResponse(res, &resBody)
+			err = api.UnmarshalResponse(res, &resGroup)
 			if err != nil {
 				return nil, err
 			}
-
-			return resBody, err
+			return resGroup, err
 		},
 		func(basicRes context.BasicRes, gid string, queryData *api.RemoteQueryData, connection models.GitlabConnection) ([]models.GitlabApiProject, errors.Error) {
 			apiClient, err := api.NewApiClientFromConnection(gocontext.TODO(), basicRes, &connection)
@@ -94,13 +93,19 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 				}
 
 				for _, project := range resProjects {
-					if project.Permissions.GroupAccess == nil {
+					skipProject := false
+					for _, group := range resGroup {
+						if project.Namespace.Name == group.Name && project.Namespace.Path == group.Path {
+							skipProject = true
+							break
+						}
+					}
+					if !skipProject {
 						resBody = append(resBody, project)
 					}
 				}
-
+				return resBody, nil
 			} else {
-				query.Set("with_shared", "false")
 				if gid[:6] == "group:" {
 					gid = gid[6:]
 				}

--- a/backend/plugins/gitlab/models/project.go
+++ b/backend/plugins/gitlab/models/project.go
@@ -116,6 +116,14 @@ type GitlabApiProject struct {
 	HttpUrlToRepo     string              `json:"http_url_to_repo"`
 	Archived          bool                `json:"archived"`
 	Permissions       Permissions         `json:"permissions"`
+	Namespace         struct {
+		ID       int    `json:"id"`
+		Name     string `json:"name"`
+		Path     string `json:"path"`
+		Kind     string `json:"kind"`
+		FullPath string `json:"full_path"`
+		ParentID any    `json:"parent_id"`
+	} `json:"namespace"`
 }
 
 type Permissions struct {


### PR DESCRIPTION
### Summary

When server add data scope, for groups owned by the login user, items belonging to a certain group will also be displayed in the first column; for items shared with the login user, items belonging to a certain group will only be displayed in the submenu. column

### Does this close any open issues?
close na

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/65367ecc-81ae-4f09-85ba-6f95d444fbd6)


### Other Information
Any other information that is important to this PR.
