### PR TITLE
fix: gitextractor reporting object not found

### DIFF
--- a/backend/plugins/gitextractor/parser/repo_gogit.go
+++ b/backend/plugins/gitextractor/parser/repo_gogit.go
@@ -372,6 +372,10 @@ func (r *GogitRepoCollector) storeParentCommits(commitSha string, commit *object
 	for i := 0; i < commit.NumParents(); i++ {
 		parent, err := commit.Parent(i)
 		if err != nil {
+			// parent commit might not exist when repo is shallow cloned (tradeoff of supporting timeAfter paramenter)
+			if err.Error() == "object not found" {
+				continue
+			}
 			return err
 		}
 		if parent != nil {

--- a/backend/plugins/gitextractor/parser/repo_libgit2.go
+++ b/backend/plugins/gitextractor/parser/repo_libgit2.go
@@ -85,7 +85,11 @@ func (r *Libgit2RepoCollector) CollectAll(subtaskCtx plugin.SubTaskContext) erro
 	if err != nil {
 		return err
 	}
-	return r.CollectDiffLine(subtaskCtx)
+	opt := subtaskCtx.GetData().(*GitExtractorTaskData).Options
+	if !*opt.SkipCommitStat {
+		return r.CollectDiffLine(subtaskCtx)
+	}
+	return nil
 }
 
 // Close resources

--- a/backend/plugins/gitextractor/tasks/clone.go
+++ b/backend/plugins/gitextractor/tasks/clone.go
@@ -62,9 +62,9 @@ func CloneGitRepo(subTaskCtx plugin.SubTaskContext) errors.Error {
 	// We have done comparison experiments for git2go and go-git, and the results show that git2go has better performance.
 	var repoCollector parser.RepoCollector
 	if *taskData.Options.UseGoGit {
-		repoCollector, err = parser.NewLibgit2RepoCollector(localDir, op.RepoId, storage, logger)
-	} else {
 		repoCollector, err = parser.NewGogitRepoCollector(localDir, op.RepoId, storage, logger)
+	} else {
+		repoCollector, err = parser.NewLibgit2RepoCollector(localDir, op.RepoId, storage, logger)
 	}
 	if err != nil {
 		return err

--- a/backend/plugins/gitextractor/tasks/git_repo_collector.go
+++ b/backend/plugins/gitextractor/tasks/git_repo_collector.go
@@ -61,14 +61,12 @@ func CollectGitTags(subTaskCtx plugin.SubTaskContext) errors.Error {
 
 func CollectGitDiffLines(subTaskCtx plugin.SubTaskContext) errors.Error {
 	repo := getGitRepo(subTaskCtx)
-	if count, err := repo.CountTags(subTaskCtx.GetContext()); err != nil {
-		subTaskCtx.GetLogger().Error(err, "unable to get line content")
+	opt := subTaskCtx.GetData().(*parser.GitExtractorTaskData).Options
+	if !*opt.SkipCommitStat {
 		subTaskCtx.SetProgress(0, -1)
-		return errors.Convert(err)
-	} else {
-		subTaskCtx.SetProgress(0, count)
+		return errors.Convert(repo.CollectDiffLine(subTaskCtx))
 	}
-	return errors.Convert(repo.CollectDiffLine(subTaskCtx))
+	return nil
 }
 
 func getGitRepo(subTaskCtx plugin.SubTaskContext) parser.RepoCollector {


### PR DESCRIPTION
### Summary
1. fixes `object not found` when using `go-git` collector
2. fixes `go-git` collector is used when `useGoGit=false` 
