### PR TITLE
chore: bumps node to 18 in builder image and actions for config-ui

### DIFF
--- a/.github/workflows/config-ui.yml
+++ b/.github/workflows/config-ui.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '18'
         cache: 'yarn'
         cache-dependency-path: config-ui/yarn.lock
     - name: Install with Yarn

--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -23,7 +23,7 @@
 #While incubation status is not necessarily a reflection of the completeness or stability of the code,
 #it does indicate that the project has yet to be fully endorsed by the ASF.
 
-FROM node:16 as builder
+FROM node:18-bookworm-slim as builder
 
 WORKDIR /home/node/code
 COPY . .


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
This PR upgrades the config-ui to node 18 because node 16 deprecated and without active support

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/6885

### Screenshots
Include any relevant screenshots here.

### Other Information
I built the config-ui ldocker image locally against node 18 and it was successful.
