### PR TITLE
fix(zentao): fix parsing errors for date related fields on zentao v18.10

### DIFF
--- a/backend/core/models/common/iso8601time.go
+++ b/backend/core/models/common/iso8601time.go
@@ -97,6 +97,9 @@ func (jt Iso8601Time) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON FIXME ...
 func (jt *Iso8601Time) UnmarshalJSON(b []byte) error {
 	timeString := string(b)
+	if timeString == `""` {
+		return nil
+	}
 	if timeString == "null" {
 		return nil
 	}

--- a/backend/core/models/migrationscripts/archived/iso8601time.go
+++ b/backend/core/models/migrationscripts/archived/iso8601time.go
@@ -100,6 +100,9 @@ func (jt *Iso8601Time) UnmarshalJSON(b []byte) error {
 	if timeString == "null" {
 		return nil
 	}
+	if timeString == `""` {
+		return nil
+	}
 	if strings.Contains(timeString, "0000-00-00") {
 		return nil
 	}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
In Zentao v18.10, when parsing response from `/projects`,  an error happend, and it's due to the field in resp like:
```json
"suspendedDate": "",
```
Which is not compatible with current codes.

### Does this close any open issues?
Closes #7053 

### Screenshots
Include any relevant screenshots here.
I have no testing environment but I think it can work.

### Other Information
Any other information that is important to this PR.
