### PR TITLE
fix: Version API response in coming as empty string in v0.20.0-beta1

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -17,7 +17,7 @@
 # https://stackoverflow.com/questions/920413/make-error-missing-separator
 # https://tutorialedge.net/golang/makefiles-for-go-developers/
 
-SHA = $(shell git show -s --format=%h)
+SHA ?= $(shell git show -s --format=%h)
 TAG ?= $(shell git tag --points-at HEAD)
 IMAGE_REPO ?= "apache"
 VERSION = $(TAG)@$(SHA)
@@ -44,7 +44,7 @@ build-plugin:
 	scripts/build-plugins.sh
 
 build-server: swag
-	scripts/build-server.sh
+	VERSION=$(VERSION) scripts/build-server.sh
 
 build-python: #don't mix this with the other build commands
 	scripts/build-python.sh

--- a/backend/scripts/build-server.sh
+++ b/backend/scripts/build-server.sh
@@ -17,6 +17,8 @@
 
 set -e
 
+echo build-server.sh VERSION: $VERSION
+
 ROOT_DIR=$(dirname $(dirname "$0"))
 VERSION=${VERSION:-$(git describe --tags --always --dirty || true)}
 EXTRA=""


### PR DESCRIPTION
### Summary
fix: Version API response in coming as empty string in v0.20.0-beta1

### Does this close any open issues?
Closes #6468

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/6c6382aa-d887-432a-a728-bfcad75cf79a)

