### PR TITLE
fix: gitextractor error out on empty bitbucket shallow clone

### DIFF
--- a/backend/plugins/gitextractor/parser/clone_gitcli.go
+++ b/backend/plugins/gitextractor/parser/clone_gitcli.go
@@ -196,7 +196,8 @@ func (g *GitcliCloner) execCloneCommand(cmd *exec.Cmd) errors.Error {
 	err = cmd.Wait()
 	if err != nil {
 		g.logger.Error(err, "git exited with error\n%s", combinedOutput.String())
-		if strings.Contains(combinedOutput.String(), "stderr: fatal: error processing shallow info: 4") {
+		if strings.Contains(combinedOutput.String(), "stderr: fatal: error processing shallow info: 4") ||
+			strings.Contains(combinedOutput.String(), "stderr: fatal: the remote end hung up unexpectedly") {
 			return ErrShallowInfoProcessing
 		}
 		return errors.Default.New("git exit error")


### PR DESCRIPTION
### Summary
It appears that bitbucket would hang up the connection directly when the shallow clone has no data to work with, this PR mitigates the problem by ignoring the error.


### Does this close any open issues?
Closes #7333

