### PR TITLE
feat(grafana): Add HTTP query parameter in DORA dashboard panels

### DIFF
--- a/grafana/dashboards/DORA.json
+++ b/grafana/dashboards/DORA.json
@@ -184,7 +184,7 @@
                   {
                     "targetBlank": false,
                     "title": "",
-                    "url": "/d/${__data.fields[\"metric_hidden\"]}"
+                    "url": "/d/${__data.fields[\"metric_hidden\"]}?var-project=${project:raw}&from=${__from}&to=${__to}"
                   }
                 ]
               }
@@ -351,7 +351,7 @@
         {
           "targetBlank": false,
           "title": "link",
-          "url": "/d/Deployment-frequency/dora-drill-down-deployment-frequency?orgId=1"
+          "url": "/d/Deployment-frequency/dora-drill-down-deployment-frequency?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -494,7 +494,7 @@
       "links": [
         {
           "title": "link",
-          "url": "/d/Lead-time-for-changes/dora-drill-down-lead-time-for-changes?orgId=1"
+          "url": "/d/Lead-time-for-changes/dora-drill-down-lead-time-for-changes?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -638,7 +638,7 @@
       "links": [
         {
           "title": "link",
-          "url": "/d/Change-failure-rate/dora-drill-down-change-failure-rate?orgId=1"
+          "url": "/d/Change-failure-rate/dora-drill-down-change-failure-rate?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -786,11 +786,11 @@
       "links": [
         {
           "title": "Failed Deployment Recovery Time",
-          "url": "/d/Failed-deployment-recovery-time/dora-details-failed-deployment-recovery-time?orgId=1"
+          "url": "/d/Failed-deployment-recovery-time/dora-details-failed-deployment-recovery-time?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         },
         {
           "title": "Median Time to Restore Service",
-          "url": "/d/Time-to-restore-service/dora-details-median-time-to-restore-service?orgId=1"
+          "url": "/d/Time-to-restore-service/dora-details-median-time-to-restore-service?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -917,7 +917,7 @@
       "links": [
         {
           "title": "link",
-          "url": "/d/Deployment-frequency/dora-drill-down-deployment-frequency?orgId=1"
+          "url": "/d/Deployment-frequency/dora-drill-down-deployment-frequency?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -1047,7 +1047,7 @@
       "links": [
         {
           "title": "link",
-          "url": "/d/Lead-time-for-changes/dora-drill-down-lead-time-for-changes?orgId=1"
+          "url": "/d/Lead-time-for-changes/dora-drill-down-lead-time-for-changes?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -1197,7 +1197,7 @@
       "links": [
         {
           "title": "link",
-          "url": "/d/Change-failure-rate/dora-drill-down-change-failure-rate?orgId=1"
+          "url": "/d/Change-failure-rate/dora-drill-down-change-failure-rate?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {
@@ -1351,11 +1351,11 @@
       "links": [
         {
           "title": "Failed Deployment Recovery Time",
-          "url": "/d/Failed-deployment-recovery-time/dora-details-failed-deployment-recovery-time?orgId=1"
+          "url": "/d/Failed-deployment-recovery-time/dora-details-failed-deployment-recovery-time?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         },
         {
           "title": "Median Time To Restore Service",
-          "url": "/d/Time-to-restore-service/dora-details-median-time-to-restore-service?orgId=1"
+          "url": "/d/Time-to-restore-service/dora-details-median-time-to-restore-service?orgId=1&var-project=${project:raw}&from=${__from}&to=${__to}"
         }
       ],
       "options": {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This PR introduces a new HTTP query parameter (`var-project=${project:raw}`) to the links within the DORA dashboard's panels. This enhancement ensures that when a user clicks on a panel link, they are directly navigated to the external dashboard that corresponds with the `Search` project, as illustrated in the attached screenshot.

Also added a time filter variable as @Startrekzky suggested [here](https://github.com/apache/incubator-devlake/pull/7263/commits/1c9178b51cb8c6a7aa932291dc3c62e5acc85e61#r1554811279)

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/46712946/aeae49ad-5e99-40cd-b635-4d8af40bf3f3)


### Other Information
There are some Grafana limitations e.g.: in case of multiple projects the link will not work properly, but it's very helpful when a single project is selected.