### PR TITLE
fix(azuredevops): remove unneccessary collectors when re-transformati…

### DIFF
--- a/backend/python/pydevlake/pydevlake/plugin.py
+++ b/backend/python/pydevlake/pydevlake/plugin.py
@@ -218,7 +218,7 @@ class Plugin(ABC):
                 name=subtask.name,
                 entry_point_name=subtask.verb,
                 arguments=[subtask.stream.name],
-                required=True,
+                required=False,
                 enabled_by_default=False,
                 description=subtask.description,
                 domain_types=[dm.value for dm in subtask.stream.domain_types]


### PR DESCRIPTION


<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
[AzureDevops] Remove unneccessary collectors when re-transformating projects.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

#### Before
When clicking re-transform, collect tasks will execute.
<img width="1320" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/2d714dae-229b-44f5-aecc-22df5d60d43d">

#### After 
No collect tasks, such as collectAzuredevopsJobs.
![image](https://github.com/apache/incubator-devlake/assets/5844806/d8b2c957-fadb-4243-80ff-6efd514dd1c3)


### Other Information
Any other information that is important to this PR.
