### PR TITLE
feat: extends DNS variable assignment to additionally handle IPv6

### DIFF
--- a/config-ui/nginx.sh
+++ b/config-ui/nginx.sh
@@ -24,7 +24,7 @@ if [ -n "$ADMIN_USER" ] && [ -n "$ADMIN_PASS" ]; then
     auth_basic_user_file /etc/nginx/.htpasswd;
     '
 fi
-export DNS=$(grep nameserver /etc/resolv.conf | awk '{print $2}')
+export DNS=$(awk 'BEGIN{ORS=" "} $1=="nameserver" {if ($2 ~ ":") {print "["$2"]"} else {print $2}}' /etc/resolv.conf)
 export DNS_VALID=${DNS_VALID:-300s}
 export DEVLAKE_ENDPOINT_PROTO=${DEVLAKE_ENDPOINT_PROTO:-http}
 export GRAFANA_ENDPOINT_PROTO=${GRAFANA_ENDPOINT_PROTO:-http}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

Running the config-ui in an IPv6 only environment throws the below error:
`2024/02/19 09:31:08 [emerg] 14#14: invalid port in resolver "xxxx:xxxx:xxxx::a" in /etc/nginx/conf.d/default.conf:26
nginx: [emerg] invalid port in resolver "xxxx:xxxx:xxxx::a" in /etc/nginx/conf.d/default.conf:26`

This PR fixes this error. Since an IPv6 structure is different than IPv4, the existing command did not account for it and did not surround the IP with the needed `[]` brackets.  This should continue working normally for IPv4 based DNS without problems.


This PR is inspired by the changes done in the latest release of the upstream [nginxinc/docker-nginx-unprivileged](https://github.com/nginxinc/docker-nginx-unprivileged) via this https://github.com/nginxinc/docker-nginx-unprivileged/pull/186



### Does this close any open issues?
Closes [#6977](https://github.com/apache/incubator-devlake/issues/6977)

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
