### PR TITLE
fix(azuredevops): fix environment field in cicd_tasks and cicd_pipelines

### DIFF
--- a/backend/impls/logruslog/init.go
+++ b/backend/impls/logruslog/init.go
@@ -50,8 +50,8 @@ func init() {
 
 	var formatter logrus.Formatter
 
-    format := os.Getenv("LOGGING_FORMAT")
-	
+	format := os.Getenv("LOGGING_FORMAT")
+
 	switch format {
 	case "json":
 		formatter = &logrus.JSONFormatter{
@@ -63,7 +63,7 @@ func init() {
 			FullTimestamp:   true,
 		}
 	}
-	
+
 	inner.SetFormatter(formatter)
 
 	basePath := cfg.GetString("LOGGING_DIR")

--- a/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
@@ -67,7 +67,7 @@ class Builds(Stream):
         environment = devops.CICDEnvironment.PRODUCTION
         if ctx.scope_config.production_pattern is not None and ctx.scope_config.production_pattern.search(
                 b.name) is None:
-            environment = ""
+            environment = devops.CICDEnvironment.EMPTY
 
         if b.finish_time:
             duration_sec = abs(b.finish_time.timestamp() - b.start_time.timestamp())

--- a/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
@@ -84,7 +84,7 @@ class Jobs(Substream):
         environment = devops.CICDEnvironment.PRODUCTION
         if ctx.scope_config.production_pattern is not None and ctx.scope_config.production_pattern.search(
                 j.name) is None:
-            environment = ""
+            environment = devops.CICDEnvironment.EMPTY
 
         if j.finish_time:
             duration_sec = abs(j.finish_time.timestamp() - j.start_time.timestamp())

--- a/backend/python/pydevlake/pydevlake/domain_layer/devops.py
+++ b/backend/python/pydevlake/pydevlake/domain_layer/devops.py
@@ -44,6 +44,7 @@ class CICDEnvironment(Enum):
     PRODUCTION = "PRODUCTION"
     STAGING = "STAGING"
     TESTING = "TESTING"
+    EMPTY = ""
 
 
 class CICDPipeline(DomainModel, table=True):
@@ -66,7 +67,7 @@ class CICDPipeline(DomainModel, table=True):
     queued_duration_sec: Optional[float]
 
     type: Optional[CICDType]
-    environment: Optional[str]
+    environment: Optional[CICDEnvironment]
 
 
 class CiCDPipelineCommit(NoPKModel, table=True):
@@ -100,7 +101,7 @@ class CICDTask(DomainModel, table=True):
     original_result: Optional[str]
 
     type: Optional[CICDType]
-    environment: Optional[str]
+    environment: Optional[CICDEnvironment]
 
     created_date: Optional[datetime]
     queued_date: Optional[datetime]


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
`environment` field in `cicd_tasks` and `cicd_pipelines`  is a varchar type, but in Python, it's defined with type hint like

```Python
environment: Optional[CICDEnvironment]
# CICDEnvironment is an enum class.
```

If the value you assign to environment is a string, it cannot work as expected.
Otherwise, if environment is defined like
```Python
environment: Optional[str]
```
and you assign it with an enum, it cannot work either.

### Does this close any open issues?
Closes N/A.

### Screenshots
Include any relevant screenshots here.
With same scope config
<img width="853" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/43f4e94f-0cf0-4908-b52a-608191da82be">

#### Before
<img width="924" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/a9006d77-e679-48d6-80f7-760522411535">
#### After
<img width="1142" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/ea3a6ad2-3cc5-4150-ad63-0b262a6e2746">


### Other Information
Any other information that is important to this PR.
