### PR TITLE
cherry pick #7060 fix(azuredevops): fix environment field in cicd_tasks and cicd_pipelines to v0.21

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
@@ -67,7 +67,7 @@ class Builds(Stream):
         environment = devops.CICDEnvironment.PRODUCTION
         if ctx.scope_config.production_pattern is not None and ctx.scope_config.production_pattern.search(
                 b.name) is None:
-            environment = ""
+            environment = devops.CICDEnvironment.EMPTY
 
         if b.finish_time:
             duration_sec = abs(b.finish_time.timestamp() - b.start_time.timestamp())

--- a/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
@@ -84,7 +84,7 @@ class Jobs(Substream):
         environment = devops.CICDEnvironment.PRODUCTION
         if ctx.scope_config.production_pattern is not None and ctx.scope_config.production_pattern.search(
                 j.name) is None:
-            environment = ""
+            environment = devops.CICDEnvironment.EMPTY
 
         if j.finish_time:
             duration_sec = abs(j.finish_time.timestamp() - j.start_time.timestamp())

--- a/backend/python/pydevlake/pydevlake/domain_layer/devops.py
+++ b/backend/python/pydevlake/pydevlake/domain_layer/devops.py
@@ -44,6 +44,7 @@ class CICDEnvironment(Enum):
     PRODUCTION = "PRODUCTION"
     STAGING = "STAGING"
     TESTING = "TESTING"
+    EMPTY = ""
 
 
 class CICDPipeline(DomainModel, table=True):
@@ -66,7 +67,7 @@ class CICDPipeline(DomainModel, table=True):
     queued_duration_sec: Optional[float]
 
     type: Optional[CICDType]
-    environment: Optional[str]
+    environment: Optional[CICDEnvironment]
 
 
 class CiCDPipelineCommit(NoPKModel, table=True):
@@ -100,7 +101,7 @@ class CICDTask(DomainModel, table=True):
     original_result: Optional[str]
 
     type: Optional[CICDType]
-    environment: Optional[str]
+    environment: Optional[CICDEnvironment]
 
     created_date: Optional[datetime]
     queued_date: Optional[datetime]


### PR DESCRIPTION
cherry pick #7060 fix(azuredevops): fix environment field in cicd_tasks and cicd_pipelines to v0.21