### PR TITLE
fix: populate missing RepoUrl in CiCDPipelineCommit

### DIFF
--- a/backend/plugins/azuredevops_go/e2e/build_test.go
+++ b/backend/plugins/azuredevops_go/e2e/build_test.go
@@ -52,6 +52,7 @@ func TestAzuredevopsBuildDataFlow(t *testing.T) {
 
 	dataflowTester.FlushTabler(&models.AzuredevopsBuild{})
 	dataflowTester.ImportCsvIntoRawTable("./raw_tables/_raw_azuredevops_go_api_builds.csv", "_raw_azuredevops_go_api_builds")
+	dataflowTester.ImportCsvIntoTabler("./raw_tables/_tool_azuredevops_go_repos.csv", &models.AzuredevopsRepo{})
 	dataflowTester.Subtask(tasks.ExtractApiBuildsMeta, taskData)
 
 	// Omit the datetime columns to avoid test failures caused by the varying precision

--- a/backend/plugins/azuredevops_go/e2e/snapshot_tables/cicd_pipeline_commits.csv
+++ b/backend/plugins/azuredevops_go/e2e/snapshot_tables/cicd_pipeline_commits.csv
@@ -1,8 +1,8 @@
 pipeline_id,commit_sha,commit_msg,branch,repo_id,repo_url
-azuredevops_go:AzuredevopsBuild:1:12,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
-azuredevops_go:AzuredevopsBuild:1:13,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
-azuredevops_go:AzuredevopsBuild:1:14,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
-azuredevops_go:AzuredevopsBuild:1:15,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
-azuredevops_go:AzuredevopsBuild:1:16,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
-azuredevops_go:AzuredevopsBuild:1:17,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
-azuredevops_go:AzuredevopsBuild:1:18,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,
+azuredevops_go:AzuredevopsBuild:1:12,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo
+azuredevops_go:AzuredevopsBuild:1:13,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo
+azuredevops_go:AzuredevopsBuild:1:14,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo
+azuredevops_go:AzuredevopsBuild:1:15,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo
+azuredevops_go:AzuredevopsBuild:1:16,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo
+azuredevops_go:AzuredevopsBuild:1:17,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo
+azuredevops_go:AzuredevopsBuild:1:18,40c59264e73fc5e1a6cab192f1622d26b7bd5c2a,,refs/heads/main,0d50ba13-f9ad-49b0-9b21-d29eda50ca33,https://dev.azure.com/devlake/project-1/_git/first-repo

--- a/backend/plugins/azuredevops_go/tasks/ci_cd_build_converter.go
+++ b/backend/plugins/azuredevops_go/tasks/ci_cd_build_converter.go
@@ -44,13 +44,22 @@ var ConvertBuildsMeta = plugin.SubTaskMeta{
 	},
 }
 
+type JoinedBuild struct {
+	models.AzuredevopsBuild
+
+	URL string
+}
+
 func ConvertBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RawPullRequestTable)
 	clauses := []dal.Clause{
-		dal.Select("*"),
+		dal.Select("_tool_azuredevops_go_builds.*, _tool_azuredevops_go_repos.url"),
 		dal.From(&models.AzuredevopsBuild{}),
-		dal.Where(`repository_id = ? and connection_id = ?`, data.Options.RepositoryId, data.Options.ConnectionId),
+		dal.Join(`left join _tool_azuredevops_go_repos
+			on _tool_azuredevops_go_builds.repository_id = _tool_azuredevops_go_repos.id`),
+		dal.Where(`_tool_azuredevops_go_builds.repository_id = ? and _tool_azuredevops_go_builds.connection_id = ?`,
+			data.Options.RepositoryId, data.Options.ConnectionId),
 	}
 
 	cursor, err := db.Cursor(clauses...)
@@ -64,10 +73,10 @@ func ConvertBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 
 	converter, err := api.NewDataConverter(api.DataConverterArgs{
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
-		InputRowType:       reflect.TypeOf(models.AzuredevopsBuild{}),
+		InputRowType:       reflect.TypeOf(JoinedBuild{}),
 		Input:              cursor,
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
-			build := inputRow.(*models.AzuredevopsBuild)
+			build := inputRow.(*JoinedBuild)
 			duration := 0.0
 
 			if build.FinishTime != nil {
@@ -100,7 +109,7 @@ func ConvertBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 				CommitSha:  build.SourceVersion,
 				Branch:     build.SourceBranch,
 				RepoId:     build.RepositoryId,
-				RepoUrl:    "",
+				RepoUrl:    build.URL,
 			}
 
 			return []interface{}{


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
The `enrichPrevSuccessDeploymentCommits` task of the dora plugin relies on `cicd_deployment_commits.repo_url` to fetch  all successful deployments in a given project. Deployments without a specified `repo_url` will not be included in the subsequent calculation steps. Which will lead to problems in the form of #7193.

This PR populates the missing `repo_url`column by joining `_tool_azuredevops_go_builds` and `_tool_azuredevops_go_repos` in the `convertApiBuilds` task of the Azure DevOps Go plugin.

### Does this close any open issues?
Not sure if this closes #7193 but is definitely related
