### PR TITLE
cherrypick #6836 fix: circleci dashboard has same uid to the jenkins to v0.20

### DIFF
--- a/grafana/dashboards/Circleci.json
+++ b/grafana/dashboards/Circleci.json
@@ -972,6 +972,6 @@
   "timepicker": {},
   "timezone": "",
   "title": "Circleci",
-  "uid": "W8AiDFQnk",
+  "uid": "Circleci",
   "version": 10
 }


### PR DESCRIPTION
cherrypick #6836 fix: circleci dashboard has same uid to the jenkins to v0.20