### PR TITLE
fix(dockerfile): try to fix build errors

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -116,7 +116,7 @@ RUN cd /usr/local/deps/target/lib && \
 FROM python:3.9-slim-bullseye as base
 
 RUN apt-get update && \
-    apt-get install -y python3-dev python3-pip tar curl libssh2-1 zlib1g libffi-dev default-libmysqlclient-dev libpq-dev tini && \
+    apt-get install -y python3-dev python3-pip tar pkg-config curl libssh2-1 zlib1g libffi-dev default-libmysqlclient-dev libpq-dev tini && \
     apt-get clean && \
     rm -fr /usr/share/doc/* \
            /usr/share/info/* \


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
After updating mysqlclient to v2.2.4, building images fail. Errors like:
```
#26 7.359   Trying pkg-config --exists mysqlclient
#26 7.359   /bin/sh: 1: pkg-config: not found
#26 7.359   Command 'pkg-config --exists mysqlclient' returned non-zero exit status 127.
#26 7.359   Trying pkg-config --exists mariadb
#26 7.359   /bin/sh: 1: pkg-config: not found
#26 7.359   Command 'pkg-config --exists mariadb' returned non-zero exit status 127.
#26 7.359   Trying pkg-config --exists libmariadb
#26 7.359   /bin/sh: 1: pkg-config: not found
#26 7.359   Command 'pkg-config --exists libmariadb' returned non-zero exit status 127.
#26 7.359   Traceback (most recent call last):
#26 7.359     File "/app/.local/share/pypoetry/venv/lib/python3.9/site-packages/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
#26 7.359       main()
#26 7.359     File "/app/.local/share/pypoetry/venv/lib/python3.9/site-packages/pyproject_hooks/_in_process/_in_process.py", line 335, in main
#26 7.359       json_out['return_val'] = hook(**hook_input['kwargs'])
#26 7.359     File "/app/.local/share/pypoetry/venv/lib/python3.9/site-packages/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
#26 7.359       return hook(config_settings)
#26 7.359     File "/tmp/tmpy9l5ai_3/.venv/lib/python3.9/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
#26 7.359       return self._get_build_requires(config_settings, requirements=['wheel'])
#26 7.359     File "/tmp/tmpy9l5ai_3/.venv/lib/python3.9/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
#26 7.359       self.run_setup()
#26 7.359     File "/tmp/tmpy9l5ai_3/.venv/lib/python3.9/site-packages/setuptools/build_meta.py", line 311, in run_setup
#26 7.359       exec(code, locals())
#26 7.359     File "<string>", line 155, in <module>
#26 7.359     File "<string>", line 49, in get_config_posix
#26 7.359     File "<string>", line 28, in find_package_name
#26 7.359   Exception: Can not find valid pkg-config name.
#26 7.359   Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually
#26 7.359   
#26 7.359 
#26 7.360   at ~/.local/share/pypoetry/venv/lib/python3.9/site-packages/poetry/installation/chef.py:164 in _prepare
#26 7.393       160│ 
#26 7.403       161│                 error = ChefBuildError("\n\n".join(message_parts))
#26 7.403       162│ 
#26 7.403       163│             if error is not None:
#26 7.404     → 164│                 raise error from None
#26 7.404       165│ 
#26 7.404       166│             return path
#26 7.404       167│ 
#26 7.405       168│     def _prepare_sdist(self, archive: Path, destination: Path | None = None) -> Path:
#26 7.406 
#26 7.406 Note: This error originates from the build backend, and is likely not a problem with poetry but with mysqlclient (2.2.4) not supporting PEP 517 builds. You can verify this by running 'pip wheel --no-cache-dir --use-pep517 "mysqlclient (==2.2.4)"'.
```
According to https://github.com/PyMySQL/mysqlclient/discussions/624, it can be fixed by using `pkg-config`.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
