### PR TITLE
fix: blueprint gets disabled when disabling dora for project

### DIFF
--- a/backend/scripts/build-plugins.sh
+++ b/backend/scripts/build-plugins.sh
@@ -47,7 +47,7 @@ if [ "$DEVLAKE_PLUGINS" = "none" ]; then
 fi
 
 if [ -n "$DEVLAKE_DEBUG" ]; then
-    EXTRA="-gcflags='all=-N -l'"
+    GCFLAGS=all=-N\ -l
 fi
 
 if [ -z "$DEVLAKE_PLUGINS" ]; then
@@ -67,7 +67,7 @@ PIDS=""
 for PLUG in $PLUGINS; do
     NAME=$(basename $PLUG)
     echo "Building plugin $NAME to bin/plugins/$NAME/$NAME.so with args: $*"
-    go build -buildmode=plugin $EXTRA -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go &
+    go build -buildmode=plugin --gcflags="$GCFLAGS" -o $PLUGIN_OUTPUT_DIR/$NAME/$NAME.so $PLUG/*.go &
     PIDS="$PIDS $!"
     # avoid too many processes causing signal killed
     COUNT=$(echo "$PIDS" | wc -w)

--- a/backend/server/services/init.go
+++ b/backend/server/services/init.go
@@ -119,9 +119,6 @@ func ExecuteMigration() errors.Error {
 	// cronjob for blueprint triggering
 	location := cron.WithLocation(time.UTC)
 	cronManager = cron.New(location)
-	if err != nil {
-		panic(err)
-	}
 
 	// initialize pipeline server, mainly to start the pipeline consuming process
 	pipelineServiceInit()

--- a/backend/server/services/project.go
+++ b/backend/server/services/project.go
@@ -224,14 +224,14 @@ func PatchProject(name string, body map[string]interface{}) (*models.ApiOutputPr
 	}
 
 	// Blueprint
-	err = tx.UpdateColumn(
-		&models.Blueprint{},
-		"enable", projectInput.Enable,
-		dal.Where("project_name = ?", name),
-	)
-	if err != nil {
-		return nil, err
-	}
+	// err = tx.UpdateColumn(
+	// 	&models.Blueprint{},
+	// 	"enable", projectInput.Enable,
+	// 	dal.Where("project_name = ?", name),
+	// )
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	// refresh project metrics if needed
 	if len(projectInput.Metrics) > 0 {
@@ -377,7 +377,7 @@ func makeProjectOutput(project *models.Project, withLastPipeline bool) (*models.
 	}
 	if withLastPipeline {
 		if projectOutput.Blueprint == nil {
-			logger.Warn(fmt.Errorf("Blueprint is nil"), "want to get latest pipeline, but blueprint is nil")
+			logger.Warn(fmt.Errorf("blueprint is nil"), "want to get latest pipeline, but blueprint is nil")
 		} else {
 			pipelines, pipelinesCount, err := GetPipelines(&PipelineQuery{
 				BlueprintId: projectOutput.Blueprint.ID,


### PR DESCRIPTION

### Summary
The bluprint of a project would be disabled when disabling dora metric for the project
![img_v3_028o_e669aed9-1a22-4a67-9edc-836d61ecca7g](https://github.com/apache/incubator-devlake/assets/61080/02dce7d5-15b5-4786-9809-d88ffa3c3e71)

Which practically paralyse the Project altogether
![image](https://github.com/apache/incubator-devlake/assets/61080/b9c76b1e-8246-4641-a235-da17d4955e7d)


According to @Startrekzky  and @mintsweet , Projects and their blueprints should never been disabled, this PR fixes the bug accordingly.