### PR TITLE
Cherry-pick: fix(api): proxy api pass through x-headers (#6788)

### DIFF
--- a/backend/core/plugin/plugin_api.go
+++ b/backend/core/plugin/plugin_api.go
@@ -51,6 +51,7 @@ type ApiResourceOutput struct {
 	Status      int
 	File        *OutputFile
 	ContentType string
+	Header      http.Header // optional response header
 }
 
 type ApiResourceHandler func(input *ApiResourceInput) (*ApiResourceOutput, errors.Error)

--- a/backend/helpers/pluginhelper/api/remote_api_helper.go
+++ b/backend/helpers/pluginhelper/api/remote_api_helper.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 
 	"github.com/apache/incubator-devlake/core/log"
 
@@ -171,7 +172,17 @@ func (r *RemoteApiHelper[Conn, Scope, ApiScope, Group]) ProxyApiGet(conn plugin.
 	if err != nil {
 		return nil, err
 	}
-	return &plugin.ApiResourceOutput{Status: resp.StatusCode, Body: json.RawMessage(body)}, nil
+	headers := http.Header{}
+	for k, vs := range resp.Header {
+		// skip headers doesn't start with "x-"
+		if !strings.HasPrefix(strings.ToLower(k), "x-") {
+			continue
+		}
+		for _, v := range vs {
+			headers.Add(k, v)
+		}
+	}
+	return &plugin.ApiResourceOutput{Status: resp.StatusCode, Body: json.RawMessage(body), Header: headers}, nil
 }
 
 // PrepareFirstPageToken prepares the first page token

--- a/backend/server/api/router.go
+++ b/backend/server/api/router.go
@@ -145,6 +145,13 @@ func handlePluginCall(basicRes context.BasicRes, pluginName string, handler plug
 			if status < http.StatusContinue {
 				status = http.StatusOK
 			}
+			if output.Header != nil {
+				for k, vs := range output.Header {
+					for _, v := range vs {
+						c.Header(k, v)
+					}
+				}
+			}
 			if output.File != nil {
 				c.Data(status, output.File.ContentType, output.File.Data)
 				return


### PR DESCRIPTION
### Summary

Cherry-pick #6788 to branch release-0.20

Proxy api in release-0.20 was implemented in RemoteApiHelper, and in master branch, it's implemented in a new helper DsRemoteApiProxyHelper.

Header forward operation moved to RemoteApiHelper.ProxyApiGet

### Does this close any open issues?
Closes #6787

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
