### PR TITLE
fix: remove refdiff plugin where scope config is nil

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/main.py
+++ b/backend/python/plugins/azuredevops/azuredevops/main.py
@@ -139,7 +139,7 @@ class AzureDevOpsPlugin(Plugin):
 
     def extra_stages(self, scope_config_pairs: list[tuple[GitRepository, GitRepositoryConfig]], _):
         for scope, config in scope_config_pairs:
-            if DomainType.CODE in config.domain_types and not scope.is_external():
+            if DomainType.CODE in config.domain_types and not scope.is_external() and scope.scope_config_id != 0:
                 yield [refdiff(scope.id, config.refdiff)]
 
 


### PR DESCRIPTION
### Summary
fix: remove refdiff plugin where scope config is nil

### Does this close any open issues?
Closes na

### Screenshots
has scope config: 
![image](https://github.com/apache/incubator-devlake/assets/101256042/dd5b7666-c7c6-4a61-9a5d-ace69f782b14)

no scope config:
![image](https://github.com/apache/incubator-devlake/assets/101256042/21c602c4-e93d-4b52-a25e-63bbc80f33a1)


### Other Information
Any other information that is important to this PR.
