### PR TITLE
refactor: deprecate specifying timeAfter via `taskOptions`

### DIFF
--- a/backend/plugins/ae/tasks/task_data.go
+++ b/backend/plugins/ae/tasks/task_data.go
@@ -22,9 +22,8 @@ import (
 )
 
 type AeOptions struct {
-	ConnectionId            uint64 `json:"connectionId"`
-	ProjectId               int
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId uint64 `json:"connectionId"`
+	ProjectId    int
 }
 
 type AeTaskData struct {

--- a/backend/plugins/bamboo/models/task_data.go
+++ b/backend/plugins/bamboo/models/task_data.go
@@ -17,8 +17,6 @@ limitations under the License.
 
 package models
 
-import "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-
 type BambooApiParams struct {
 	ConnectionId uint64 `json:"connectionId"`
 	PlanKey      string
@@ -29,9 +27,8 @@ type BambooOptions struct {
 	// options means some custom params required by plugin running.
 	// Such As How many rows do your want
 	// You can use it in sub tasks and you need pass it in main.go and pipelines.
-	ConnectionId         uint64 `json:"connectionId" mapstructure:"connectionId"`
-	PlanKey              string `json:"planKey" mapstructure:"planKey"`
-	ScopeConfigId        uint64 ` json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	*BambooScopeConfig   `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId       uint64 `json:"connectionId" mapstructure:"connectionId"`
+	PlanKey            string `json:"planKey" mapstructure:"planKey"`
+	ScopeConfigId      uint64 ` json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
+	*BambooScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
 }

--- a/backend/plugins/bitbucket/tasks/task_data.go
+++ b/backend/plugins/bitbucket/tasks/task_data.go
@@ -29,7 +29,6 @@ type BitbucketOptions struct {
 	FullName                     string   `json:"fullName" mapstructure:"fullName"`
 	ScopeConfigId                uint64   `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
 	*models.BitbucketScopeConfig `mapstructure:"scopeConfig,omitempty" json:"scopeConfig"`
-	api.CollectorOptions         `mapstructure:",squash"`
 }
 
 type BitbucketTaskData struct {

--- a/backend/plugins/circleci/tasks/task_data.go
+++ b/backend/plugins/circleci/tasks/task_data.go
@@ -24,12 +24,11 @@ import (
 )
 
 type CircleciOptions struct {
-	ConnectionId            uint64                      `json:"connectionId" mapstructure:"connectionId"`
-	ProjectSlug             string                      `json:"projectSlug" mapstructure:"projectSlug"`
-	PageSize                uint64                      `mapstruct:"pageSize" mapstructure:"pageSize,omitempty"`
-	ScopeConfigId           uint64                      `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	ScopeConfig             *models.CircleciScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64                      `json:"connectionId" mapstructure:"connectionId"`
+	ProjectSlug   string                      `json:"projectSlug" mapstructure:"projectSlug"`
+	PageSize      uint64                      `mapstruct:"pageSize" mapstructure:"pageSize,omitempty"`
+	ScopeConfigId uint64                      `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
+	ScopeConfig   *models.CircleciScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
 }
 
 type CircleciTaskData struct {

--- a/backend/plugins/customize/tasks/task_data.go
+++ b/backend/plugins/customize/tasks/task_data.go
@@ -17,8 +17,6 @@ limitations under the License.
 
 package tasks
 
-import "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-
 type MappingRules struct {
 	Table         string            `json:"table" example:"issues"`
 	RawDataTable  string            `json:"rawDataTable" example:"_raw_jira_api_issues"`
@@ -27,8 +25,7 @@ type MappingRules struct {
 }
 
 type Options struct {
-	TransformationRules  []MappingRules `json:"transformationRules"`
-	api.CollectorOptions `mapstructure:",squash"`
+	TransformationRules []MappingRules `json:"transformationRules"`
 }
 
 type TaskData struct {

--- a/backend/plugins/feishu/tasks/task_data.go
+++ b/backend/plugins/feishu/tasks/task_data.go
@@ -26,9 +26,8 @@ type FeishuApiParams struct {
 }
 
 type FeishuOptions struct {
-	ConnectionId            uint64  `json:"connectionId"`
-	NumOfDaysToCollect      float64 `json:"numOfDaysToCollect"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId       uint64  `json:"connectionId"`
+	NumOfDaysToCollect float64 `json:"numOfDaysToCollect"`
 }
 
 type FeishuTaskData struct {

--- a/backend/plugins/gitee/tasks/task_data.go
+++ b/backend/plugins/gitee/tasks/task_data.go
@@ -26,11 +26,10 @@ import (
 )
 
 type GiteeOptions struct {
-	ConnectionId         uint64 `json:"connectionId"`
-	Owner                string
-	Repo                 string
-	ScopeConfig          models.GiteeScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId uint64 `json:"connectionId"`
+	Owner        string
+	Repo         string
+	ScopeConfig  models.GiteeScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
 }
 
 type GiteeTaskData struct {

--- a/backend/plugins/github/tasks/task_data.go
+++ b/backend/plugins/github/tasks/task_data.go
@@ -27,15 +27,14 @@ import (
 )
 
 type GithubOptions struct {
-	ConnectionId            uint64                    `json:"connectionId" mapstructure:"connectionId,omitempty"`
-	ScopeConfigId           uint64                    `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	GithubId                int                       `json:"githubId" mapstructure:"githubId,omitempty"`
-	Owner                   string                    `json:"owner" mapstructure:"owner,omitempty"`
-	Repo                    string                    `json:"repo"  mapstructure:"repo,omitempty"`
-	Name                    string                    `json:"name"  mapstructure:"name,omitempty"`
-	FullName                string                    `json:"fullName"  mapstructure:"fullName,omitempty"`
-	ScopeConfig             *models.GithubScopeConfig `mapstructure:"scopeConfig,omitempty" json:"scopeConfig"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64                    `json:"connectionId" mapstructure:"connectionId,omitempty"`
+	ScopeConfigId uint64                    `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
+	GithubId      int                       `json:"githubId" mapstructure:"githubId,omitempty"`
+	Owner         string                    `json:"owner" mapstructure:"owner,omitempty"`
+	Repo          string                    `json:"repo"  mapstructure:"repo,omitempty"`
+	Name          string                    `json:"name"  mapstructure:"name,omitempty"`
+	FullName      string                    `json:"fullName"  mapstructure:"fullName,omitempty"`
+	ScopeConfig   *models.GithubScopeConfig `mapstructure:"scopeConfig,omitempty" json:"scopeConfig"`
 }
 
 type GithubTaskData struct {

--- a/backend/plugins/gitlab/tasks/task_data.go
+++ b/backend/plugins/gitlab/tasks/task_data.go
@@ -24,12 +24,11 @@ import (
 )
 
 type GitlabOptions struct {
-	ConnectionId            uint64                    `mapstructure:"connectionId" json:"connectionId"`
-	ProjectId               int                       `mapstructure:"projectId" json:"projectId"`
-	FullName                string                    `mapstructure:"fullName" json:"fullName"`
-	ScopeConfigId           uint64                    `mapstructure:"scopeConfigId" json:"scopeConfigId"`
-	ScopeConfig             *models.GitlabScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64                    `mapstructure:"connectionId" json:"connectionId"`
+	ProjectId     int                       `mapstructure:"projectId" json:"projectId"`
+	FullName      string                    `mapstructure:"fullName" json:"fullName"`
+	ScopeConfigId uint64                    `mapstructure:"scopeConfigId" json:"scopeConfigId"`
+	ScopeConfig   *models.GitlabScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
 }
 
 type GitlabTaskData struct {

--- a/backend/plugins/icla/tasks/task_data.go
+++ b/backend/plugins/icla/tasks/task_data.go
@@ -29,8 +29,7 @@ type IclaOptions struct {
 	// options means some custom params required by plugin running.
 	// Such As How many rows do your want
 	// You can use it in subtasks, and you need to pass it to main.go and pipelines.
-	Tasks                   []string `json:"tasks,omitempty"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	Tasks []string `json:"tasks,omitempty"`
 }
 
 type IclaTaskData struct {

--- a/backend/plugins/jenkins/tasks/task_data.go
+++ b/backend/plugins/jenkins/tasks/task_data.go
@@ -27,15 +27,14 @@ import (
 
 type JenkinsApiParams models.JenkinsApiParams
 type JenkinsOptions struct {
-	ConnectionId         uint64                     `json:"connectionId" mapstructure:"connectionId"`
-	ScopeConfigId        uint64                     `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	FullName             string                     `json:"fullName,omitempty" mapstructure:"fullName,omitempty"`       // "path1/path2/job name"
-	JobFullName          string                     `json:"jobFullName,omitempty" mapstructure:"jobFullName,omitempty"` // "path1/path2/job name"
-	JobName              string                     `json:"jobName,omitempty" mapstructure:"jobName,omitempty"`         // "job name"
-	JobPath              string                     `json:"jobPath,omitempty" mapstructure:"jobPath,omitempty"`         // "job/path1/job/path2"
-	Tasks                []string                   `json:"tasks,omitempty" mapstructure:"tasks,omitempty"`
-	ScopeConfig          *models.JenkinsScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64                     `json:"connectionId" mapstructure:"connectionId"`
+	ScopeConfigId uint64                     `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
+	FullName      string                     `json:"fullName,omitempty" mapstructure:"fullName,omitempty"`       // "path1/path2/job name"
+	JobFullName   string                     `json:"jobFullName,omitempty" mapstructure:"jobFullName,omitempty"` // "path1/path2/job name"
+	JobName       string                     `json:"jobName,omitempty" mapstructure:"jobName,omitempty"`         // "job name"
+	JobPath       string                     `json:"jobPath,omitempty" mapstructure:"jobPath,omitempty"`         // "job/path1/job/path2"
+	Tasks         []string                   `json:"tasks,omitempty" mapstructure:"tasks,omitempty"`
+	ScopeConfig   *models.JenkinsScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
 }
 
 type JenkinsTaskData struct {

--- a/backend/plugins/jira/tasks/task_data.go
+++ b/backend/plugins/jira/tasks/task_data.go
@@ -26,12 +26,11 @@ import (
 )
 
 type JiraOptions struct {
-	ConnectionId         uint64                  `json:"connectionId" mapstructure:"connectionId"`
-	BoardId              uint64                  `json:"boardId" mapstructure:"boardId"`
-	ScopeConfig          *models.JiraScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig"`
-	ScopeConfigId        uint64                  `json:"scopeConfigId" mapstructure:"scopeConfigId"`
-	PageSize             int                     `json:"pageSize" mapstructure:"pageSize"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64                  `json:"connectionId" mapstructure:"connectionId"`
+	BoardId       uint64                  `json:"boardId" mapstructure:"boardId"`
+	ScopeConfig   *models.JiraScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig"`
+	ScopeConfigId uint64                  `json:"scopeConfigId" mapstructure:"scopeConfigId"`
+	PageSize      int                     `json:"pageSize" mapstructure:"pageSize"`
 }
 
 type JiraTaskData struct {

--- a/backend/plugins/opsgenie/tasks/task_data.go
+++ b/backend/plugins/opsgenie/tasks/task_data.go
@@ -24,11 +24,10 @@ import (
 )
 
 type OpsgenieOptions struct {
-	ConnectionId         uint64   `json:"connectionId"`
-	ServiceId            string   `json:"service_id,omitempty"`
-	ServiceName          string   `json:"service_name,omitempty"`
-	Tasks                []string `json:"tasks,omitempty"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId uint64   `json:"connectionId"`
+	ServiceId    string   `json:"service_id,omitempty"`
+	ServiceName  string   `json:"service_name,omitempty"`
+	Tasks        []string `json:"tasks,omitempty"`
 	*models.OpsenieScopeConfig
 }
 

--- a/backend/plugins/pagerduty/tasks/task_data.go
+++ b/backend/plugins/pagerduty/tasks/task_data.go
@@ -24,11 +24,10 @@ import (
 )
 
 type PagerDutyOptions struct {
-	ConnectionId         uint64   `json:"connectionId"`
-	ServiceId            string   `json:"service_id,omitempty"`
-	ServiceName          string   `json:"service_name,omitempty"`
-	Tasks                []string `json:"tasks,omitempty"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId uint64   `json:"connectionId"`
+	ServiceId    string   `json:"service_id,omitempty"`
+	ServiceName  string   `json:"service_name,omitempty"`
+	Tasks        []string `json:"tasks,omitempty"`
 	*models.PagerdutyScopeConfig
 }
 

--- a/backend/plugins/slack/tasks/task_data.go
+++ b/backend/plugins/slack/tasks/task_data.go
@@ -26,8 +26,7 @@ type SlackApiParams struct {
 }
 
 type SlackOptions struct {
-	ConnectionId            uint64 `json:"connectionId"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId uint64 `json:"connectionId"`
 }
 
 type SlackTaskData struct {

--- a/backend/plugins/sonarqube/tasks/task_data.go
+++ b/backend/plugins/sonarqube/tasks/task_data.go
@@ -28,9 +28,8 @@ type SonarqubeOptions struct {
 	// options means some custom params required by plugin running.
 	// Such As How many rows do your want
 	// You can use it in subtasks, and you need to pass it to main.go and pipelines.
-	ConnectionId         uint64 `json:"connectionId" mapstructure:"connectionId"`
-	ProjectKey           string `json:"projectKey" mapstructure:"projectKey"`
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId uint64 `json:"connectionId" mapstructure:"connectionId"`
+	ProjectKey   string `json:"projectKey" mapstructure:"projectKey"`
 }
 
 type SonarqubeTaskData struct {

--- a/backend/plugins/tapd/tasks/task_data.go
+++ b/backend/plugins/tapd/tasks/task_data.go
@@ -26,13 +26,12 @@ import (
 )
 
 type TapdOptions struct {
-	ConnectionId            uint64 `mapstruct:"connectionId"`
-	WorkspaceId             uint64 `mapstruct:"workspaceId"`
-	PageSize                uint64 `mapstruct:"pageSize"`
-	CstZone                 *time.Location
-	ScopeConfigId           uint64
-	ScopeConfig             *models.TapdScopeConfig `json:"scopeConfig"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64 `mapstruct:"connectionId"`
+	WorkspaceId   uint64 `mapstruct:"workspaceId"`
+	PageSize      uint64 `mapstruct:"pageSize"`
+	CstZone       *time.Location
+	ScopeConfigId uint64
+	ScopeConfig   *models.TapdScopeConfig `json:"scopeConfig"`
 }
 
 type TapdTaskData struct {

--- a/backend/plugins/teambition/tasks/task_data.go
+++ b/backend/plugins/teambition/tasks/task_data.go
@@ -25,12 +25,11 @@ import (
 )
 
 type TeambitionOptions struct {
-	ConnectionId            uint64 `json:"connectionId"`
-	ProjectId               string `json:"projectId"`
-	PageSize                uint64 `mapstruct:"pageSize"`
-	CstZone                 *time.Location
-	TransformationRules     TransformationRules `json:"transformationRules"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ConnectionId        uint64 `json:"connectionId"`
+	ProjectId           string `json:"projectId"`
+	PageSize            uint64 `mapstruct:"pageSize"`
+	CstZone             *time.Location
+	TransformationRules TransformationRules `json:"transformationRules"`
 }
 
 type TeambitionTaskData struct {

--- a/backend/plugins/trello/tasks/task_data.go
+++ b/backend/plugins/trello/tasks/task_data.go
@@ -23,11 +23,10 @@ import (
 )
 
 type TrelloOptions struct {
-	ConnectionId         uint64 `json:"connectionId"`
-	BoardId              string `json:"boardId"`
-	ScopeId              string
-	ScopeConfigId        uint64
-	api.CollectorOptions `mapstructure:",squash"`
+	ConnectionId  uint64 `json:"connectionId"`
+	BoardId       string `json:"boardId"`
+	ScopeId       string
+	ScopeConfigId uint64
 }
 
 type TrelloTaskData struct {

--- a/backend/plugins/zentao/tasks/task_data.go
+++ b/backend/plugins/zentao/tasks/task_data.go
@@ -36,9 +36,8 @@ type ZentaoOptions struct {
 	ConnectionId uint64 `json:"connectionId"`
 	ProjectId    int64  `json:"projectId" mapstructure:"projectId"`
 	// TODO not support now
-	ScopeConfigId           uint64                    `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
-	ScopeConfig             *models.ZentaoScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
-	helper.CollectorOptions `mapstructure:",squash"`
+	ScopeConfigId uint64                    `json:"scopeConfigId" mapstructure:"scopeConfigId,omitempty"`
+	ScopeConfig   *models.ZentaoScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig,omitempty"`
 }
 
 func (o *ZentaoOptions) GetParams() any {


### PR DESCRIPTION
### Summary

In the current implementation, one can specify the `timeAfter` via the `taskOptions` like the following:
```
[
  [
    {"plugin": "github", "options": { "timeAfter": "2024-04-15T15:29:43Z", ... }},
    {"plugin": "jira", "options": { "timeAfter": "2023-04-15T15:29:43Z", ... }}
  ]
]
```
This looks flexible but doesn't make too much sense because a Project/Blueprint/Pipeline crunches the **SAME** time range of data from different data sources in most cases if not all.

So, this feature is rarely used because we have `timeAfter` on the Project/Blueprint/Pipeline level, it is easier to use. 

For those who really need to collector different data sources with different time range can could use multiple Projects/Blueprints, or Pipelines. So no point in maintaining such a feature.

This  PR remove the `timeAfter` option from the `taskOptions` for all plugin to simply our logic and make contributors life easier.
