### PR TITLE
fix(backend): update log message when reading configurations

### DIFF
--- a/backend/core/config/config_viper.go
+++ b/backend/core/config/config_viper.go
@@ -72,7 +72,7 @@ func initConfig(v *viper.Viper) {
 
 	if _, err := os.Stat(v.ConfigFileUsed()); err != nil {
 		if os.IsNotExist(err) {
-			logrus.Info("no [.env] file, please make sure you have set the environment variable.")
+			logrus.Info("no [.env] file, devlake will read configuration from environment, please make sure you have set correct environment variable.")
 		} else {
 			panic(fmt.Errorf("failed to get config file info: %v", err))
 		}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
When users deploy DevLake using helm with some wrong env values such as `commonEnvs.TZ=UTC-3` (UTC-3 is illegal), user can see a log `time="2024-01-30T17:54:34Z" level=info msg="no [.env] file, please make sure you have set the environment variable."`.  This log is very misleading and it should be improved.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
