### PR TITLE
fix(zentao): fix remote scope api

### DIFF
--- a/backend/plugins/zentao/api/remote.go
+++ b/backend/plugins/zentao/api/remote.go
@@ -62,11 +62,7 @@ func getGroup(basicRes context.BasicRes, gid string, queryData *api.RemoteQueryD
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/zentao/connections/{connectionId}/remote-scopes [GET]
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
-	groupId, ok := input.Query["groupId"]
-	if !ok || len(groupId) == 0 {
-		groupId = []string{""}
-	}
-	gid := groupId[0]
+	gid := input.Query.Get("groupId")
 	if gid == "" {
 		return projectRemoteHelper.GetScopesFromRemote(input, getGroup, nil)
 	} else if gid == `projects` {
@@ -93,6 +89,10 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 				if err != nil {
 					logger.Error(err, "unmarshal projects response")
 					return nil, err
+				}
+				if resBody.Page < queryData.Page {
+					fmt.Println(resBody.Page, queryData.Page, resBody)
+					return nil, nil
 				}
 				return resBody.Values, nil
 			})

--- a/backend/plugins/zentao/api/remote.go
+++ b/backend/plugins/zentao/api/remote.go
@@ -91,7 +91,6 @@ func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, er
 					return nil, err
 				}
 				if resBody.Page < queryData.Page {
-					fmt.Println(resBody.Page, queryData.Page, resBody)
 					return nil, nil
 				}
 				return resBody.Values, nil


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Zentao's project api act like this: if request with a very big page and page_size that greater than projects' total count, it will return the last page.
We must handle it, make sure remote-scope api has an end.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
#### First page
![image](https://github.com/apache/incubator-devlake/assets/5844806/e241466c-a65e-4fd0-b86a-42c53a6a93a9)

#### Next Page
![image](https://github.com/apache/incubator-devlake/assets/5844806/6a7b150d-24af-4632-bb34-0366bf5411f7)


### Other Information
Any other information that is important to this PR.
