### PR TITLE
fix(pipeline): fix potiential panic

### DIFF
--- a/backend/core/runner/run_pipeline.go
+++ b/backend/core/runner/run_pipeline.go
@@ -68,6 +68,11 @@ func runPipelineTasks(
 		return err
 	}
 
+	// if pipeline has been cancelled, just return.
+	if dbPipeline.Status == models.TASK_CANCELLED {
+		return nil
+	}
+
 	// This double for loop executes each set of tasks sequentially while
 	// executing the set of tasks concurrently.
 	for i, row := range taskIds {
@@ -90,6 +95,10 @@ func runPipelineTasks(
 			}
 		}
 	}
-	log.Info("pipeline finished in %d ms: %v", time.Now().UnixMilli()-dbPipeline.BeganAt.UnixMilli(), err)
+	if dbPipeline.BeganAt != nil {
+		log.Info("pipeline finished in %d ms: %v", time.Now().UnixMilli()-dbPipeline.BeganAt.UnixMilli(), err)
+	} else {
+		log.Info("pipeline finished at %d ms: %v", time.Now().UnixMilli(), err)
+	}
 	return err
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Fix a potiential panic.
When a blueprint is triggered, all pipelines behind it will be executed. If a pipeline is canceled manually. the running pipeline will still go on, and this will lead to a panic.

here are panic logs:
```
[GIN] 2023/11/19 - 22:18:08 | 201 |    10.36002ms |   {ip} | POST     "/blueprints"
time="2023-11-19 22:18:08" level=info msg="path /blueprints/3817/trigger will continue"
time="2023-11-19 22:18:08" level=info msg="try locking tables with timeout 2s"
[GIN] 2023/11/19 - 22:18:08 | 200 |   39.843051ms |   {ip} | POST     "/blueprints/3817/trigger"
time="2023-11-19 22:18:08" level=info msg="path /pipelines will continue"
[GIN] 2023/11/19 - 22:18:08 | 200 |   80.326947ms |   {ip} | GET      "/pipelines?blueprint_id=3817&page=1&pageSize=1&pending=1"
time="2023-11-19 22:18:08" level=info msg="path /pipelines/110925 will continue"
time="2023-11-19 22:18:08" level=info msg=" [pipeline service] get lock and wait next pipeline"
time="2023-11-19 22:18:08" level=info msg=" [pipeline service] run pipeline, 110925, now running runningParallelLabels are [parallel/jenkins_sync]"
[GIN] 2023/11/19 - 22:18:08 | 200 |   53.667161ms |   {ip} | DELETE   "/pipelines/110925"
time="2023-11-19 22:18:08" level=info msg=" [pipeline service] finish pipeline #110925, now runningParallelLabels is []"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x170cb37]

goroutine 184483 [running]:
github.com/apache/incubator-devlake/core/runner.runPipelineTasks({0x20d86d0, 0xc002ab6750}, 0xc003ae8570?, {0xc005a57c18, 0x0, 0xadb90a?}, 0xc005a57dd8)
	/app/backend/core/runner/run_pipeline.go:93 +0x517
github.com/apache/incubator-devlake/core/runner.RunPipeline({0x20d86d0, 0xc002ab6750}, 0xc00283e450?, 0x1a86fa8?)
	/app/backend/core/runner/run_pipeline.go:53 +0x41b
github.com/apache/incubator-devlake/server/services.(*pipelineRunner).runPipelineStandalone(0xc005a57eb0)
	/app/backend/server/services/pipeline_runner.go:41 +0x65
github.com/apache/incubator-devlake/server/services.runPipeline(0xc002aa0f00?)
	/app/backend/server/services/pipeline_runner.go:113 +0x88
github.com/apache/incubator-devlake/server/services.RunPipelineInQueue.func1(0x1b14d, {0xc00310fa70?, 0xe42b26?, 0xc0046b1b00?})
	/app/backend/server/services/pipeline.go:264 +0x1c5
created by github.com/apache/incubator-devlake/server/services.RunPipelineInQueue
	/app/backend/server/services/pipeline.go:255 +0xa7
time="2023-11-19 22:18:11" level=info msg="plugin loaded sonarqube"
time="2023-11-19 22:18:11" level=info msg="plugin loaded sprint-performance-enricher"
time="2023-11-19 22:18:11" level=info msg="plugin loaded starrocks"
time="2023-11-19 22:18:11" level=info msg="plugin loaded tapd"
time="2023-11-19 22:18:12" level=info msg="plugin loaded teambition"
time="2023-11-19 22:18:12" level=info msg="plugin loaded trello"
time="2023-11-19 22:18:12" level=info msg="plugin loaded webhook"
time="2023-11-19 22:18:12" level=info msg="plugin loaded zentao"

```

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
