### PR TITLE
fix: jenkins should be using `fullName` instead of `scopeId` when generating plan

### DIFF
--- a/backend/plugins/jenkins/api/blueprint_v200.go
+++ b/backend/plugins/jenkins/api/blueprint_v200.go
@@ -86,8 +86,8 @@ func makeDataSourcePipelinePlanV200(
 			subtaskMetas,
 			scopeConfig.Entities,
 			tasks.JenkinsOptions{
-				ConnectionId: jenkinsJob.ConnectionId,
-				ScopeId:      jenkinsJob.ScopeId(),
+				ConnectionId: connection.ID,
+				FullName:     jenkinsJob.FullName,
 			},
 		)
 		if err != nil {

--- a/backend/plugins/jenkins/impl/impl.go
+++ b/backend/plugins/jenkins/impl/impl.go
@@ -230,9 +230,8 @@ func EnrichOptions(taskCtx plugin.TaskContext,
 	op *tasks.JenkinsOptions,
 	apiClient *helper.ApiAsyncClient) errors.Error {
 	jenkinsJob := &models.JenkinsJob{}
-	// If this is from BpV200, we should set JobFullName to scopeId
 	if op.JobFullName == "" {
-		op.JobFullName = op.ScopeId
+		op.JobFullName = op.FullName
 	}
 	// validate the op and set name=owner/repo if this is from advanced mode or bpV100
 	op, err := tasks.ValidateTaskOptions(op)

--- a/backend/plugins/jenkins/tasks/task_data.go
+++ b/backend/plugins/jenkins/tasks/task_data.go
@@ -28,12 +28,12 @@ import (
 type JenkinsApiParams models.JenkinsApiParams
 type JenkinsOptions struct {
 	ConnectionId         uint64                     `json:"connectionId" mapstructure:"connectionId"`
-	ScopeId              string                     `json:"scopeId" mapstructure:"scopeId"`
-	ScopeConfigId        uint64                     `json:"scopeConfigId" mapstructure:"scopeConfigId"`
-	JobFullName          string                     `json:"jobFullName" mapstructure:"jobFullName"` // "path1/path2/job name"
-	JobName              string                     `json:"jobName" mapstructure:"jobName"`         // "job name"
-	JobPath              string                     `json:"jobPath" mapstructure:"jobPath"`         // "job/path1/job/path2"
-	Tasks                []string                   `json:"tasks,omitempty" mapstructure:"tasks"`
+	ScopeConfigId        uint64                     `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
+	FullName             string                     `json:"fullName,omitempty" mapstructure:"fullName,omitempty"`       // "path1/path2/job name"
+	JobFullName          string                     `json:"jobFullName,omitempty" mapstructure:"jobFullName,omitempty"` // "path1/path2/job name"
+	JobName              string                     `json:"jobName,omitempty" mapstructure:"jobName,omitempty"`         // "job name"
+	JobPath              string                     `json:"jobPath,omitempty" mapstructure:"jobPath,omitempty"`         // "job/path1/job/path2"
+	Tasks                []string                   `json:"tasks,omitempty" mapstructure:"tasks,omitempty"`
 	ScopeConfig          *models.JenkinsScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
 	api.CollectorOptions `mapstructure:",squash"`
 }


### PR DESCRIPTION

### Summary
rename `scopeId` to `fullName` for jenkins 

### Does this close any open issues?
Part of #7059 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/3d0bb935-9e2c-41a7-aa3e-8f57afb27b05)
