### PR TITLE
fix: cronjob won't work for a new instance

### DIFF
--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -270,9 +270,7 @@ func ReloadBlueprints() (err errors.Error) {
 			return err
 		}
 	}
-	if len(blueprints) > 0 {
-		cronManager.Start()
-	}
+	cronManager.Start()
 	logger.Info("total %d blueprints were scheduled", len(blueprints))
 	return nil
 }


### PR DESCRIPTION
### Summary
Due to the `ReloadBlueprints` would be called only once during bootstrapping, the `cronManager.Start` would never be called for a Brand New Instance, causing no blueprints would ever be schedule unless the application is reboot.


Related to #6995