### PR TITLE
fix: gitlab deployment api by order_by=updated_at or order_by=created_at

### DIFF
--- a/backend/plugins/gitlab/tasks/deployment_collector.go
+++ b/backend/plugins/gitlab/tasks/deployment_collector.go
@@ -18,11 +18,14 @@ limitations under the License.
 package tasks
 
 import (
+	"net/url"
+	"time"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"net/url"
-	"time"
+	"github.com/apache/incubator-devlake/plugins/gitlab/models"
+	"golang.org/x/mod/semver"
 )
 
 var _ plugin.SubTaskEntryPoint = CollectDeployment
@@ -62,7 +65,11 @@ func CollectDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 			}
 			// https://gitlab.com/gitlab-org/gitlab/-/issues/328500
 			// https://docs.gitlab.com/ee/api/deployments.html#list-project-deployments
-			query.Set("order_by", "updated_at")
+			if semver.Compare(data.ApiClient.GetData(models.GitlabApiClientData_ApiVersion).(string), "v16.0") >= 0 {
+				query.Set("order_by", "updated_at")
+			} else {
+				query.Set("order_by", "created_at")
+			}
 			if collectorWithState.Since != nil {
 				query.Set("updated_after", collectorWithState.Since.Format(time.RFC3339))
 			}


### PR DESCRIPTION
### Summary
fix: gitlab deployment api by order_by=updated_at or order_by=created_at

### Does this close any open issues?
Closes na

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/5c497892-ab3d-4b54-af04-921278b35107)


### Other Information
Any other information that is important to this PR.
