### PR TITLE
cherry-pick #7051 fix(zentao): fix parsing errors for date related fields on zentao v18.10 to v0.21

### DIFF
--- a/backend/core/models/common/iso8601time.go
+++ b/backend/core/models/common/iso8601time.go
@@ -97,6 +97,9 @@ func (jt Iso8601Time) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON FIXME ...
 func (jt *Iso8601Time) UnmarshalJSON(b []byte) error {
 	timeString := string(b)
+	if timeString == `""` {
+		return nil
+	}
 	if timeString == "null" {
 		return nil
 	}

--- a/backend/core/models/migrationscripts/archived/iso8601time.go
+++ b/backend/core/models/migrationscripts/archived/iso8601time.go
@@ -100,6 +100,9 @@ func (jt *Iso8601Time) UnmarshalJSON(b []byte) error {
 	if timeString == "null" {
 		return nil
 	}
+	if timeString == `""` {
+		return nil
+	}
 	if strings.Contains(timeString, "0000-00-00") {
 		return nil
 	}


### PR DESCRIPTION
cherry-pick #7051 fix(zentao): fix parsing errors for date related fields on zentao v18.10 to v0.21