### PR TITLE
chore: adjust the doc link to v0.21

### DIFF
--- a/config-ui/src/release/index.ts
+++ b/config-ui/src/release/index.ts
@@ -16,4 +16,4 @@
  *
  */
 
-export { default as DOC_URL } from './stable';
+export { default as DOC_URL } from './v0.21';


### PR DESCRIPTION
### Summary
Adjust the doc link to v0.21.
