### PR TITLE
fix(api): proxy api pass through x-headers

### DIFF
--- a/backend/core/plugin/plugin_api.go
+++ b/backend/core/plugin/plugin_api.go
@@ -51,6 +51,7 @@ type ApiResourceOutput struct {
 	Status      int
 	File        *OutputFile
 	ContentType string
+	Header      http.Header // optional response header
 }
 
 type ApiResourceHandler func(input *ApiResourceInput) (*ApiResourceOutput, errors.Error)

--- a/backend/server/api/router.go
+++ b/backend/server/api/router.go
@@ -145,6 +145,13 @@ func handlePluginCall(basicRes context.BasicRes, pluginName string, handler plug
 			if status < http.StatusContinue {
 				status = http.StatusOK
 			}
+			if output.Header != nil {
+				for k, vs := range output.Header {
+					for _, v := range vs {
+						c.Header(k, v)
+					}
+				}
+			}
 			if output.File != nil {
 				c.Data(status, output.File.ContentType, output.File.Data)
 				return


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

Added Header field to ApiResourceOutput, so that ApiResourceHandler can controll response headers.

Proxy api pass X- prefixed headers through.

### Does this close any open issues?

Closes #6787 

### Screenshots

![image](https://github.com/apache/incubator-devlake/assets/863493/b12b1c03-1715-47e8-8265-7c8078024f50)


### Other Information
Any other information that is important to this PR.
