### PR TITLE
fix: panic during github_graphql task when grabbing deployments

### DIFF
--- a/backend/plugins/github_graphql/tasks/deployment_collector_extractor.go
+++ b/backend/plugins/github_graphql/tasks/deployment_collector_extractor.go
@@ -104,15 +104,11 @@ func CollectAndExtractDeployments(taskCtx plugin.SubTaskContext) errors.Error {
 	if collectorWithState.Since != nil {
 		since = helper.DateTime{Time: *collectorWithState.Since}
 	}
-	enableSince := false
 
 	err = collectorWithState.InitGraphQLCollector(helper.GraphqlCollectorArgs{
 		GraphqlClient: data.GraphqlClient,
 		PageSize:      100,
 		BuildQuery: func(reqData *helper.GraphqlRequestData) (interface{}, map[string]interface{}, error) {
-			if enableSince {
-				return nil, nil, nil
-			}
 			query := &GraphqlQueryDeploymentWrapper{}
 			variables := make(map[string]interface{})
 			if reqData == nil {
@@ -138,7 +134,6 @@ func CollectAndExtractDeployments(taskCtx plugin.SubTaskContext) errors.Error {
 			for _, deployment := range deployments {
 				//Skip deployments with createdAt earlier than 'since'
 				if deployment.CreatedAt.Before(since.Time) {
-					enableSince = true
 					continue
 				}
 				githubDeployment, err := convertGithubDeployment(deployment, data.Options.ConnectionId, data.Options.GithubId)


### PR DESCRIPTION
### Summary
fix: panic during github_graphql task when grabbing deployments

### Does this close any open issues?
Closes #6510

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/0edff3a1-e379-41be-af6b-6f19c746998f)


### Other Information
Any other information that is important to this PR.
