### PR TITLE
feat: add fullsync flag to DirectRun

### DIFF
--- a/backend/core/runner/directrun.go
+++ b/backend/core/runner/directrun.go
@@ -37,6 +37,7 @@ import (
 // RunCmd FIXME ...
 func RunCmd(cmd *cobra.Command) {
 	cmd.Flags().StringSliceP("subtasks", "t", nil, "specify what tasks to run, --subtasks=collectIssues,extractIssues")
+	cmd.Flags().BoolP("fullsync", "f", false, "run fullsync")
 	err := cmd.Execute()
 	if err != nil {
 		panic(err)
@@ -51,6 +52,10 @@ func RunCmd(cmd *cobra.Command) {
 func DirectRun(cmd *cobra.Command, args []string, pluginTask plugin.PluginTask, options map[string]interface{}, timeAfter string) {
 	basicRes := CreateAppBasicRes()
 	tasks, err := cmd.Flags().GetStringSlice("subtasks")
+	if err != nil {
+		panic(err)
+	}
+	fullSync, err := cmd.Flags().GetBool("fullsync")
 	if err != nil {
 		panic(err)
 	}
@@ -94,6 +99,7 @@ func DirectRun(cmd *cobra.Command, args []string, pluginTask plugin.PluginTask, 
 		}
 		syncPolicy.TimeAfter = &parsedTimeAfter
 	}
+	syncPolicy.FullSync = fullSync
 
 	err = RunPluginSubTasks(
 		ctx,


### PR DESCRIPTION
### Summary
add `--fullsync -f` flag to `runner.DirectRun` to support running plugin in fullsync mode

### Screenshots
<img width="862" alt="full sync fixes the error" src="https://github.com/apache/incubator-devlake/assets/61080/fb77ded3-9a68-4d95-8aab-90372e51d1b0">



