### PR TITLE
Fix zentao and opsgenis API about sensitive fields

### DIFF
--- a/backend/core/plugin/plugin_datasource.go
+++ b/backend/core/plugin/plugin_datasource.go
@@ -51,7 +51,7 @@ type ApiAuthenticator interface {
 // TODO: deprecated, remove
 // ConnectionValidator represents the API Connection would validate its fields with customized logic
 type ConnectionValidator interface {
-	ValidateConnection(connection interface{}, valdator *validator.Validate) errors.Error
+	ValidateConnection(connection interface{}, validator *validator.Validate) errors.Error
 }
 
 // PrepareApiClient is to be implemented by the concrete Connection which requires

--- a/backend/helpers/pluginhelper/api/connection_helper.go
+++ b/backend/helpers/pluginhelper/api/connection_helper.go
@@ -92,7 +92,6 @@ func (c *ConnectionApiHelper) Patch(connection interface{}, input *plugin.ApiRes
 	if err != nil {
 		return err
 	}
-
 	err = c.merge(connection, input.Body)
 	if err != nil {
 		return err
@@ -180,6 +179,9 @@ func (c *ConnectionApiHelper) Delete(connection interface{}, input *plugin.ApiRe
 	}
 	return &plugin.ApiResourceOutput{Body: result}, err
 }
+func (c *ConnectionApiHelper) Merge(connection interface{}, body map[string]interface{}) errors.Error {
+	return c.merge(connection, body)
+}
 
 func (c *ConnectionApiHelper) merge(connection interface{}, body map[string]interface{}) errors.Error {
 	connection = models.UnwrapObject(connection)
@@ -191,6 +193,10 @@ func (c *ConnectionApiHelper) merge(connection interface{}, body map[string]inte
 		return connectionValidator.ValidateConnection(connection, c.validator)
 	}
 	return Decode(body, connection, c.validator)
+}
+
+func (c *ConnectionApiHelper) SaveWithCreateOrUpdate(connection interface{}) errors.Error {
+	return c.save(connection, c.db.CreateOrUpdate)
 }
 
 func (c *ConnectionApiHelper) save(connection interface{}, method func(entity interface{}, clauses ...dal.Clause) errors.Error) errors.Error {

--- a/backend/plugins/opsgenie/impl/impl.go
+++ b/backend/plugins/opsgenie/impl/impl.go
@@ -164,6 +164,9 @@ func (p Opsgenie) ApiResources() map[string]map[string]plugin.ApiResourceHandler
 			"PATCH":  api.PatchConnection,
 			"DELETE": api.DeleteConnection,
 		},
+		"connections/:connectionId/test": {
+			"POST": api.TestExistingConnection,
+		},
 		"connections/:connectionId/remote-scopes": {
 			"GET": api.RemoteScopes,
 		},

--- a/backend/plugins/zentao/api/connection.go
+++ b/backend/plugins/zentao/api/connection.go
@@ -20,7 +20,6 @@ package api
 import (
 	"context"
 	"github.com/apache/incubator-devlake/core/runner"
-	"github.com/apache/incubator-devlake/helpers/utils"
 	"net/http"
 	"time"
 
@@ -147,19 +146,16 @@ func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /plugins/zentao/connections/{connectionId} [PATCH]
 func PatchConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	connection := &models.ZentaoConnection{}
-	if err := utils.Decode(input.Body, connection, nil); err != nil {
+	existedConnection := models.ZentaoConnection{}
+	if err := connectionHelper.First(&existedConnection, input.Params); err != nil {
 		return nil, err
 	}
+	connection := existedConnection
 	if err := connectionHelper.Merge(connection, input.Body); err != nil {
 		return nil, err
 	}
 	// make sure zentao config's db url field is not in secret format
-	existedConnection := &models.ZentaoConnection{}
-	if err := connectionHelper.First(existedConnection, input.Params); err != nil {
-		return nil, err
-	}
-	if err := (models.ZentaoConnection{}).Merge(existedConnection, connection); err != nil {
+	if err := (models.ZentaoConnection{}).Merge(&existedConnection, &connection); err != nil {
 		return nil, errors.Convert(err)
 	}
 	connection.DbUrl = existedConnection.DbUrl

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -117,6 +117,8 @@ func (connection ZentaoConnection) Merge(existed, modified *ZentaoConnection) er
 			existed.DbUrl = modified.DbUrl
 		} else {
 			// there is no change with db url field.
+			// existedDBUrl = origin(modified.DbUrl)
+			return nil
 		}
 	} else {
 		existed.DbUrl = modified.DbUrl

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -107,6 +107,7 @@ func (connection ZentaoConnection) Sanitize() ZentaoConnection {
 	return connection
 }
 
+// Merge works with the new connection helper.
 func (connection ZentaoConnection) Merge(existed, modified *ZentaoConnection) error {
 	existedDBUrl := existed.DbUrl
 	if existedDBUrl == "" && modified.DbUrl == "" {

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -74,6 +74,7 @@ func (connection ZentaoConn) Sanitize() ZentaoConn {
 	if connection.DbUrl != "" {
 		connection.DbUrl = connection.SanitizeDbUrl()
 	}
+	connection.Password = ""
 	return connection
 }
 
@@ -104,6 +105,30 @@ func (connection ZentaoConn) SanitizeDbUrl() string {
 func (connection ZentaoConnection) Sanitize() ZentaoConnection {
 	connection.ZentaoConn = connection.ZentaoConn.Sanitize()
 	return connection
+}
+
+func (connection ZentaoConnection) Merge(existed, modified *ZentaoConnection) error {
+	existedDBUrl := existed.DbUrl
+	if existedDBUrl == "" && modified.DbUrl == "" {
+		return nil
+	}
+	if existedDBUrl != "" && modified.DbUrl == "" {
+		existed.DbUrl = ""
+		return nil
+	}
+	if existedDBUrl == "" && modified.DbUrl != "" {
+		existed.DbUrl = modified.DbUrl
+		return nil
+	}
+	if existedDBUrl != "" && modified.DbUrl != "" {
+		existedSanitizedConnection := existed.Sanitize()
+		if existedSanitizedConnection.DbUrl != modified.DbUrl {
+			// db url is updated
+			existed.DbUrl = modified.DbUrl
+		}
+		return nil
+	}
+	return nil
 }
 
 // This object conforms to what the frontend currently expects.

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -110,24 +110,16 @@ func (connection ZentaoConnection) Sanitize() ZentaoConnection {
 // Merge works with the new connection helper.
 func (connection ZentaoConnection) Merge(existed, modified *ZentaoConnection) error {
 	existedDBUrl := existed.DbUrl
-	if existedDBUrl == "" && modified.DbUrl == "" {
-		return nil
-	}
-	if existedDBUrl != "" && modified.DbUrl == "" {
-		existed.DbUrl = ""
-		return nil
-	}
-	if existedDBUrl == "" && modified.DbUrl != "" {
-		existed.DbUrl = modified.DbUrl
-		return nil
-	}
 	if existedDBUrl != "" && modified.DbUrl != "" {
 		existedSanitizedConnection := existed.Sanitize()
 		if existedSanitizedConnection.DbUrl != modified.DbUrl {
 			// db url is updated
 			existed.DbUrl = modified.DbUrl
+		} else {
+			// there is no change with db url field.
 		}
-		return nil
+	} else {
+		existed.DbUrl = modified.DbUrl
 	}
 	return nil
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. fix a typo
#### Opsgenie
1. add new test connection API
2. hide sensitive tokens' content in all existing APIs
#### Zentao
1. add custom patcher when updating connections(works with new connection helper)
2. update path connection api, support secret db url field.


### Does this close any open issues?
Closes #5643 

### Screenshots
Include any relevant screenshots here.
#### Opsgenie using new test API
<img width="837" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/871b584f-8ab9-44db-93a6-263cf7df21d5">


### Other Information
Any other information that is important to this PR.
