### PR TITLE
fix(tapd): change iteration_id's type from uint64 to int64

### DIFF
--- a/backend/plugins/tapd/models/bug.go
+++ b/backend/plugins/tapd/models/bug.go
@@ -35,7 +35,7 @@ type TapdBug struct {
 	Begin        *common.CSTTime `json:"begin"`
 	Due          *common.CSTTime `json:"due"`
 	Priority     string          `json:"priority" gorm:"type:varchar(255)"`
-	IterationId  uint64          `json:"iteration_id,string"`
+	IterationId  int64           `json:"iteration_id,string"`
 	Source       string          `json:"source" gorm:"type:varchar(255)"`
 	Module       string          `json:"module" gorm:"type:varchar(255)"`
 	ReleaseId    uint64          `json:"release_id,string"`

--- a/backend/plugins/tapd/models/bug_changelog.go
+++ b/backend/plugins/tapd/models/bug_changelog.go
@@ -41,8 +41,8 @@ type TapdBugChangelogItem struct {
 	Field             string `json:"field" gorm:"primaryKey;"`
 	ValueBeforeParsed string `json:"value_before_parsed"`
 	ValueAfterParsed  string `json:"value_after_parsed"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 

--- a/backend/plugins/tapd/models/changelog.go
+++ b/backend/plugins/tapd/models/changelog.go
@@ -31,8 +31,8 @@ type ChangelogTmp struct {
 	FieldName       string
 	FromValue       string
 	ToValue         string
-	IterationIdFrom uint64
-	IterationIdTo   uint64
+	IterationIdFrom int64
+	IterationIdTo   int64
 	CreatedDate     time.Time
 	common.RawDataOrigin
 }

--- a/backend/plugins/tapd/models/iteration.go
+++ b/backend/plugins/tapd/models/iteration.go
@@ -23,7 +23,7 @@ import (
 
 type TapdIteration struct {
 	ConnectionId uint64          `gorm:"primaryKey;type:BIGINT NOT NULL"`
-	Id           uint64          `gorm:"primaryKey;type:BIGINT NOT NULL;autoIncrement:false" json:"id,string"`
+	Id           int64           `gorm:"primaryKey;type:BIGINT NOT NULL;autoIncrement:false" json:"id,string"`
 	Name         string          `gorm:"type:varchar(255)" json:"name"`
 	WorkspaceId  uint64          `json:"workspace_id,string"`
 	Startdate    *common.CSTTime `json:"startdate"`
@@ -46,7 +46,7 @@ type TapdWorkspaceIteration struct {
 	common.NoPKModel
 	ConnectionId uint64 `gorm:"primaryKey"`
 	WorkspaceId  uint64 `gorm:"primaryKey"`
-	IterationId  uint64 `gorm:"primaryKey"`
+	IterationId  int64  `gorm:"primaryKey"`
 }
 
 func (TapdIteration) TableName() string {

--- a/backend/plugins/tapd/models/iteration_bug.go
+++ b/backend/plugins/tapd/models/iteration_bug.go
@@ -24,7 +24,7 @@ import (
 type TapdIterationBug struct {
 	common.NoPKModel
 	ConnectionId   uint64 `gorm:"primaryKey"`
-	IterationId    uint64 `gorm:"primaryKey"`
+	IterationId    int64  `gorm:"primaryKey"`
 	WorkspaceId    uint64 `gorm:"primaryKey"`
 	BugId          uint64 `gorm:"primaryKey"`
 	ResolutionDate *common.CSTTime

--- a/backend/plugins/tapd/models/iteration_story.go
+++ b/backend/plugins/tapd/models/iteration_story.go
@@ -24,7 +24,7 @@ import (
 type TapdIterationStory struct {
 	common.NoPKModel
 	ConnectionId uint64 `gorm:"primaryKey"`
-	IterationId  uint64 `gorm:"primaryKey"`
+	IterationId  int64  `gorm:"primaryKey"`
 	WorkspaceId  uint64 `gorm:"primaryKey"`
 
 	StoryId          uint64 `gorm:"primaryKey"`

--- a/backend/plugins/tapd/models/iteration_task.go
+++ b/backend/plugins/tapd/models/iteration_task.go
@@ -24,7 +24,7 @@ import (
 type TapdIterationTask struct {
 	common.NoPKModel
 	ConnectionId uint64 `gorm:"primaryKey"`
-	IterationId  uint64 `gorm:"primaryKey"`
+	IterationId  int64  `gorm:"primaryKey"`
 	WorkspaceId  uint64 `gorm:"primaryKey"`
 
 	TaskId          uint64 `gorm:"primaryKey"`

--- a/backend/plugins/tapd/models/story.go
+++ b/backend/plugins/tapd/models/story.go
@@ -39,7 +39,7 @@ type TapdStory struct {
 	Size            int16           `json:"size,string"`
 	Priority        string          `gorm:"type:varchar(255)" json:"priority"`
 	Developer       string          `gorm:"type:varchar(255)" json:"developer"`
-	IterationId     uint64          `json:"iteration_id,string"`
+	IterationId     int64           `json:"iteration_id,string"`
 	TestFocus       string          `json:"test_focus" gorm:"type:varchar(255)"`
 	Type            string          `json:"type" gorm:"type:varchar(255)"`
 	Source          string          `json:"source" gorm:"type:varchar(255)"`

--- a/backend/plugins/tapd/models/story_changelog.go
+++ b/backend/plugins/tapd/models/story_changelog.go
@@ -47,8 +47,8 @@ type TapdStoryChangelogItemRes struct {
 	ValueAfterParsed  json.RawMessage `json:"value_after_parsed"`
 	ValueBefore       json.RawMessage `json:"value_before"`
 	ValueAfter        json.RawMessage `json:"value_after"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 
@@ -58,8 +58,8 @@ type TapdStoryChangelogItem struct {
 	Field             string `json:"field" gorm:"primaryKey;type:varchar(255)"`
 	ValueBeforeParsed string `json:"value_before_parsed"`
 	ValueAfterParsed  string `json:"value_after_parsed"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 

--- a/backend/plugins/tapd/models/task.go
+++ b/backend/plugins/tapd/models/task.go
@@ -36,7 +36,7 @@ type TapdTask struct {
 	Begin           *common.CSTTime `json:"begin"`
 	Due             *common.CSTTime `json:"due"`
 	Priority        string          `gorm:"type:varchar(255)" json:"priority"`
-	IterationId     uint64          `json:"iteration_id,string"`
+	IterationId     int64           `json:"iteration_id,string"`
 	Completed       *common.CSTTime `json:"completed"`
 	Effort          float32         `json:"effort,string"`
 	EffortCompleted float32         `json:"effort_completed,string"`

--- a/backend/plugins/tapd/models/task_changelog.go
+++ b/backend/plugins/tapd/models/task_changelog.go
@@ -46,8 +46,8 @@ type TapdTaskChangelogItem struct {
 	Field             string `json:"field" gorm:"primaryKey;type:varchar(255)"`
 	ValueBeforeParsed string `json:"value_before_parsed"`
 	ValueAfterParsed  string `json:"value_after_parsed"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 
@@ -59,8 +59,8 @@ type TapdTaskChangelogItemRes struct {
 	ValueAfterParsed  json.RawMessage `json:"value_after_parsed"`
 	ValueBefore       json.RawMessage `json:"value_before"`
 	ValueAfter        json.RawMessage `json:"value_after"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 

--- a/backend/plugins/tapd/tasks/bug_changelog_converter.go
+++ b/backend/plugins/tapd/tasks/bug_changelog_converter.go
@@ -46,8 +46,8 @@ type BugChangelogItemResult struct {
 	ChangelogId       uint64     `gorm:"primaryKey;type:BIGINT  NOT NULL"`
 	ValueBeforeParsed string     `json:"value_before"`
 	ValueAfterParsed  string     `json:"value_after"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 

--- a/backend/plugins/tapd/tasks/shared.go
+++ b/backend/plugins/tapd/tasks/shared.go
@@ -98,7 +98,7 @@ func GetTotalPagesFromResponse(r *http.Response, args *api.ApiCollectorArgs) (in
 }
 
 // parseIterationChangelog function is used to parse the iteration changelog
-func parseIterationChangelog(taskCtx plugin.SubTaskContext, old string, new string) (iterationFromId uint64, iterationToId uint64, err errors.Error) {
+func parseIterationChangelog(taskCtx plugin.SubTaskContext, old string, new string) (iterationFromId int64, iterationToId int64, err errors.Error) {
 	data := taskCtx.GetData().(*TapdTaskData)
 	db := taskCtx.GetDal()
 

--- a/backend/plugins/tapd/tasks/shared_test.go
+++ b/backend/plugins/tapd/tasks/shared_test.go
@@ -64,8 +64,8 @@ func TestParseIterationChangelog(t *testing.T) {
 	}).Return(nil).Once()
 	// Test case 2: success scenario
 	iterationFromId, iterationToId, err := parseIterationChangelog(mockCtx, "old", "new")
-	assert.Equal(t, uint64(1), iterationFromId)
-	assert.Equal(t, uint64(2), iterationToId)
+	assert.Equal(t, int64(1), iterationFromId)
+	assert.Equal(t, int64(2), iterationToId)
 	assert.Nil(t, err)
 }
 

--- a/backend/plugins/tapd/tasks/story_changelog_converter.go
+++ b/backend/plugins/tapd/tasks/story_changelog_converter.go
@@ -49,8 +49,8 @@ type StoryChangelogItemResult struct {
 	Field             string     `json:"field" gorm:"primaryKey;type:varchar(255)"`
 	ValueBeforeParsed string     `json:"value_before"`
 	ValueAfterParsed  string     `json:"value_after"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 

--- a/backend/plugins/tapd/tasks/task_changelog_converter.go
+++ b/backend/plugins/tapd/tasks/task_changelog_converter.go
@@ -50,8 +50,8 @@ type TaskChangelogItemResult struct {
 	Field             string     `json:"field" gorm:"primaryKey;type:varchar(255)"`
 	ValueBeforeParsed string     `json:"value_before"`
 	ValueAfterParsed  string     `json:"value_after"`
-	IterationIdFrom   uint64
-	IterationIdTo     uint64
+	IterationIdFrom   int64
+	IterationIdTo     int64
 	common.NoPKModel
 }
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Change iteration_id's type from uint64 to int64, because of this error:
```
Error running pipeline 21249. Wraps: (2) Error running task 23171. | Wraps: (2) subtask extractTasks ended unexpectedly | Wraps: (3) error calling plugin Extract implementation | Wraps: (4) json: cannot unmarshal number
-1 into Go struct field TapdTask.Task.iteration _id of type uint64 | Wraps: (5) json: cannot unmarshal number - 1 into Go struct field TapdTask. Task iteration_ id of type uint64 | Error types: (1) *hintdetail.withDetail (2)
*hintdetail.withDetail (3) *hintdetail.withDetail (4) *hintdetail.withDetail (5) *json.UnmarshalTypeError Error types:
(1) *hintdetail.withDetail (2) *errors.errorString
```
Here is TAPD API doc: https://o.tapd.cn/document/api-doc/API%E6%96%87%E6%A1%A3/api_reference/bug/get_bug_fields_info.html , but it doesn't explain what does -1 mean.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
