### PR TITLE
fix(azuredevops): fix some bugs

### DIFF
--- a/backend/plugins/gitextractor/parser/clone.go
+++ b/backend/plugins/gitextractor/parser/clone.go
@@ -122,7 +122,11 @@ func (l *GitRepoCreator) cloneOverHTTP(ctx plugin.SubTaskContext, withGoGit bool
 		done <- struct{}{}
 		if err != nil {
 			// Some sensitive information such as password will be released in this err.
-			err = fmt.Errorf("plain clone git error")
+			if err.Error() == "repository not found" {
+				// do nothing, it's a safe error message.
+			} else {
+				err = fmt.Errorf("plain clone git error")
+			}
 			l.logger.Error(err, "PlainCloneContext")
 			return nil, err
 		}

--- a/backend/python/plugins/azuredevops/azuredevops/main.py
+++ b/backend/python/plugins/azuredevops/azuredevops/main.py
@@ -120,7 +120,7 @@ class AzureDevOpsPlugin(Plugin):
         hint = None
         try:
             if connection.organization is None:
-                hint = "You may need to edit your token to set organization to 'All accessible organizations"
+                hint = "You may need to edit your token to set organization to 'All accessible organizations'"
                 res = api.my_profile()
             else:
                 hint = "Organization name may be incorrect or your token may not have access to the organization."

--- a/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/builds.py
@@ -30,8 +30,16 @@ class Builds(Stream):
     def collect(self, state, context) -> Iterable[tuple[object, dict]]:
         repo: GitRepository = context.scope
         api = AzureDevOpsAPI(context.connection)
+        provider = repo.provider or 'tfsgit'
         response = api.builds(repo.org_id, repo.project_id, repo.id, repo.provider or 'tfsgit')
         for raw_build in response:
+            raw_build["x_request_url"] = response.get_url_with_query_string()
+            raw_build["x_request_input"] = {
+                "OrgId": repo.org_id,
+                "ProjectId": repo.project_id,
+                "RepoId": repo.id,
+                "Provider": provider,
+            }
             yield raw_build, state
 
     def convert(self, b: Build, ctx: Context):

--- a/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/jobs.py
@@ -50,6 +50,12 @@ class Jobs(Substream):
         for raw_job in response.json["records"]:
             if raw_job["type"] == "Job":
                 raw_job["build_id"] = parent.domain_id()
+                raw_job["x_request_url"] = response.get_url_with_query_string()
+                raw_job["x_request_input"] = {
+                    "OrgId": repo.org_id,
+                    "ProjectId": repo.project_id,
+                    "BuildId": parent.id,
+                }
                 yield raw_job, state
 
     def convert(self, j: Job, ctx: Context) -> Iterable[devops.CICDPipeline]:

--- a/backend/python/plugins/azuredevops/azuredevops/streams/pull_request_commits.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/pull_request_commits.py
@@ -15,11 +15,11 @@
 
 from typing import Iterable
 
+import pydevlake.domain_layer.code as code
 from azuredevops.api import AzureDevOpsAPI
 from azuredevops.models import GitPullRequest, GitPullRequestCommit, GitRepository
 from azuredevops.streams.pull_requests import GitPullRequests
 from pydevlake import Substream, DomainType
-import pydevlake.domain_layer.code as code
 
 
 class GitPullRequestCommits(Substream):
@@ -34,9 +34,17 @@ class GitPullRequestCommits(Substream):
     def collect(self, state, context, parent: GitPullRequest) -> Iterable[tuple[object, dict]]:
         repo: GitRepository = context.scope
         azuredevops_api = AzureDevOpsAPI(context.connection)
-        response = azuredevops_api.git_repo_pull_request_commits(repo.org_id, repo.project_id, repo.id, parent.pull_request_id)
+        response = azuredevops_api.git_repo_pull_request_commits(repo.org_id, repo.project_id, repo.id,
+                                                                 parent.pull_request_id)
         for raw_commit in response:
             raw_commit["pull_request_id"] = parent.domain_id()
+            raw_commit["x_request_url"] = response.get_url_with_query_string()
+            raw_commit["x_request_input"] = {
+                "OrgId": repo.org_id,
+                "ProjectId": repo.project_id,
+                "RepoId": repo.id,
+                "PullRequestId": parent.pull_request_id,
+            }
             yield raw_commit, state
 
     def convert(self, commit: GitPullRequestCommit, context) -> Iterable[code.PullRequestCommit]:

--- a/backend/python/plugins/azuredevops/azuredevops/streams/pull_requests.py
+++ b/backend/python/plugins/azuredevops/azuredevops/streams/pull_requests.py
@@ -34,6 +34,12 @@ class GitPullRequests(Stream):
         repo: GitRepository = context.scope
         response = api.git_repo_pull_requests(repo.org_id, repo.project_id, repo.id)
         for raw_pr in response:
+            raw_pr["x_request_url"] = response.get_url_with_query_string()
+            raw_pr["x_request_input"] = {
+                "OrgId": repo.org_id,
+                "ProjectId": repo.project_id,
+                "RepoId": repo.id,
+            }
             yield raw_pr, state
 
     def convert(self, pr: GitPullRequest, ctx):

--- a/backend/python/pydevlake/pydevlake/api.py
+++ b/backend/python/pydevlake/pydevlake/api.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 from typing import Optional, Union
+from urllib.parse import urlencode
 from http import HTTPStatus
 import json
 import time
@@ -70,6 +71,12 @@ class Response:
 
     def __str__(self):
         return f'{self.request}: {self.status}'
+
+    def get_url_with_query_string(self) -> str:
+        url = self.request.url
+        if self.request.query_args is not None:
+            url = f'{url}?{urlencode(self.request.query_args)}'
+        return url
 
 
 # Sentinel value to abort processing of requests/responses in hooks


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. Fix  error message when token is expired or doesn't have enough perms.
2. Fulfill `url` and `input` fields in AzureDevops' raw layer tables.
3. Make error message clear when gitextracor failed to clone repositories.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

####  Project run successfully.
<img width="1637" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/506d1c58-79b0-484d-b1fd-83a24d42be19">

#### `url` and `input` fields are not empty now.
<img width="1909" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/6c08ac48-0eb9-497a-99bc-e5a434da9b11">


### Other Information
Any other information that is important to this PR.
