### PR TITLE
feat: add ready and health probes

### DIFF
--- a/backend/core/errors/types.go
+++ b/backend/core/errors/types.go
@@ -36,8 +36,9 @@ var (
 	Conflict     = register(&Type{httpCode: http.StatusConflict, meta: "internal"})
 
 	//500+
-	Internal = register(&Type{httpCode: http.StatusInternalServerError, meta: "internal"})
-	Timeout  = register(&Type{httpCode: http.StatusGatewayTimeout, meta: "timeout"})
+	Internal    = register(&Type{httpCode: http.StatusInternalServerError, meta: "internal"})
+	Timeout     = register(&Type{httpCode: http.StatusGatewayTimeout, meta: "timeout"})
+	Unavailable = register(&Type{httpCode: http.StatusServiceUnavailable, meta: "unavailable"})
 
 	//cached values
 	typesByHttpCode = newSyncMap[int, *Type]()

--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -78,7 +78,8 @@ func CreateApiServer() *gin.Engine {
 
 	// For both protected and unprotected routes
 	router.GET("/ping", ping.Get)
-	router.GET("/health", ping.Get)
+	router.GET("/ready", ping.Ready)
+	router.GET("/health", ping.Health)
 	router.GET("/version", version.Get)
 
 	// Api keys

--- a/backend/server/api/ping/ping.go
+++ b/backend/server/api/ping/ping.go
@@ -20,6 +20,8 @@ package ping
 import (
 	"net/http"
 
+	"github.com/apache/incubator-devlake/server/api/shared"
+	"github.com/apache/incubator-devlake/server/services"
 	"github.com/gin-gonic/gin"
 )
 
@@ -32,4 +34,36 @@ import (
 // @Router /ping [get]
 func Get(c *gin.Context) {
 	c.Status(http.StatusOK)
+}
+
+// @Summary Ready
+// @Description check if service is ready
+// @Tags framework/ping
+// @Success 200
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /ready [get]
+func Ready(c *gin.Context) {
+	status, err := services.Ready()
+	if err != nil {
+		shared.ApiOutputError(c, err)
+		return
+	}
+	shared.ApiOutputSuccess(c, shared.ApiBody{Success: true, Message: status}, http.StatusOK)
+}
+
+// @Summary Health
+// @Description check if service is health
+// @Tags framework/ping
+// @Success 200
+// @Failure 400  {string} errcode.Error "Bad Request"
+// @Failure 500  {string} errcode.Error "Internal Error"
+// @Router /health [get]
+func Health(c *gin.Context) {
+	msg, err := services.Health()
+	if err != nil {
+		shared.ApiOutputError(c, err)
+		return
+	}
+	shared.ApiOutputSuccess(c, shared.ApiBody{Success: true, Message: msg}, http.StatusOK)
 }

--- a/backend/server/services/probes.go
+++ b/backend/server/services/probes.go
@@ -1,0 +1,58 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package services
+
+import (
+	"time"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/models"
+)
+
+// Ready returns the readiness status of the service
+func Ready() (string, errors.Error) {
+	var err errors.Error
+	if serviceStatus != SERVICE_STATUS_READY {
+		err = errors.Unavailable.New("service is not ready: " + serviceStatus)
+	}
+	return serviceStatus, err
+}
+
+// Health returns the health status of the service
+func Health() (string, errors.Error) {
+	// return true, nil unless we are 100% sure that the service is unhealthy
+	if serviceStatus != SERVICE_STATUS_READY {
+		return "maybe", nil
+	}
+	// cover the cases #5711, #6685 that we ran into in the pass
+	// it is healthy if we could read one record from the pipelines table in 5 seconds
+	result := make(chan errors.Error, 1)
+	go func() {
+		result <- db.All(&models.Pipeline{}, dal.Limit(1))
+	}()
+	select {
+	case <-time.After(5 * time.Second):
+		return "timeouted", errors.Default.New("timeout reading from pipelines")
+	case err := <-result:
+		if err != nil {
+			return "bad", err
+		}
+		return "good", nil
+	}
+}


### PR DESCRIPTION
### Summary
Added the following probing endpoints:
1. `/ready`: returns `200 OK` when system is fully initialized, or `503 Service Unavailable` otherwise
2. `/health`: returns `200 OK` when system is health, or `500 Server Insternal Error` when loading pipelines from the database

