### PR TITLE
fix(ui): Add /health url with basicAuth disabled

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -68,4 +68,10 @@ ${SERVER_CONF}
     auth_basic off;
     return 200;
   }
+
+  location /health {
+    auth_basic off;
+    return 200;
+  }
+
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This PR adds a /health endpoint to the nginx config for the config-ui.  

It is required when basic authentication is enabled for config-ui and services like Kubernetes want to perform readiness/liveness checks for config-ui pods which gets blocked due to authentication today. 

Note: There is already a /health/ endpoint with trailing slash but the trailing slash is confusing. This PR tries to address that.

### Does this close any open issues?
[6957](https://github.com/apache/incubator-devlake/issues/6957)

### Screenshots
NA

### Other Information
NA
