### PR TITLE
Improving _tool_jira_accounts table filtering

### DIFF
--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -125,8 +125,6 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 		tasks.CollectIssueChangelogsMeta,
 		tasks.ExtractIssueChangelogsMeta,
 
-		tasks.CollectAccountsMeta,
-
 		tasks.CollectWorklogsMeta,
 		tasks.ExtractWorklogsMeta,
 
@@ -138,6 +136,8 @@ func (p Jira) SubTaskMetas() []plugin.SubTaskMeta {
 
 		tasks.CollectEpicsMeta,
 		tasks.ExtractEpicsMeta,
+
+		tasks.CollectAccountsMeta,
 
 		tasks.ConvertBoardMeta,
 

--- a/backend/plugins/jira/tasks/account_collector.go
+++ b/backend/plugins/jira/tasks/account_collector.go
@@ -19,9 +19,11 @@ package tasks
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -45,10 +47,15 @@ func CollectAccounts(taskCtx plugin.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	logger := taskCtx.GetLogger()
 	logger.Info("collect account")
+	connectionId := strconv.FormatUint(data.Options.ConnectionId, 10)
+	boardId := strconv.FormatUint(data.Options.BoardId, 10)
 	cursor, err := db.Cursor(
 		dal.Select("account_id"),
 		dal.From("_tool_jira_accounts"),
-		dal.Where("account_id != ? AND connection_id = ?", "", data.Options.ConnectionId),
+		dal.Where("account_id != ? AND _raw_data_params = ?",
+			"",
+			fmt.Sprintf("{\"ConnectionId\":%s,\"BoardId\":%s}", connectionId, boardId),
+		),
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This refactor aims to enhance the efficiency of collecting data from the Jira board by excluding irrelevant accounts from collect process. More info can be found in the #7020 

### Does this close any open issues?
#7020 

### Other Information
How to test:
1. Create a Devlake project connected to a large Jira board.
2. Run the import process.
3. For me this project discovered over 350 accounts and saved them in the `_tool_jira_accounts` table.
4. Create another Devlake project linked to a smaller Jira board, with a time range set to let's say last week.
5. Run the import process.
6. Notice that the smaller Jira board has called the `/rest/api/2/user`endpoint for accounts only relevant to this smaller board (that can be confirmed using the logs or by checking the `updated_at` in `_tool_jira_accounts` table).
