### PR TITLE
fix: selectorDialog name error

### DIFF
--- a/config-ui/src/plugins/register/webhook/components/selector-dialog.tsx
+++ b/config-ui/src/plugins/register/webhook/components/selector-dialog.tsx
@@ -47,7 +47,7 @@ export const SelectorDialog = ({ open, saving, onCancel, onSubmit }: Props) => {
       width={820}
       centered
       title="Select Existing Webhooks"
-      okText="Confrim"
+      okText="Confirm"
       okButtonProps={{
         disabled: !selectedIds.length,
         loading: saving,


### PR DESCRIPTION
Summary
Fixed webhook name error .
Confrim -> Confirm 

<img width="1641" alt="image" src="https://github.com/apache/incubator-devlake/assets/50174803/cdaaf73f-5320-4c4e-86b1-a3ee0bda5e1d">
