### PR TITLE
fix(gitlab): add envNamePattern, and fix missing ScopeConfig

### DIFF
--- a/backend/helpers/pluginhelper/api/enrich_with_regex.go
+++ b/backend/helpers/pluginhelper/api/enrich_with_regex.go
@@ -98,7 +98,7 @@ func (r *RegexEnricher) ReturnNameIfMatched(name string, targets ...string) stri
 	return ""
 }
 
-// ReturnNameIfMatchedOrOmitted returns the given name if regex of the given name is omitted or fallback to ReturnNameIfMatched
+// ReturnNameIfOmittedOrMatched returns the given name if regex of the given name is omitted or fallback to ReturnNameIfMatched
 func (r *RegexEnricher) ReturnNameIfOmittedOrMatched(name string, targets ...string) string {
 	if _, ok := r.regexpMap[name]; !ok {
 		return name

--- a/backend/plugins/gitlab/models/migrationscripts/20231026_add_env_name_pattern_to_tool_gitlab_scope_configs.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20231026_add_env_name_pattern_to_tool_gitlab_scope_configs.go
@@ -18,29 +18,35 @@ limitations under the License.
 package migrationscripts
 
 import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addGitlabCI),
-		new(addPipelineID),
-		new(addPipelineProjects),
-		new(fixDurationToFloat8),
-		new(addTransformationRule20221125),
-		new(addStdTypeToIssue221230),
-		new(addIsDetailRequired20230210),
-		new(addConnectionIdToTransformationRule),
-		new(addGitlabCommitAuthorInfo),
-		new(addTypeEnvToPipeline),
-		new(renameTr2ScopeConfig),
-		new(addGitlabIssueAssignee),
-		new(addMrCommitSha),
-		new(addRawParamTableForScope),
-		new(addProjectArchived),
-		new(addDeployment),
-		new(addEnvNamePattern),
-	}
+var _ plugin.MigrationScript = (*addEnvNamePattern)(nil)
+
+type scopeConfig20231026 struct {
+	EnvNamePattern string `mapstructure:"envNamePattern,omitempty" json:"envNamePattern" gorm:"type:varchar(255)"`
+}
+
+func (scopeConfig20231026) TableName() string {
+	return "_tool_gitlab_scope_configs"
+}
+
+type addEnvNamePattern struct{}
+
+func (script *addEnvNamePattern) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(
+		basicRes,
+		&scopeConfig20231026{},
+	)
+}
+
+func (*addEnvNamePattern) Version() uint64 {
+	return 20231026165000
+}
+
+func (script *addEnvNamePattern) Name() string {
+	return "add env_name_pattern to _tool_gitlab_scope_configs"
 }

--- a/backend/plugins/gitlab/models/scope_config.go
+++ b/backend/plugins/gitlab/models/scope_config.go
@@ -37,6 +37,7 @@ type GitlabScopeConfig struct {
 	IssueTypeRequirement string            `mapstructure:"issueTypeRequirement" json:"issueTypeRequirement"`
 	DeploymentPattern    string            `mapstructure:"deploymentPattern" json:"deploymentPattern"`
 	ProductionPattern    string            `mapstructure:"productionPattern,omitempty" json:"productionPattern" gorm:"type:varchar(255)"`
+	EnvNamePattern       string            `mapstructure:"envNamePattern,omitempty" json:"envNamePattern" gorm:"type:varchar(255)"`
 	Refdiff              datatypes.JSONMap `mapstructure:"refdiff,omitempty" json:"refdiff" swaggertype:"object" format:"json"`
 }
 

--- a/backend/plugins/gitlab/tasks/deployment_convertor.go
+++ b/backend/plugins/gitlab/tasks/deployment_convertor.go
@@ -120,7 +120,9 @@ func ConvertDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 				domainDeployCommit.DurationSec = duration
 			}
 			if data.RegexEnricher != nil {
-				domainDeployCommit.Environment = data.RegexEnricher.ReturnNameIfOmittedOrMatched(devops.PRODUCTION, gitlabDeployment.Environment)
+				if data.RegexEnricher.ReturnNameIfMatched(devops.ENV_NAME_PATTERN, gitlabDeployment.Environment) != "" {
+					domainDeployCommit.Environment = devops.PRODUCTION
+				}
 			}
 
 			domainDeployCommit.CicdDeploymentId = domainDeployCommit.Id

--- a/backend/plugins/gitlab/tasks/task_data.go
+++ b/backend/plugins/gitlab/tasks/task_data.go
@@ -49,8 +49,5 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*GitlabOption
 	if op.ConnectionId == 0 {
 		return nil, errors.BadInput.New("connectionId is invalid")
 	}
-	if op.ScopeConfig == nil && op.ScopeConfigId == 0 {
-		op.ScopeConfig = new(models.GitlabScopeConfig)
-	}
 	return &op, nil
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. add `envNamePattern` to GitLab plugin, it works as the same parameter in Bamboo
2. fix missing `ScopeConfig` in GitLab's task data

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
scope config
![image](https://github.com/apache/incubator-devlake/assets/5844806/d8df975e-1639-4b73-bad5-f66c689d3b28)
env name pattern in db
![image](https://github.com/apache/incubator-devlake/assets/5844806/b0754246-3eeb-4170-93cc-324382876dce)
api response
![image](https://github.com/apache/incubator-devlake/assets/5844806/7d21680d-d168-406f-af53-25d71de56062)
gitlab deployments
![image](https://github.com/apache/incubator-devlake/assets/5844806/da50aefc-300c-44e2-a328-0fe20f2f899b)
domain layer data cicd_deployment_commits
![image](https://github.com/apache/incubator-devlake/assets/5844806/4704fa86-64d4-417b-a0db-6ac205443162)
domain layer data cicd_deployments
![image](https://github.com/apache/incubator-devlake/assets/5844806/cd33be78-584a-46a2-92d6-175196ab14d7)

### Other Information
Any other information that is important to this PR.
