### PR TITLE
fix(dora): remove calculated `started_date` when converting pipelines to deployments

### DIFF
--- a/backend/plugins/dora/tasks/deployment_generator.go
+++ b/backend/plugins/dora/tasks/deployment_generator.go
@@ -18,15 +18,13 @@ limitations under the License.
 package tasks
 
 import (
-	"reflect"
-	"time"
-
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"reflect"
 )
 
 var DeploymentGeneratorMeta = plugin.SubTaskMeta{
@@ -144,10 +142,6 @@ func GenerateDeployment(taskCtx plugin.SubTaskContext) errors.Error {
 				},
 				DurationSec:       &pipelineExInfo.DurationSec,
 				QueuedDurationSec: pipelineExInfo.QueuedDurationSec,
-			}
-			if pipelineExInfo.FinishedDate != nil && pipelineExInfo.DurationSec != 0 {
-				s := pipelineExInfo.FinishedDate.Add(-time.Duration(pipelineExInfo.DurationSec) * time.Second)
-				domainDeployment.StartedDate = &s
 			}
 			if pipelineExInfo.Environment == "" {
 				if pipelineExInfo.HasProductionTasks {


### PR DESCRIPTION


<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
When converting pipelines to deployments in plugin dora, pipeline has its own started_date, so there is no need to calculate stated_date manually. 

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
