### PR TITLE
pr-type/bug-fix 7100 fixed by adding auto-discovery of interface type (ipv4/ipv6) inside nginx container

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -41,7 +41,7 @@ WORKDIR /usr/share/nginx/html
 RUN rm -rf ./*
 COPY --from=builder /home/node/code/dist/. ./
 EXPOSE 4000 4443
-RUN apt update && apt install -y apache2-utils
+RUN apt update && apt install -y apache2-utils iproute2
 COPY --from=builder /home/node/code/nginx.sh /usr/bin/nginx.sh
 RUN chmod +x /usr/bin/nginx.sh
 USER 101

--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -1,6 +1,5 @@
 server {
-  listen 4000;
-  listen [::]:4000;
+${LISTENER}
   server_name localhost;
   absolute_redirect off;
   client_max_body_size 20m;


### PR DESCRIPTION

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [/] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [/] I have added relevant tests.
- [/] I have added relevant documentation.
- [/] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Due to the bug described in #7100, config-ui nginx container will start only on dual-stack IP environments. This PR adds auto-discovery of interface type to nginx container and configures the nginx listener(s) accordingly. 

### Does this close any open issues?
Closes #7100 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
