### PR TITLE
Fixed Pull Request issue regex pattern in Github plugin

### DIFF
--- a/config-ui/src/plugins/register/github/config.tsx
+++ b/config-ui/src/plugins/register/github/config.tsx
@@ -121,7 +121,7 @@ export const GitHubConfig: IPluginConfig = {
       prType: 'type(.*)',
       prComponent: 'component(.*)',
       prBodyClosePattern:
-        '(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved|bloop)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/issues\\/)\\d+[ ]*)+)',
+        '(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/issues\\/)\\d+[ ]*)+)',
       refdiff: {
         tagsLimit: 10,
         tagsPattern: '/v\\d+\\.\\d+(\\.\\d+(-rc)*\\d*)*$/',

--- a/config-ui/src/plugins/register/github/config.tsx
+++ b/config-ui/src/plugins/register/github/config.tsx
@@ -121,7 +121,7 @@ export const GitHubConfig: IPluginConfig = {
       prType: 'type(.*)',
       prComponent: 'component(.*)',
       prBodyClosePattern:
-        '(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[s]*.*(((and )?(#|https://github.com/%s/%s/issues/)d+[ ]*)+)',
+        '(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved|bloop)[\\s]*.*(((and )?(#|https:\\/\\/github.com\\/%s\\/issues\\/)\\d+[ ]*)+)',
       refdiff: {
         tagsLimit: 10,
         tagsPattern: '/v\\d+\\.\\d+(\\.\\d+(-rc)*\\d*)*$/',

--- a/config-ui/src/plugins/register/github/transformation.tsx
+++ b/config-ui/src/plugins/register/github/transformation.tsx
@@ -385,7 +385,7 @@ const renderCollapseItems = ({
           >
             <Input.TextArea
               value={transformation.prBodyClosePattern ?? ''}
-              placeholder="(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved|blaap)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/issues\/)\d+[ ]*)+)"
+              placeholder="(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/issues\/)\d+[ ]*)+)"
               onChange={(e) =>
                 onChangeTransformation({
                   ...transformation,

--- a/config-ui/src/plugins/register/github/transformation.tsx
+++ b/config-ui/src/plugins/register/github/transformation.tsx
@@ -385,7 +385,7 @@ const renderCollapseItems = ({
           >
             <Input.TextArea
               value={transformation.prBodyClosePattern ?? ''}
-              placeholder="(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved)[s]*.*(((and )?(#|https://github.com/%s/%s/issues/)d+[ ]*)+)"
+              placeholder="(?mi)(fix|close|resolve|fixes|closes|resolves|fixed|closed|resolved|blaap)[\s]*.*(((and )?(#|https:\/\/github.com\/%s\/issues\/)\d+[ ]*)+)"
               onChange={(e) =>
                 onChangeTransformation({
                   ...transformation,


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

### Summary
What does this PR do?

This fixes a bug in the Github plugin frontend, where the default PR Issue pattern in the config-ui lacks escape characters and had an extra `%s`. This resulted in issue numbers in PR bodies not being parsed.

### Does this close any open issues?
Not apparently.

### Other Information
The backend tests already include the proper pattern, which is probably why this wasn't noticed before.