### PR TITLE
fix: update CircleCI dashboard, and add missing `queued_duration_sec` field  when cicd_piplines are transformed to cicd_deployment_commits

### DIFF
--- a/backend/plugins/dora/tasks/deployment_commits_generator.go
+++ b/backend/plugins/dora/tasks/deployment_commits_generator.go
@@ -46,6 +46,7 @@ type pipelineCommitEx struct {
 	OriginalStatus     string
 	OriginalResult     string
 	DurationSec        *float64
+	QueuedDurationSec  *float64
 	CreatedDate        *time.Time
 	FinishedDate       *time.Time
 	Environment        string
@@ -69,6 +70,7 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				p.result,
 				p.status,
 				p.duration_sec,
+				p.queued_duration_sec,
 				p.created_date,
 				p.finished_date,
 				p.environment,
@@ -138,11 +140,12 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 					CreatedDate:  *pipelineCommit.CreatedDate,
 					FinishedDate: pipelineCommit.FinishedDate,
 				},
-				DurationSec: pipelineCommit.DurationSec,
-				CommitSha:   pipelineCommit.CommitSha,
-				RefName:     pipelineCommit.Branch,
-				RepoId:      pipelineCommit.RepoId,
-				RepoUrl:     pipelineCommit.RepoUrl,
+				DurationSec:       pipelineCommit.DurationSec,
+				QueuedDurationSec: pipelineCommit.QueuedDurationSec,
+				CommitSha:         pipelineCommit.CommitSha,
+				RefName:           pipelineCommit.Branch,
+				RepoId:            pipelineCommit.RepoId,
+				RepoUrl:           pipelineCommit.RepoUrl,
 			}
 			if pipelineCommit.FinishedDate != nil && pipelineCommit.DurationSec != nil {
 				s := pipelineCommit.FinishedDate.Add(-time.Duration(*pipelineCommit.DurationSec) * time.Second)

--- a/grafana/dashboards/Circleci.json
+++ b/grafana/dashboards/Circleci.json
@@ -29,7 +29,7 @@
       },
       "id": 58,
       "options": {
-        "content": "- Use Cases: This dashboard shows the basic CI/CD metrics from Circleci, such as [Build Count](https://devlake.apache.org/docs/Metrics/BuildCount), [Build Duration](https://devlake.apache.org/docs/Metrics/BuildDuration) and [Build Success Rate](https://devlake.apache.org/docs/Metrics/BuildSuccessRate).\n- Data Source Required: Circleci",
+        "content": "- Use Cases: This dashboard shows the basic CI/CD metrics from CircleCI, such as [Build Count](https://devlake.apache.org/docs/Metrics/BuildCount), [Build Duration](https://devlake.apache.org/docs/Metrics/BuildDuration) and [Build Success Rate](https://devlake.apache.org/docs/Metrics/BuildSuccessRate).\n- Data Source Required: CircleCI",
         "mode": "markdown"
       },
       "pluginVersion": "8.0.6",
@@ -971,7 +971,7 @@
   },
   "timepicker": {},
   "timezone": "",
-  "title": "Circleci",
-  "uid": "W8AiDFQnk",
+  "title": "CircleCI",
+  "uid": "W8AiDFQmk",
   "version": 10
 }


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. Update CircleCI dashboard(uid and typos)
2. Add missing `queued_duration_sec` field  when `cicd_piplines` are transformed to `cicd_deployment_commits`


### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

#### CircleCI
![image](https://github.com/apache/incubator-devlake/assets/5844806/b103751e-356c-412d-9185-c5b9c3e61b6f)
![image](https://github.com/apache/incubator-devlake/assets/5844806/81b2bea9-96c7-4dfe-a376-ec32b7f3a60b)



#### QueuedDurationSec from cicd_pipelines
![image](https://github.com/apache/incubator-devlake/assets/5844806/15a85eb8-4fa0-43c4-bfc6-9037a3c8eb22)
![image](https://github.com/apache/incubator-devlake/assets/5844806/4892eaba-2d44-43f9-b4ab-85a2b13647d7)


### Other Information
Any other information that is important to this PR.
