### PR TITLE
cherry-pick #6318 fix: jira epics wont be converted to domain layer at the first run to v0.19

### DIFF
--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -134,6 +134,9 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectSprintsMeta,
 		tasks.ExtractSprintsMeta,
 
+		tasks.CollectEpicsMeta,
+		tasks.ExtractEpicsMeta,
+
 		tasks.ConvertBoardMeta,
 
 		tasks.ConvertIssuesMeta,
@@ -153,9 +156,6 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 
 		tasks.ExtractAccountsMeta,
 		tasks.ConvertAccountsMeta,
-
-		tasks.CollectEpicsMeta,
-		tasks.ExtractEpicsMeta,
 	}
 }
 


### PR DESCRIPTION
cherry-pick #6318 fix: jira epics wont be converted to domain layer at the first run to v0.19