### PR TITLE
fix: circleci dashboard has same uid to the jenkins

### DIFF
--- a/grafana/dashboards/CircleCI.json
+++ b/grafana/dashboards/CircleCI.json
@@ -1034,6 +1034,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "CircleCI",
-  "uid": "W8AiDFQmk",
+  "uid": "CircleCI",
   "version": 10
 }


### PR DESCRIPTION
### Summary
fix: circleci dashboard has same uid to the jenkins

### Does this close any open issues?
Closes #6833 

