### PR TITLE
fix: gitlab server extract deployment may fail

### DIFF
--- a/backend/plugins/gitlab/models/deployment.go
+++ b/backend/plugins/gitlab/models/deployment.go
@@ -29,9 +29,9 @@ type GitlabDeployment struct {
 	ConnectionId uint64 `json:"connection_id" gorm:"primaryKey"`
 	GitlabId     int    `json:"gitlab_id" gorm:"primaryKey"`
 
-	CreatedDate time.Time `json:"created_date"`
-	UpdatedDate time.Time `json:"updated_date"`
-	Status      string    `json:"status"` //created, running, success, failed, canceled, or blocked
+	CreatedDate time.Time  `json:"created_date"`
+	UpdatedDate *time.Time `json:"updated_date"`
+	Status      string     `json:"status"` //created, running, success, failed, canceled, or blocked
 
 	DeploymentId int    `json:"id" gorm:"primaryKey"`
 	Iid          int    `json:"iid"`
@@ -78,13 +78,13 @@ type GitlabDeployment struct {
 	DeployableUserWebsiteURL   string `json:"deployable_user_website_url" gorm:"type:varchar(255)"`
 	DeployableUserOrganization string `json:"deployable_user_organization" gorm:"type:varchar(255)"`
 
-	DeployablePipelineCreatedAt time.Time `json:"deployable_pipeline_created_at"`
-	DeployablePipelineID        int       `json:"deployable_pipeline_id"`
-	DeployablePipelineRef       string    `json:"deployable_pipeline_ref" gorm:"type:varchar(255)"`
-	DeployablePipelineSha       string    `json:"deployable_pipeline_sha" gorm:"type:varchar(255)"`
-	DeployablePipelineStatus    string    `json:"deployable_pipeline_status" gorm:"type:varchar(255)"`
-	DeployablePipelineUpdatedAt time.Time `json:"deployable_pipeline_updated_at"`
-	DeployablePipelineWebURL    string    `json:"deployable_pipeline_web_url" gorm:"type:varchar(255)"`
+	DeployablePipelineCreatedAt *time.Time `json:"deployable_pipeline_created_at"`
+	DeployablePipelineID        int        `json:"deployable_pipeline_id"`
+	DeployablePipelineRef       string     `json:"deployable_pipeline_ref" gorm:"type:varchar(255)"`
+	DeployablePipelineSha       string     `json:"deployable_pipeline_sha" gorm:"type:varchar(255)"`
+	DeployablePipelineStatus    string     `json:"deployable_pipeline_status" gorm:"type:varchar(255)"`
+	DeployablePipelineUpdatedAt *time.Time `json:"deployable_pipeline_updated_at"`
+	DeployablePipelineWebURL    string     `json:"deployable_pipeline_web_url" gorm:"type:varchar(255)"`
 
 	UserAvatarURL string `json:"user_avatar_url" gorm:"type:varchar(255)"`
 	UserID        int    `json:"user_id"`

--- a/backend/plugins/gitlab/tasks/deployment_extractor.go
+++ b/backend/plugins/gitlab/tasks/deployment_extractor.go
@@ -70,7 +70,7 @@ func ExtractDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 
 type GitlabDeploymentResp struct {
 	CreatedAt   time.Time                   `json:"created_at"`
-	UpdatedAt   time.Time                   `json:"updated_at"`
+	UpdatedAt   *time.Time                  `json:"updated_at"`
 	Status      string                      `json:"status"`
 	Deployable  GitlabDeploymentDeployable  `json:"deployable"`
 	Environment GitlabDeploymentEnvironment `json:"environment"`
@@ -179,13 +179,13 @@ type GitlabDeploymentFullUser struct {
 }
 
 type GitlabDeploymentPipeline struct {
-	CreatedAt time.Time `json:"created_at"`
-	ID        int       `json:"id"`
-	Ref       string    `json:"ref"`
-	Sha       string    `json:"sha"`
-	Status    string    `json:"status"`
-	UpdatedAt time.Time `json:"updated_at"`
-	WebURL    string    `json:"web_url"`
+	CreatedAt *time.Time `json:"created_at"`
+	ID        int        `json:"id"`
+	Ref       string     `json:"ref"`
+	Sha       string     `json:"sha"`
+	Status    string     `json:"status"`
+	UpdatedAt *time.Time `json:"updated_at"`
+	WebURL    string     `json:"web_url"`
 }
 
 type GitlabDeploymentDeployable struct {


### PR DESCRIPTION
### Summary
Related fields might not available on Gitlab Server, this PR simply make them `nullable` because they are not used in anywhere at this point.

No need to migrate db since they are already `Nullable` in `mysql` and `postgres` by default

![image](https://github.com/apache/incubator-devlake/assets/61080/0077ec22-9991-4c6a-b39d-fcaebc781563)
![image](https://github.com/apache/incubator-devlake/assets/61080/e2ce52bf-e1c6-4c90-9c90-a1b346a3bf16)


### Screenshots
self tested OK
![image](https://github.com/apache/incubator-devlake/assets/61080/eaf778dd-397a-412a-85cf-edbe1b32c07e)





### Other Information
Any other information that is important to this PR.
