### PR TITLE
fix(customize): issue_repo_commit.host column ignores port

### DIFF
--- a/backend/helpers/pluginhelper/api/issue_repo_commit_convertor.go
+++ b/backend/helpers/pluginhelper/api/issue_repo_commit_convertor.go
@@ -43,7 +43,7 @@ func RefineIssueRepoCommit(item *crossdomain.IssueRepoCommit, repoPatterns []*re
 	if err != nil {
 		return item
 	}
-	item.Host = u.Host
+	item.Host = u.Hostname()
 	for _, pattern := range repoPatterns {
 		if pattern.MatchString(commitUrl) {
 			group := pattern.FindStringSubmatch(commitUrl)

--- a/backend/plugins/tapd/tasks/bug_commit_converter.go
+++ b/backend/plugins/tapd/tasks/bug_commit_converter.go
@@ -71,7 +71,7 @@ func ConvertBugCommit(taskCtx plugin.SubTaskContext) errors.Error {
 					IssueId:   issueIdGen.Generate(data.Options.ConnectionId, toolL.BugId),
 					RepoUrl:   repoUrl,
 					CommitSha: toolL.CommitId,
-					Host:      u.Host,
+					Host:      u.Hostname(),
 					Namespace: getRepoNamespaceFromUrlPath(u.Path),
 					RepoName:  getRepoNameFromUrlPath(u.Path),
 				}

--- a/backend/plugins/tapd/tasks/story_commit_converter.go
+++ b/backend/plugins/tapd/tasks/story_commit_converter.go
@@ -69,7 +69,7 @@ func ConvertStoryCommit(taskCtx plugin.SubTaskContext) errors.Error {
 					IssueId:   issueIdGen.Generate(data.Options.ConnectionId, toolL.StoryId),
 					RepoUrl:   repoUrl,
 					CommitSha: toolL.CommitId,
-					Host:      u.Host,
+					Host:      u.Hostname(),
 					Namespace: getRepoNamespaceFromUrlPath(u.Path),
 					RepoName:  getRepoNameFromUrlPath(u.Path),
 				}

--- a/backend/plugins/tapd/tasks/task_commit_converter.go
+++ b/backend/plugins/tapd/tasks/task_commit_converter.go
@@ -72,7 +72,7 @@ func ConvertTaskCommit(taskCtx plugin.SubTaskContext) errors.Error {
 					IssueId:   issueIdGen.Generate(data.Options.ConnectionId, toolL.TaskId),
 					RepoUrl:   repoUrl,
 					CommitSha: toolL.CommitId,
-					Host:      u.Host,
+					Host:      u.Hostname(),
 					Namespace: getRepoNamespaceFromUrlPath(u.Path),
 					RepoName:  getRepoNameFromUrlPath(u.Path),
 				}

--- a/backend/plugins/zentao/tasks/shared.go
+++ b/backend/plugins/zentao/tasks/shared.go
@@ -154,7 +154,7 @@ func parseRepoUrl(repoUrl string) (string, string, string, error) {
 		return "", "", "", err
 	}
 
-	host := parsedUrl.Host
+	host := parsedUrl.Hostname()
 	host = strings.TrimPrefix(host, "www.")
 	pathParts := strings.Split(parsedUrl.Path, "/")
 	if len(pathParts) < 3 {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

In domain layer table `issue_repo_commit`, fields `host, namespace, repo_name` are extracted from git repository url, and later used to join issue with coresponding commits in devinsights.
Currently the `host` field contains port besides hostname. The port stand for the protocol or a means to expose a certain repository on a certain host, the same repository might be accessed via different protocol (port), only the hostname and path in repo_url is considered as unique indicator of a git repository (in devinsights).
This PR changed the code that extracts `host, namespace, repo_name` from `repo_url`, use hostname without port as the `host` field.


### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
