### PR TITLE
fix(apikeys): webhook's api keys work with /rest prefix

### DIFF
--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -185,11 +185,11 @@ func GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, e
 
 func formatConnection(connection *models.WebhookConnection, withApiKeyInfo bool) (*WebhookConnectionResponse, errors.Error) {
 	response := &WebhookConnectionResponse{WebhookConnection: *connection}
-	response.PostIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/issues`, connection.ID)
-	response.CloseIssuesEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/issue/:issueKey/close`, connection.ID)
-	response.PostPipelineTaskEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/cicd_tasks`, connection.ID)
-	response.PostPipelineDeployTaskEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/deployments`, connection.ID)
-	response.ClosePipelineEndpoint = fmt.Sprintf(`/plugins/webhook/connections/%d/cicd_pipeline/:pipelineName/finish`, connection.ID)
+	response.PostIssuesEndpoint = fmt.Sprintf(`/rest/plugins/webhook/connections/%d/issues`, connection.ID)
+	response.CloseIssuesEndpoint = fmt.Sprintf(`/rest/plugins/webhook/connections/%d/issue/:issueKey/close`, connection.ID)
+	response.PostPipelineTaskEndpoint = fmt.Sprintf(`/rest/plugins/webhook/connections/%d/cicd_tasks`, connection.ID)
+	response.PostPipelineDeployTaskEndpoint = fmt.Sprintf(`/rest/plugins/webhook/connections/%d/deployments`, connection.ID)
+	response.ClosePipelineEndpoint = fmt.Sprintf(`/rest/plugins/webhook/connections/%d/cicd_pipeline/:pipelineName/finish`, connection.ID)
 	if withApiKeyInfo {
 		db := basicRes.GetDal()
 		apiKeyName := apiKeyHelper.GenApiKeyNameForPlugin(pluginName, connection.ID)

--- a/config-ui/src/routes/api-keys/api-keys.tsx
+++ b/config-ui/src/routes/api-keys/api-keys.tsx
@@ -192,7 +192,7 @@ export const ApiKeys = () => {
             required
           >
             <S.InputContainer>
-              <span>http://localhost:4000/api/rest</span>
+              <span>http://localhost:4000/api/rest/</span>
               <InputGroup
                 placeholder=""
                 value={form.allowedPath}


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
webhooks' api keys and framework's api keys should control path with prefix `/rest`, and the api keys generated by framework can call webhooks' api too.
This PR just makes it works as expected.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
![image](https://github.com/apache/incubator-devlake/assets/5844806/16ddee4b-b1de-481f-bc85-83cf6ff2200b)
![image](https://github.com/apache/incubator-devlake/assets/5844806/5be131c8-6583-422c-b92a-dcfa277fbd17)


### Other Information
Any other information that is important to this PR.
