### PR TITLE
fix: jira remote scope api does not return nextPageToken

### DIFF
--- a/backend/plugins/jira/api/remote_api.go
+++ b/backend/plugins/jira/api/remote_api.go
@@ -44,7 +44,7 @@ func queryJiraAgileBoards(
 	err errors.Error,
 ) {
 	if page.MaxResults == 0 {
-		page.MaxResults = 100
+		page.MaxResults = 50
 	}
 	res, err := apiClient.Get("agile/1.0/board", url.Values{
 		"maxResults": {fmt.Sprintf("%v", page.MaxResults)},
@@ -75,6 +75,13 @@ func queryJiraAgileBoards(
 			FullName: board.Name,
 			Data:     board.ToToolLayer(0),
 		})
+	}
+
+	if !resBody.IsLast {
+		nextPage = &JiraRemotePagination{
+			MaxResults: page.MaxResults,
+			StartAt:    page.StartAt + page.MaxResults,
+		}
 	}
 
 	return


### PR DESCRIPTION
### Summary
fix: jira remote scope api does not return nextPageToken


### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/6a0cf8a7-db5c-4c5e-afd6-8caea54fef08)

