### PR TITLE
fix(db): alter commit columns to binary type

### DIFF
--- a/backend/plugins/sonarqube/models/migrationscripts/20240325_modify_commit_character_type.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/20240325_modify_commit_character_type.go
@@ -1,0 +1,58 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"net/url"
+
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+)
+
+type modifyCommitCharacterType struct{}
+
+func (*modifyCommitCharacterType) Up(basicRes context.BasicRes) errors.Error {
+	dbUrl := basicRes.GetConfig("DB_URL")
+	if dbUrl == "" {
+		return errors.BadInput.New("DB_URL is required")
+	}
+	u, err1 := url.Parse(dbUrl)
+	if err1 != nil {
+		return errors.Convert(err1)
+	}
+	if u.Scheme == "mysql" {
+		err := basicRes.GetDal().Exec(`ALTER TABLE commits MODIFY COLUMN message LONGTEXT CHARACTER SET binary;`)
+		if err != nil {
+			return err
+		}
+		err = basicRes.GetDal().Exec(`ALTER TABLE commit_files MODIFY COLUMN file_path VARBINARY(255);`)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+
+}
+
+func (*modifyCommitCharacterType) Version() uint64 {
+	return 20240325160001
+}
+
+func (*modifyCommitCharacterType) Name() string {
+	return "support commits with ascii-extended character set"
+}

--- a/backend/plugins/sonarqube/models/migrationscripts/register.go
+++ b/backend/plugins/sonarqube/models/migrationscripts/register.go
@@ -30,5 +30,6 @@ func All() []plugin.MigrationScript {
 		new(modifyFileMetricsKeyLength),
 		new(modifyComponentLength),
 		new(addSonarQubeScopeConfig20231214),
+		new(modifyCommitCharacterType),
 	}
 }


### PR DESCRIPTION
### Summary
Migration schema for MySQL.
- `commits.message` is now `CHARACTER SET binary`,
- `commit_files.file_path` is now `VARBINARY`.

The reason is to support ASCII-extended characters in both columns.

⚠️ NOTE: Migration for  `file_path` is slow, about 3 minutes for ~1.4 million records.

### Does this close any open issues?
Fixes #7203
Fixes #7198