### PR TITLE
Fetch AzureDevops Builds by `finishTimeDescending`

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/api.py
+++ b/backend/python/plugins/azuredevops/azuredevops/api.py
@@ -78,7 +78,9 @@ class AzureDevOpsAPI(API):
         return self.get(org, project, '_apis/git/repositories', repo_id, 'commits')
 
     def builds(self, org: str, project: str, repository_id: str, provider: str):
-        return self.get(org, project, '_apis/build/builds', repositoryId=repository_id, repositoryType=provider, deletedFilter='excludeDeleted')
+        return self.get(org, project, '_apis/build/builds', repositoryId=repository_id, repositoryType=provider,
+                        deletedFilter='excludeDeleted',
+                        queryOrder="finishTimeDescending")
 
     def jobs(self, org: str, project: str, build_id: int):
         return self.get(org, project, '_apis/build/builds', build_id, 'timeline')

--- a/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
@@ -67,7 +67,7 @@ class Builds(Stream):
         environment = devops.CICDEnvironment.PRODUCTION
         if ctx.scope_config.production_pattern is not None and ctx.scope_config.production_pattern.search(
                 b.name) is None:
-            environment = devops.CICDEnvironment.EMPTY
+            environment = None
 
         if b.finish_time:
             duration_sec = abs(b.finish_time.timestamp() - b.start_time.timestamp())

--- a/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
@@ -84,7 +84,7 @@ class Jobs(Substream):
         environment = devops.CICDEnvironment.PRODUCTION
         if ctx.scope_config.production_pattern is not None and ctx.scope_config.production_pattern.search(
                 j.name) is None:
-            environment = devops.CICDEnvironment.EMPTY
+            environment = None
 
         if j.finish_time:
             duration_sec = abs(j.finish_time.timestamp() - j.start_time.timestamp())


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Fetch AzureDevops Builds by `finishTimeDescending`, According to https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-7.1 and https://learn.microsoft.com/en-us/rest/api/azure/devops/build/builds/list?view=azure-devops-rest-7.1#buildqueryorder

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
