### PR TITLE
fix(zentao): set correct value for 'nextPageToken'

### DIFF
--- a/backend/plugins/zentao/api/remote.go
+++ b/backend/plugins/zentao/api/remote.go
@@ -64,7 +64,14 @@ func getGroup(basicRes context.BasicRes, gid string, queryData *api.RemoteQueryD
 func RemoteScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	gid := input.Query.Get("groupId")
 	if gid == "" {
-		return projectRemoteHelper.GetScopesFromRemote(input, getGroup, nil)
+		apiResourceOutput, err := projectRemoteHelper.GetScopesFromRemote(input, getGroup, nil)
+		if err != nil {
+			return apiResourceOutput, err
+		}
+		if _, ok := apiResourceOutput.Body.(*api.RemoteScopesOutput); ok {
+			apiResourceOutput.Body.(*api.RemoteScopesOutput).NextPageToken = ""
+		}
+		return apiResourceOutput, err
 	} else if gid == `projects` {
 		return projectRemoteHelper.GetScopesFromRemote(input,
 			nil,


### PR DESCRIPTION
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
When loading all scopes in Zentao, 'nextPageToken' should be empty when request first level folder.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="1839" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/94e6943a-d7f8-4abe-bc73-e866a2d44692">


### Other Information
Any other information that is important to this PR.
