### PR TITLE
fix: no entities specified, use all entities enabled by default

### DIFF
--- a/backend/helpers/pluginhelper/api/pipeline_plan.go
+++ b/backend/helpers/pluginhelper/api/pipeline_plan.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"fmt"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	plugin "github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/core/utils"
@@ -27,7 +28,7 @@ import (
 // MakePipelinePlanSubtasks generates subtasks list based on sub-task meta information and entities wanted by user
 func MakePipelinePlanSubtasks(subtaskMetas []plugin.SubTaskMeta, entities []string) ([]string, errors.Error) {
 	subtasks := make([]string, 0)
-	// if no entities specified, use all subtasks enabled by default
+	// if no entities specified, use all entities enabled by default
 	if len(entities) == 0 {
 		entities = plugin.DOMAIN_TYPES
 	}

--- a/backend/helpers/pluginhelper/api/pipeline_plan.go
+++ b/backend/helpers/pluginhelper/api/pipeline_plan.go
@@ -27,8 +27,9 @@ import (
 // MakePipelinePlanSubtasks generates subtasks list based on sub-task meta information and entities wanted by user
 func MakePipelinePlanSubtasks(subtaskMetas []plugin.SubTaskMeta, entities []string) ([]string, errors.Error) {
 	subtasks := make([]string, 0)
+	// if no entities specified, use all subtasks enabled by default
 	if len(entities) == 0 {
-		return subtasks, nil
+		entities = plugin.DOMAIN_TYPES
 	}
 	wanted := make(map[string]bool, len(entities))
 	for _, entity := range entities {


### PR DESCRIPTION
### Summary
if no entities, according to the code, then the subtasks are empty, so the skipCollector strategy cannot be carried out through subtasks (that is, matching by whether there is a collect character)

### Does this close any open issues?
Closes na

### Screenshots
previos:
![image](https://github.com/apache/incubator-devlake/assets/101256042/ef061ae6-f602-41c7-9a75-8c95321c7fe1)

now:
![image](https://github.com/apache/incubator-devlake/assets/101256042/13f276e2-18ef-4256-a692-c51a658d8822)


### Other Information
Any other information that is important to this PR.
