### PR TITLE
fix: more friendly msg when no data with shallow clone

### DIFF
--- a/backend/plugins/gitextractor/parser/clone_gitcli.go
+++ b/backend/plugins/gitextractor/parser/clone_gitcli.go
@@ -157,6 +157,9 @@ func (g *GitcliCloner) CloneRepo(ctx plugin.SubTaskContext, localDir string) err
 	err = cmd.Wait()
 	if err != nil {
 		g.logger.Error(err, "git exited with error\n%s", combinedOutput.String())
+		if strings.Contains(combinedOutput.String(), "stderr: fatal: error processing shallow info: 4") {
+			return errors.BadInput.New("No data found for the selected time range. Please revise the 'Time Range' on your Project/Blueprint/Configuration page or in the API parameter.")
+		}
 		return errors.Default.New("git exit error")
 	}
 	return nil


### PR DESCRIPTION
### Summary

With `timeAfter` support was added to the `gitextractor` plugin, it became possible for `git cli` to end up with nothing to clone for, which leads to a `shallow clone` error.

This PR turns the message into a more user-friendly one to help them solve the error.

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/20a88e60-9b97-4c5f-8f23-7c9145748c40)

