### PR TITLE
feat(dora): Add ScopeId to DoraOptions, to support run dora task on specific scope

### DIFF
--- a/backend/plugins/dora/tasks/deployment_commits_generator.go
+++ b/backend/plugins/dora/tasks/deployment_commits_generator.go
@@ -62,7 +62,7 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 	// select all cicd_pipeline_commits from all "Deployments" in the project
 	// Note that failed records shall be included as well
 	noneSkippedResult := []string{devops.RESULT_FAILURE, devops.RESULT_SUCCESS}
-	cursor, err := db.Cursor(
+	var clauses = []dal.Clause{
 		dal.Select(
 			`
 				pc.*,
@@ -77,12 +77,9 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				p.cicd_scope_id,
 				p.original_status,
 				p.original_result,
-				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?)
-				as has_testing_tasks,
-				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?)
-				as has_staging_tasks,
-				EXISTS( SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?)
-				as has_production_tasks
+				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?) as has_testing_tasks,
+				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?) as has_staging_tasks,
+				EXISTS( SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?) as has_production_tasks
 			`,
 			devops.TESTING, noneSkippedResult,
 			devops.STAGING, noneSkippedResult,
@@ -90,22 +87,27 @@ func GenerateDeploymentCommits(taskCtx plugin.SubTaskContext) errors.Error {
 		),
 		dal.From("cicd_pipeline_commits pc"),
 		dal.Join("LEFT JOIN cicd_pipelines p ON (p.id = pc.pipeline_id)"),
-		dal.Join("LEFT JOIN project_mapping pm ON (pm.table = 'cicd_scopes' AND pm.row_id = p.cicd_scope_id)"),
 		dal.Where(
 			`
-			pm.project_name = ? AND (
-				p.type = ? OR EXISTS(
-					SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.type = ? AND t.result IN ?
-				)
-			) AND p.result IN ?
+			p.result IN ? AND (
+				p.type = ? OR EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.type = ? AND t.result IN ?)
+			)
 			`,
-			data.Options.ProjectName,
-			devops.DEPLOYMENT,
-			devops.DEPLOYMENT,
 			noneSkippedResult,
+			devops.DEPLOYMENT,
+			devops.DEPLOYMENT,
 			noneSkippedResult,
 		),
-	)
+	}
+	if data.Options.ScopeId != nil {
+		clauses = append(clauses, dal.Where(`p.cicd_scope_id = ?`, data.Options.ScopeId))
+	} else {
+		clauses = append(clauses,
+			dal.Join("LEFT JOIN project_mapping pm ON (pm.table = 'cicd_scopes' AND pm.row_id = p.cicd_scope_id)"),
+			dal.Where(`pm.project_name = ?`, data.Options.ProjectName),
+		)
+	}
+	cursor, err := db.Cursor(clauses...)
 	if err != nil {
 		return err
 	}

--- a/backend/plugins/dora/tasks/deployment_generator.go
+++ b/backend/plugins/dora/tasks/deployment_generator.go
@@ -49,7 +49,7 @@ func GenerateDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 	data := taskCtx.GetData().(*DoraTaskData)
 	// Note that failed records shall be included as well
 	noneSkippedResult := []string{devops.RESULT_FAILURE, devops.RESULT_SUCCESS}
-	cursor, err := db.Cursor(
+	var clauses = []dal.Clause{
 		dal.Select(
 			`
 				p.*,
@@ -57,7 +57,7 @@ func GenerateDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 				as has_testing_tasks,
 				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?)
 				as has_staging_tasks,
-				EXISTS( SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?)
+				EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.environment = ? AND t.result IN ?)
 				as has_production_tasks
 			`,
 			devops.TESTING, noneSkippedResult,
@@ -65,22 +65,27 @@ func GenerateDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 			devops.PRODUCTION, noneSkippedResult,
 		),
 		dal.From("cicd_pipelines p"),
-		dal.Join("LEFT JOIN project_mapping pm ON (pm.table = 'cicd_scopes' AND pm.row_id = p.cicd_scope_id)"),
-		dal.Where(
-			`
-			pm.project_name = ? AND (
-				p.type = ? OR EXISTS(
-					SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.type = ? AND t.result IN ?
-				)
-			) AND p.result IN ?
-			`,
-			data.Options.ProjectName,
-			devops.DEPLOYMENT,
-			devops.DEPLOYMENT,
+		dal.Where(`
+			p.result IN ? AND (
+				p.type = ? OR EXISTS(SELECT 1 FROM cicd_tasks t WHERE t.pipeline_id = p.id AND t.type = ? AND t.result IN ?)
+			)`,
 			noneSkippedResult,
+			devops.DEPLOYMENT,
+			devops.DEPLOYMENT,
 			noneSkippedResult,
 		),
-	)
+	}
+	if data.Options.ScopeId != nil {
+		clauses = append(clauses,
+			dal.Where("p.cicd_scope_id = ?", data.Options.ScopeId),
+		)
+	} else {
+		clauses = append(clauses,
+			dal.Join("LEFT JOIN project_mapping pm ON (pm.table = 'cicd_scopes' AND pm.row_id = p.cicd_scope_id)"),
+			dal.Where("pm.project_name = ?", data.Options.ProjectName),
+		)
+	}
+	cursor, err := db.Cursor(clauses...)
 	if err != nil {
 		return err
 	}

--- a/backend/plugins/dora/tasks/task_data.go
+++ b/backend/plugins/dora/tasks/task_data.go
@@ -29,7 +29,8 @@ type DoraApiParams struct {
 type DoraOptions struct {
 	Tasks       []string `json:"tasks,omitempty"`
 	Since       string
-	ProjectName string `json:"projectName"`
+	ProjectName string  `json:"projectName"`
+	ScopeId     *string `json:"scopeId,omitempty"`
 }
 
 type DoraTaskData struct {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

Added an optional ScopeId to DoraOptions, so a dora task can be used to process deployment data of a single scope, without the need to define a project.

Example plan definition in blueprint:
```json
  {
      "plugin": "dora",
      "subtasks": [
        "generateDeployments",
        "generateDeploymentCommits",
        "enrichPrevSuccessDeploymentCommits"
      ],
      "options": {
        "connectionId": 1,
        "projectName": "",
        "scopeId": "jenkins:JenkinsJob:1:auto_api_test"
      }
    }
```


### Does this close any open issues?
Closes #6964 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
