### PR TITLE
docs: page and pageSize should not be required

### DIFF
--- a/backend/scripts/build-plugins.sh
+++ b/backend/scripts/build-plugins.sh
@@ -34,6 +34,12 @@ echo "Usage: "
 echo "  build all plugins:              $0 [golang build flags...]"
 echo "  build and keep specified plugins only: DEVLAKE_PLUGINS=github,jira $0 [golang build flags...]"
 
+
+if [ "$DEVLAKE_PLUGINS" = "none" ]; then
+    echo "skip building plugins" > &2
+    exit 0
+fi
+
 ROOT_DIR=$(dirname $(dirname "$0"))
 EXTRA=""
 PLUGIN_SRC_DIR=$ROOT_DIR/plugins

--- a/backend/server/api/apikeys/apikeys.go
+++ b/backend/server/api/apikeys/apikeys.go
@@ -18,14 +18,15 @@ limitations under the License.
 package apikeys
 
 import (
+	"net/http"
+	"strconv"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models"
 	"github.com/apache/incubator-devlake/impls/logruslog"
 	"github.com/apache/incubator-devlake/server/api/shared"
 	"github.com/apache/incubator-devlake/server/services"
 	"github.com/gin-gonic/gin"
-	"net/http"
-	"strconv"
 )
 
 type PaginatedApiKeys struct {
@@ -36,8 +37,8 @@ type PaginatedApiKeys struct {
 // @Summary Get list of api keys
 // @Description GET /api-keys?page=1&pageSize=10
 // @Tags framework/api-keys
-// @Param page query int true "query"
-// @Param pageSize query int true "query"
+// @Param page query int false "query"
+// @Param pageSize query int false "query"
 // @Success 200  {object} PaginatedApiKeys
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"

--- a/backend/server/api/project/project.go
+++ b/backend/server/api/project/project.go
@@ -56,8 +56,8 @@ func GetProject(c *gin.Context) {
 // @Summary Get list of projects
 // @Description GET /projects?page=1&pageSize=10
 // @Tags framework/projects
-// @Param page query int true "query"
-// @Param pageSize query int true "query"
+// @Param page query int false "query"
+// @Param pageSize query int false "query"
 // @Success 200  {object} PaginatedProjects
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"


### PR DESCRIPTION
### Summary

Update the swagger doc to reflect that the `page` and `pageSize` are not required to call APIs

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/21f30bcd-67cd-445f-b572-3c447d7b7467)
