### PR TITLE
feat: forbid starting tx via the dalgorm.Exec

### DIFF
--- a/backend/impls/dalgorm/dalgorm_test.go
+++ b/backend/impls/dalgorm/dalgorm_test.go
@@ -41,4 +41,10 @@ func Test_validateQuery(t *testing.T) {
 	} {
 		assert.EqualError(t, validateQuery(target), "illegal invocation, use the `Begin()` method instead", "failed text: `%s`", target)
 	}
+	for _, target := range []string{
+		"select 1",
+		"update a set b = c",
+	} {
+		assert.Nil(t, validateQuery(target), "failed text: `%s`", target)
+	}
 }

--- a/backend/impls/dalgorm/dalgorm_test.go
+++ b/backend/impls/dalgorm/dalgorm_test.go
@@ -1,0 +1,44 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dalgorm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_validateQuery(t *testing.T) {
+	for _, target := range []string{
+		"begin",
+		" begin",
+		"begin ",
+		" begin ",
+		"begin;",
+		"begin ;",
+		"begin ; ;",
+		"BEGIN ; ;",
+		"start transaction",
+		"start   transaction",
+		"START   TRANSACTION",
+		"start\t\n   transaction",
+		" ;; start transaction",
+	} {
+		assert.EqualError(t, validateQuery(target), "illegal invocation, use the `Begin()` method instead", "failed text: `%s`", target)
+	}
+}


### PR DESCRIPTION
### Summary

While the `Begin` method in the `dal.Dal` interface is the recommended way to initiate a transaction, some may mistakenly use `dalgorm.Exec('start transaction')`. This approach, however, carries a high risk of deadlocks due to the underlying connection pool mechanism.

To avoid deadlocks and ensure consistent data operations, always use the Begin method for initializing transactions. This will leverage the connection pool effectively and prevent potential issues.

Note: Diagnosing deadlocks caused by improper transaction initialization can be extremely challenging. This detection is implemented to proactively prevent such occurrences and safeguard data integrity.