### PR TITLE
feat: set grafana home to the Homepage dashboard

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -33,4 +33,5 @@ ENV GF_USERS_ALLOW_SIGN_UP=false
 ENV GF_SERVER_SERVE_FROM_SUB_PATH=true
 ENV GF_DASHBOARDS_JSON_ENABLED=true
 ENV GF_LIVE_ALLOWED_ORIGINS='*'
+ENV GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH=/etc/grafana/dashboards/Homepage.json
 RUN grafana-cli plugins install grafana-piechart-panel


### PR DESCRIPTION
### Summary
Make the devlake Homepage dashboard as the default home page of Grafana.
So the **newly added users would land on the dashboard when they log into Grafana**

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/fb5bb7fa-dc39-483e-9b43-391bc00e9357)



