### PR TITLE
fix: refine process of actions field in Jenkins raw data

### DIFF
--- a/backend/plugins/jenkins/tasks/build_extractor.go
+++ b/backend/plugins/jenkins/tasks/build_extractor.go
@@ -20,12 +20,13 @@ package tasks
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/jenkins/models"
-	"strings"
-	"time"
 )
 
 // this struct should be moved to `gitub_api_common.go`
@@ -75,6 +76,7 @@ func ExtractApiBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 			}
 			// we also need to collect the commit info from the build which does not have changeSet
 			// changeSet describes the changes that were made in the build
+			// process hudson.plugins.git.util.BuildData
 			for _, a := range body.Actions {
 				if a.LastBuiltRevision == nil {
 					continue
@@ -103,6 +105,9 @@ func ExtractApiBuilds(taskCtx plugin.SubTaskContext) errors.Error {
 						results = append(results, &buildCommitRemoteUrl)
 					}
 				}
+			}
+			// process hudson.model.CauseAction
+			for _, a := range body.Actions {
 				if len(a.Causes) > 0 {
 					for _, cause := range a.Causes {
 						if cause.UpstreamProject != "" {


### PR DESCRIPTION
### Summary
Refined process of actions field in Jenkins

### Does this close any open issues?
Closes #7261 

### Screenshots
![Snip20240331_5](https://github.com/apache/incubator-devlake/assets/183388/3ad4b8b7-ceab-4234-ba1a-6e19634e10f1)
Wants to bring this `triggered_by` field correctly.

### Other Information
N/A
