### PR TITLE
fix: git command doesn't exist in the docker image

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -40,7 +40,7 @@ ARG HTTP_PROXY=
 ARG HTTPS_PROXY=
 
 RUN apt-get update
-RUN apt-get install -y gcc binutils libfindbin-libs-perl cmake libssh2-1-dev libssl-dev zlib1g-dev git openssh-client corkscrew
+RUN apt-get install -y gcc binutils libfindbin-libs-perl cmake libssh2-1-dev libssl-dev zlib1g-dev
 
 RUN if [ "$(arch)" != "aarch64" ] ; then \
         apt-get install -y gcc-aarch64-linux-gnu binutils-aarch64-linux-gnu ; \
@@ -116,7 +116,7 @@ RUN cd /usr/local/deps/target/lib && \
 FROM python:3.9-slim-bullseye as base
 
 RUN apt-get update && \
-    apt-get install -y python3-dev python3-pip tar pkg-config curl libssh2-1 zlib1g libffi-dev default-libmysqlclient-dev libpq-dev tini && \
+    apt-get install -y python3-dev python3-pip tar pkg-config curl libssh2-1 zlib1g libffi-dev default-libmysqlclient-dev libpq-dev tini git openssh-client corkscrew && \
     apt-get clean && \
     rm -fr /usr/share/doc/* \
            /usr/share/info/* \


### PR DESCRIPTION

### Summary
Fixes the following error:
```
time="2024-04-08 04:01:35" level=info msg=" [pipeline service] [pipeline #80] [task #443] executing subtask Clone Git Repo"
time="2024-04-08 04:01:35" level=error msg=" [pipeline service] [pipeline #80] [task #443] [Clone Git Repo] [gitcli] failed to start\n\tcaused by: exec: \"git\": executable file not found in $PATH"
time="2024-04-08 04:01:35" level=error msg=" [pipeline service] [pipeline #80] [task #443] subtask Clone Git Repo ended unexpectedly\n\tWraps: (2) failed to start\n\tError types: (1) *hintdetail.withDetail (2) *errors.errorString"
```

