### PR TITLE
fix: config-ui is expecting the parentId to be null for the search remote scopes api

### DIFF
--- a/backend/helpers/pluginhelper/api/ds_remote_api_scope_search_helper.go
+++ b/backend/helpers/pluginhelper/api/ds_remote_api_scope_search_helper.go
@@ -66,6 +66,10 @@ func (rss *DsRemoteApiScopeSearchHelper[C, S]) Get(input *plugin.ApiResourceInpu
 	if err != nil {
 		return nil, err
 	}
+	// the config-ui is expecting the parent id to be null
+	for i := range scopes {
+		scopes[i].ParentId = nil
+	}
 	return &plugin.ApiResourceOutput{
 		Body: map[string]interface{}{
 			"children": scopes,


### PR DESCRIPTION
### Summary
fix: config-ui is expecting the parentId to be null for the search remote scopes API


### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/92b4f763-9345-457b-aadb-388c62c40d37)
