### PR TITLE
cherry-pick #7104 chore: upgrade miller-columns-select to 1.3.1

### DIFF
--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -34,7 +34,7 @@
     "dayjs": "^1.10.7",
     "file-saver": "^2.0.5",
     "lodash": "^4.17.21",
-    "miller-columns-select": "^1.3.0",
+    "miller-columns-select": "^1.3.1",
     "react": "17.0.2",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "17.0.2",

--- a/config-ui/yarn.lock
+++ b/config-ui/yarn.lock
@@ -3690,7 +3690,7 @@ __metadata:
     husky: ^8.0.0
     lint-staged: ^13.1.0
     lodash: ^4.17.21
-    miller-columns-select: ^1.3.0
+    miller-columns-select: ^1.3.1
     prettier: ^2.7.1
     react: 17.0.2
     react-copy-to-clipboard: ^5.1.0
@@ -5813,9 +5813,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"miller-columns-select@npm:^1.3.0":
-  version: 1.3.0
-  resolution: "miller-columns-select@npm:1.3.0"
+"miller-columns-select@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "miller-columns-select@npm:1.3.1"
   dependencies:
     classnames: ^2.3.2
     react-infinite-scroll-component: ^6.1.0
@@ -5823,7 +5823,7 @@ __metadata:
   peerDependencies:
     react: ^18.2.0
     react-dom: ^18.2.0
-  checksum: 6a2204b897c573418a000575096d4c27b58893a008105f454a4ae1c2dd329628306d41a77a41c278af8d1480ce9f20a01f808ea57419ae0312b62ef84789b113
+  checksum: caaad96b4d2b787b27a66e490118b8c9db192720cb351a7746b2cd64baed6350e971202b70f8162c162ade40e040e89bad4d9750a98f30db744f9442f57cf5cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
cherry-pick #7104 chore: upgrade miller-columns-select to 1.3.1