### PR TITLE
fix: mysql busy buffer, fails to fully parse all all pull request met…

### DIFF
--- a/backend/plugins/dora/tasks/change_lead_time_calculator.go
+++ b/backend/plugins/dora/tasks/change_lead_time_calculator.go
@@ -49,7 +49,7 @@ func CalculateChangeLeadTime(taskCtx plugin.SubTaskContext) errors.Error {
 
 	// Get pull requests by repo project_name
 	cursor, err := db.Cursor(
-		dal.Select("pr.*"),
+		dal.Select("pr.id, pr.pull_request_key, pr.author_id, pr.merge_commit_sha, pr.created_date, pr.merged_date"),
 		dal.From("pull_requests pr"),
 		dal.Join(`LEFT JOIN project_mapping pm ON (pm.row_id = pr.base_repo_id)`),
 		dal.Where("pr.merged_date IS NOT NULL AND pm.project_name = ? AND pm.table = 'repos'", data.Options.ProjectName),


### PR DESCRIPTION
### Summary
fix: MySQL busy buffer, fails to fully parse all all pull request metrics

### Does this close any open issues?
Closes #6612 

### Screenshots
old:
![img_v3_026u_eeec561a-d905-4731-a341-aa6972b86dag](https://github.com/apache/incubator-devlake/assets/101256042/ae6851bb-de59-4952-8551-85d7db0ce1f4)

new:
![img_v3_026u_8e1efcde-0802-4c9e-a016-673fd9db45bg](https://github.com/apache/incubator-devlake/assets/101256042/de8cee04-b453-47cd-b6f5-b87efb0e0684)


### Other Information
Any other information that is important to this PR.
