### PR TITLE
cherry-pick 6319 fix: jira epic urls look different than issues on domain layer to v0.19

### DIFF
--- a/backend/plugins/jira/tasks/issue_convertor.go
+++ b/backend/plugins/jira/tasks/issue_convertor.go
@@ -150,7 +150,10 @@ func convertURL(api, issueKey string) string {
 	if err != nil {
 		return api
 	}
-	before, _, _ := strings.Cut(u.Path, "/rest/agile/1.0/issue")
+	before, _, found := strings.Cut(u.Path, "/rest/agile/1.0/issue")
+	if !found {
+		before, _, _ = strings.Cut(u.Path, "/rest/api/2/issue")
+	}
 	u.Path = filepath.Join(before, "browse", issueKey)
 	return u.String()
 }


### PR DESCRIPTION
cherry-pick 6319 fix: jira epic urls look different than issues on domain layer to v0.19