### PR TITLE
fix: add missing config for the ADO Go Plugin

### DIFF
--- a/config-ui/src/plugins/components/scope-config-form/index.tsx
+++ b/config-ui/src/plugins/components/scope-config-form/index.tsx
@@ -194,6 +194,14 @@ export const ScopeConfigForm = ({
                 />
               )}
 
+              {plugin === 'azuredevops_go' && (
+                <AzureTransformation
+                  entities={entities}
+                  transformation={transformation}
+                  setTransformation={setTransformation}
+                />
+              )}
+
               {plugin === 'bamboo' && (
                 <BambooTransformation
                   entities={entities}

--- a/config-ui/src/release/stable.ts
+++ b/config-ui/src/release/stable.ts
@@ -30,6 +30,13 @@ const URLS = {
       TRANSFORMATION:
         'https://devlake.apache.org/docs/Configuration/AzureDevOps#step-3---adding-transformation-rules-optional',
     },
+    AZUREDEVOPS_GO: {
+      BASIS: 'https://devlake.apache.org/docs/Configuration/AzureDevOps',
+      RATE_LIMIT: 'https://devlake.apache.org/docs/Configuration/AzureDevOps/#custom-rate-limit-optional',
+      AUTH_TOKEN: 'https://devlake.apache.org/docs/Configuration/AzureDevOps#auth-tokens',
+      TRANSFORMATION:
+        'https://devlake.apache.org/docs/Configuration/AzureDevOps#step-3---adding-transformation-rules-optional',
+    },
     BAMBOO: {
       BASIS: 'https://devlake.apache.org/docs/Configuration/Bamboo',
       RATE_LIMIT: 'https://devlake.apache.org/docs/Configuration/Bamboo/#custom-rate-limit-optional',


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Fixes Scope Config Transformations. Which broke after the AzureDevOps Plugin was introduced.

### Does this close any open issues?
Closes #7208 

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/32308695/40d6f380-f98c-4bb0-8404-5c1be77c8e9b)

