### PR TITLE
fix: tapd story changelog connecting to record from another connection

### DIFF
--- a/backend/plugins/tapd/e2e/story_changelog_test.go
+++ b/backend/plugins/tapd/e2e/story_changelog_test.go
@@ -119,6 +119,13 @@ func TestTapdStoryChangelogDataFlow(t *testing.T) {
 		),
 	)
 
+	// duplicate existing changelog items to simulate the case that 2 connections having the same changelog items
+	e2ehelper.DuplicateRecords[models.TapdStoryChangelogItem](
+		dataflowTester,
+		map[string]interface{}{
+			"ConnectionId": uint64(2),
+		},
+	)
 	dataflowTester.FlushTabler(&ticket.IssueChangelogs{})
 	dataflowTester.Subtask(tasks.ConvertStoryChangelogMeta, taskData)
 	dataflowTester.VerifyTable(

--- a/backend/plugins/tapd/tasks/story_changelog_converter.go
+++ b/backend/plugins/tapd/tasks/story_changelog_converter.go
@@ -19,6 +19,9 @@ package tasks
 
 import (
 	"fmt"
+	"reflect"
+	"time"
+
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/common"
@@ -28,8 +31,6 @@ import (
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/tapd/models"
-	"reflect"
-	"time"
 )
 
 type StoryChangelogItemResult struct {
@@ -69,10 +70,10 @@ func ConvertStoryChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 	issueIdGen := didgen.NewDomainIdGenerator(&models.TapdStory{})
 	stdTypeMappings := getStdTypeMappings(data)
 	clauses := []dal.Clause{
-		dal.Select("tc.created, tc.id, tc.workspace_id, tc.story_id, tc.creator, _tool_tapd_story_changelog_items.*"),
-		dal.From(&models.TapdStoryChangelogItem{}),
-		dal.Join("left join _tool_tapd_story_changelogs tc on tc.id = _tool_tapd_story_changelog_items.changelog_id "),
-		dal.Where("tc.connection_id = ? AND tc.workspace_id = ?", data.Options.ConnectionId, data.Options.WorkspaceId),
+		dal.Select("c.created, c.id, c.workspace_id, c.story_id, c.creator, i.*"),
+		dal.From("_tool_tapd_story_changelog_items i"),
+		dal.Join("left join _tool_tapd_story_changelogs c on c.id = i.changelog_id and c.connection_id = i.connection_id"),
+		dal.Where("c.connection_id = ? AND c.workspace_id = ?", data.Options.ConnectionId, data.Options.WorkspaceId),
 		dal.Orderby("created DESC"),
 	}
 


### PR DESCRIPTION
### Summary

The cause: The SQL in the `story_changelog_convertor` fails to join tables with the same `connection_id`
The solution: 
- added a helper function to copy and change some of the fields to mimic the situation described in #6336 
- updated the e2e test case to cover the bug


### Does this close any open issues?
Closes #6336

### Screenshots
Before the fix, the updated e2e case would fail:
<img width="647" alt="Snipaste_2023-10-26_17-28-13" src="https://github.com/apache/incubator-devlake/assets/61080/f5f0d393-68af-4cf3-9364-dc2008c2264c">
