### PR TITLE
fix: avoid browser caching index.html

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -6,9 +6,15 @@ server {
 
 ${SERVER_CONF}
 
+  root /usr/share/nginx/html;
+
+  location = / {
+    add_header Cache-Control no-cache;
+    expires 0;
+    try_files /index.html =404;
+  }
+
   location / {
-    root /usr/share/nginx/html;
-    index index.html;
     try_files $uri /index.html;
   }
 


### PR DESCRIPTION
### Summary
fix: avoid browser caching index.html
The `index.html` wont be cached by the browser while other assets like `.js` `.css` are not affected.

### Screenshots
Before

![image](https://github.com/apache/incubator-devlake/assets/61080/fef06484-684b-4e46-b96f-2d6c610f3b0a)

After

![img_v3_0250_e3a41965-d3f2-487c-8543-44cd62ad38dg](https://github.com/apache/incubator-devlake/assets/61080/200882c3-a9f3-4eeb-a156-b1500b5ca292)
![44f86008-09c7-4450-9de1-6f2325f85639](https://github.com/apache/incubator-devlake/assets/61080/e8a1b2c1-b072-4db0-8957-2c8f7ec9b4d5)


