### PR TITLE
fix: collect all data when timeafter is nil

### DIFF
--- a/backend/helpers/pluginhelper/api/api_collector_with_state.go
+++ b/backend/helpers/pluginhelper/api/api_collector_with_state.go
@@ -102,8 +102,8 @@ func NewStatefulApiCollector(args RawDataSubTaskArgs) (*ApiCollectorStateManager
 	var isIncremental bool
 	var since *time.Time
 
-	if syncPolicy == nil {
-		// 1. If no syncPolicy, incremental and since is oldState.LatestSuccessStart
+	if syncPolicy == nil || (syncPolicy != nil && syncPolicy.TimeAfter == nil) {
+		// 1. If no syncPolicy TimeAfter, incremental and since is oldState.LatestSuccessStart
 		isIncremental = true
 		since = oldLatestSuccessStart
 	} else if oldLatestSuccessStart == nil {


### PR DESCRIPTION
### Summary
fix: collect all data when timeafter is nil

### Does this close any open issues?
Closes #6662

### Screenshots
Regardless of whether timeafter is empty or not, the data does not change.
![image](https://github.com/apache/incubator-devlake/assets/101256042/a0aac146-1ebe-4def-a3ca-248271d6440a)


### Other Information
Any other information that is important to this PR.
