### PR TITLE
fix: gitlab Deployable.Commit.Message can be bigger than 255

### DIFF
--- a/backend/plugins/gitlab/models/deployment.go
+++ b/backend/plugins/gitlab/models/deployment.go
@@ -18,8 +18,9 @@ limitations under the License.
 package models
 
 import (
-	"github.com/apache/incubator-devlake/core/models/common"
 	"time"
+
+	"github.com/apache/incubator-devlake/core/models/common"
 )
 
 type GitlabDeployment struct {
@@ -43,7 +44,7 @@ type GitlabDeployment struct {
 	DeployableCommitAuthorName  string    `json:"deployable_commit_author_name" gorm:"type:varchar(255)"`
 	DeployableCommitCreatedAt   time.Time `json:"deployable_commit_created_at"`
 	DeployableCommitID          string    `json:"deployable_commit_id" gorm:"type:varchar(255)"`
-	DeployableCommitMessage     string    `json:"deployable_commit_message" gorm:"type:varchar(255)"`
+	DeployableCommitMessage     string    `json:"deployable_commit_message"`
 	DeployableCommitShortID     string    `json:"deployable_commit_short_id" gorm:"type:varchar(255)"`
 	DeployableCommitTitle       string    `json:"deployable_commit_title" gorm:"type:varchar(255)"`
 

--- a/backend/plugins/gitlab/models/migrationscripts/20231207_modify_deployment_message_type.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20231207_modify_deployment_message_type.go
@@ -18,31 +18,31 @@ limitations under the License.
 package migrationscripts
 
 import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 )
 
-// All return all the migration scripts
-func All() []plugin.MigrationScript {
-	return []plugin.MigrationScript{
-		new(addInitTables),
-		new(addGitlabCI),
-		new(addPipelineID),
-		new(addPipelineProjects),
-		new(fixDurationToFloat8),
-		new(addTransformationRule20221125),
-		new(addStdTypeToIssue221230),
-		new(addIsDetailRequired20230210),
-		new(addConnectionIdToTransformationRule),
-		new(addGitlabCommitAuthorInfo),
-		new(addTypeEnvToPipeline),
-		new(renameTr2ScopeConfig),
-		new(addGitlabIssueAssignee),
-		new(addMrCommitSha),
-		new(addRawParamTableForScope),
-		new(addProjectArchived),
-		new(addDeployment),
-		new(addEnvNamePattern),
-		new(addQueuedDuration20231129),
-		new(modifyDeploymentMessageType),
-	}
+var _ plugin.MigrationScript = (*modifyDeploymentMessageType)(nil)
+
+type modifyDeploymentMessageType struct{}
+
+type deployment20231207 struct {
+	DeployableCommitMessage string `json:"deployable_commit_message"`
+}
+
+func (deployment20231207) TableName() string {
+	return "_tool_gitlab_deployments"
+}
+
+func (script *modifyDeploymentMessageType) Up(basicRes context.BasicRes) errors.Error {
+	return basicRes.GetDal().AutoMigrate(&deployment20231207{})
+}
+
+func (*modifyDeploymentMessageType) Version() uint64 {
+	return 20231205155129
+}
+
+func (*modifyDeploymentMessageType) Name() string {
+	return "modify _tool_gitlab_deployments deployable_commit_message from varchar to text"
 }

--- a/backend/plugins/gitlab/models/migrationscripts/20231207_modify_deployment_message_type.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20231207_modify_deployment_message_type.go
@@ -40,7 +40,7 @@ func (script *modifyDeploymentMessageType) Up(basicRes context.BasicRes) errors.
 }
 
 func (*modifyDeploymentMessageType) Version() uint64 {
-	return 20231205155129
+	return 20231207155129
 }
 
 func (*modifyDeploymentMessageType) Name() string {


### PR DESCRIPTION
### Summary
update deployable_commit_message from varchar(255) to longtext

### Does this close any open issues?
Closes #6455 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/101256042/57dff96c-97ec-46e5-b18e-efd9b4d85bca)


### Other Information
Any other information that is important to this PR.
