### PR TITLE
fix: jira test connection error message for wrong user/pass not working

### DIFF
--- a/backend/plugins/github/api/remote_api.go
+++ b/backend/plugins/github/api/remote_api.go
@@ -91,7 +91,9 @@ func listGithubUserOrgs(
 		return nil, nil, err
 	}
 	var orgs []org
-	errors.Must(api.UnmarshalResponse(orgsBody, &orgs))
+	if err := api.UnmarshalResponse(orgsBody, &orgs); err != nil {
+		return nil, nil, err
+	}
 	for _, o := range orgs {
 		children = append(children, dsmodels.DsRemoteApiScopeListEntry[models.GithubRepo]{
 			Type:     api.RAS_ENTRY_TYPE_GROUP,

--- a/backend/plugins/jira/api/connection_api.go
+++ b/backend/plugins/jira/api/connection_api.go
@@ -54,22 +54,22 @@ func testConnection(ctx context.Context, connection models.JiraConn) (*JiraTestC
 	// serverInfo checking
 	res, err := apiClient.Get("api/2/serverInfo", nil, nil)
 	if err != nil {
-		// check if `/rest/` was missing
-		if strings.Contains(err.Error(), "status code 404") && !strings.HasSuffix(connection.Endpoint, "/rest/") {
-			endpointUrl, err := url.Parse(connection.Endpoint)
-			if err != nil {
-				return nil, errors.Convert(err)
-			}
-			refUrl, err := url.Parse("/rest/")
-			if err != nil {
-				return nil, errors.Convert(err)
-			}
-			restUrl := endpointUrl.ResolveReference(refUrl)
-			return nil, errors.NotFound.New(fmt.Sprintf("Seems like an invalid Endpoint URL, please try %s", restUrl.String()))
-		}
 		return nil, err
 	}
 	serverInfoFail := "Failed testing the serverInfo: [ " + res.Request.URL.String() + " ]"
+	// check if `/rest/` was missing
+	if res.StatusCode == http.StatusNotFound && !strings.HasSuffix(connection.Endpoint, "/rest/") {
+		endpointUrl, err := url.Parse(connection.Endpoint)
+		if err != nil {
+			return nil, errors.Convert(err)
+		}
+		refUrl, err := url.Parse("/rest/")
+		if err != nil {
+			return nil, errors.Convert(err)
+		}
+		restUrl := endpointUrl.ResolveReference(refUrl)
+		return nil, errors.NotFound.New(fmt.Sprintf("Seems like an invalid Endpoint URL, please try %s", restUrl.String()))
+	}
 	if res.StatusCode == http.StatusUnauthorized {
 		return nil, errors.HttpStatus(http.StatusBadRequest).New("Error username/password")
 	}

--- a/backend/plugins/jira/api/connection_api.go
+++ b/backend/plugins/jira/api/connection_api.go
@@ -100,7 +100,7 @@ func testConnection(ctx context.Context, connection models.JiraConn) (*JiraTestC
 
 	errMsg := ""
 	if res.StatusCode == http.StatusUnauthorized {
-		return nil, errors.HttpStatus(http.StatusBadRequest).New("it might you use the right token(password) but with the wrong username.please check your username/password")
+		return nil, errors.HttpStatus(http.StatusBadRequest).New("Please check your username/password")
 	}
 
 	if res.StatusCode != http.StatusOK {


### PR DESCRIPTION
### Summary
Thanks @leric  for pointing out the problem at https://github.com/apache/incubator-devlake/pull/7016#discussion_r1502370197

It was wrong to modify the status code on the `api_client` level which deprive the change for caller to obtain the original status code.

However, we still need to avoid returning 401/403 status code since it would break the Basic Auth mechanism when users chose to enable it https://github.com/apache/incubator-devlake/blob/main/devops/releases/lake-v0.20.0/docker-compose.yml#L78

This fix moves the status code wrapping logic to the `api.UnmarshalResponse` function so plugins could have a chance to handle the status code on its own.



### Does this close any open issues?
Related to: #7601, #6561

### Screenshots
jira wrong endpoint
![image](https://github.com/apache/incubator-devlake/assets/61080/a08b1d6f-2137-4787-b340-d435d0e37dcf)
jira wrong user/pass
![image](https://github.com/apache/incubator-devlake/assets/61080/37e1c330-ccb0-4f22-b484-1faa4ae848a4)
github remote scope list with expired token 
![image](https://github.com/apache/incubator-devlake/assets/61080/b4fd0490-426c-4849-b126-62c363902b0c)



### Other Information
Any other information that is important to this PR.
