### PR TITLE
fix: /grafana should be off

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -45,6 +45,7 @@ ${SERVER_CONF}
   }
 
   location /grafana/ {
+    auth_basic off;
     set $external "${USE_EXTERNAL_GRAFANA}";
     if ($external = "true") {
       return 302 "${GRAFANA_ENDPOINT}";


### PR DESCRIPTION
### Summary
Turn `auth_basic` off for `/grafana`  to avoid interfering its own authentication

### Does this close any open issues?
Closes #6961

