### PR TITLE
chore: adds support for IPv6 in nginx

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -1,5 +1,6 @@
 server {
   listen 4000;
+  listen [::]:4000;
   server_name localhost;
   absolute_redirect off;
   client_max_body_size 20m;


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
At the moment nginx doesn't support listening to IPv6 based hosts, this PR tackles this issue.

### Does this close any open issues?
Closes [6954](https://github.com/apache/incubator-devlake/issues/6954)

### Screenshots
Include any relevant screenshots here.

### Other Information
We are currently running on EKS with IPv6 exclusively inside the cluster. Without that, the config-ui won't be able to listen to incoming requests from IPv6 based pods.
