### PR TITLE
fix the gitlab subtask ExtractDeployment ended unexpectedly, error: I…

### DIFF
--- a/backend/plugins/gitlab/tasks/deployment_extractor.go
+++ b/backend/plugins/gitlab/tasks/deployment_extractor.go
@@ -55,9 +55,13 @@ func ExtractDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, err
 			}
 			gitlabDeployment := deploymentResp.toGitlabDeployment(data.Options.ConnectionId, data.Options.ProjectId)
-			return []interface{}{
-				gitlabDeployment,
-			}, nil
+			if !gitlabDeployment.DeployableCommitCreatedAt.IsZero() {
+				return []interface{}{
+					gitlabDeployment,
+				}, nil
+			} else {
+				return nil, nil
+			}
 		},
 	})
 


### PR DESCRIPTION

### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
_Fix the gitlab subtask `ExtractDeployment ended unexpectedly, error: Incorrect datetime value: '0000-00-00' for column 'deployable_commit_created_at' at row 7` by adding a siilly check that `DeployableCommitCreatedAt` is not a zero._

### Does this close any open issues?
I decided to not open any issues yet. 
If its mandatory - I can create a new one.

### Screenshots
#### Before fix:
<img width="806" alt="Screenshot 2024-01-02 at 11 08 45" src="https://github.com/apache/incubator-devlake/assets/53825864/dcd0e2df-5851-4103-851b-f18c7e65386f">

#### With fix applied:
<img width="1051" alt="Screenshot 2024-01-02 at 11 34 07" src="https://github.com/apache/incubator-devlake/assets/53825864/3c713ab1-f9d2-4fbf-b3b1-e33cdbfe190f">


### Other Information
Any other information that is important to this PR.
_Minor change, easy to understand, looks safe._
