### PR TITLE
refactor(github): move deployment convertor from github_ql to github plugin

### DIFF
--- a/backend/plugins/github/tasks/shared.go
+++ b/backend/plugins/github/tasks/shared.go
@@ -19,7 +19,9 @@ package tasks
 
 import (
 	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/github/models"
 	"github.com/apache/incubator-devlake/plugins/github/utils"
 	"net/http"
 )
@@ -48,4 +50,17 @@ func ignoreHTTPStatus422(res *http.Response) errors.Error {
 		return api.ErrIgnoreAndContinue
 	}
 	return nil
+}
+
+func CreateRawDataSubTaskArgs(taskCtx plugin.SubTaskContext, table string) (*api.RawDataSubTaskArgs, *GithubTaskData) {
+	data := taskCtx.GetData().(*GithubTaskData)
+	RawDataSubTaskArgs := &api.RawDataSubTaskArgs{
+		Ctx: taskCtx,
+		Params: models.GithubApiParams{
+			Name:         data.Options.Name,
+			ConnectionId: data.Options.ConnectionId,
+		},
+		Table: table,
+	}
+	return RawDataSubTaskArgs, data
 }

--- a/backend/plugins/github_graphql/impl/impl.go
+++ b/backend/plugins/github_graphql/impl/impl.go
@@ -127,8 +127,8 @@ func (p GithubGraphql) SubTaskMetas() []plugin.SubTaskMeta {
 		githubTasks.ConvertAccountsMeta,
 
 		// deployment
-		tasks.CollectAndExtractDeploymentMeta,
-		tasks.ConvertDeploymentMeta,
+		tasks.CollectAndExtractDeploymentsMeta,
+		githubTasks.ConvertDeploymentsMeta,
 	}
 }
 

--- a/backend/plugins/github_graphql/tasks/deployment_collector_extractor.go
+++ b/backend/plugins/github_graphql/tasks/deployment_collector_extractor.go
@@ -29,17 +29,17 @@ import (
 	"time"
 )
 
-var _ plugin.SubTaskEntryPoint = CollectAndExtractDeployment
+var _ plugin.SubTaskEntryPoint = CollectAndExtractDeployments
 
 const (
-	RAW_DEPLOYMENT = "github_deployment"
+	RAW_DEPLOYMENT = "github_graphql_deployment"
 )
 
-var CollectAndExtractDeploymentMeta = plugin.SubTaskMeta{
-	Name:             "CollectAndExtractDeployment",
-	EntryPoint:       CollectAndExtractDeployment,
+var CollectAndExtractDeploymentsMeta = plugin.SubTaskMeta{
+	Name:             "CollectAndExtractDeployments",
+	EntryPoint:       CollectAndExtractDeployments,
 	EnabledByDefault: true,
-	Description:      "collect and extract github deployments to raw and tool layer",
+	Description:      "collect and extract github deployments to raw and tool layer from GithubGraphql api",
 	DomainTypes:      []string{plugin.DOMAIN_TYPE_CICD},
 }
 
@@ -84,9 +84,9 @@ type GraphqlQueryDeploymentDeployment struct {
 	UpdatedAt time.Time
 }
 
-// CollectAndExtractDeployment will request github api via graphql and store the result into raw layer by default
+// CollectAndExtractDeployments will request github api via graphql and store the result into raw layer by default
 // ResponseParser's return will be stored to tool layer. So it's called CollectorAndExtractor.
-func CollectAndExtractDeployment(taskCtx plugin.SubTaskContext) errors.Error {
+func CollectAndExtractDeployments(taskCtx plugin.SubTaskContext) errors.Error {
 
 	data := taskCtx.GetData().(*githubTasks.GithubTaskData)
 


### PR DESCRIPTION

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Move deployment convertor from github_ql to github plugin, prepare to add collector with rest API in github plugin.
Rename `_raw_github_deployment` to `_raw_github_graphql_deployment`

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
After refactor, github can still work.
![image](https://github.com/apache/incubator-devlake/assets/5844806/501cf14b-f9fb-459e-b71a-d81241c4c795)

The new raw table:
![image](https://github.com/apache/incubator-devlake/assets/5844806/ee429c0e-9112-4d61-8e46-26619412c37b)

domain layer table
![image](https://github.com/apache/incubator-devlake/assets/5844806/e401ea32-9247-4212-81ac-eaa1443c5a1d)


### Other Information
Any other information that is important to this PR.
