### PR TITLE
fix: the parentIds in the first page of tapd remote scopes should be nil

### DIFF
--- a/backend/plugins/tapd/api/remote_api.go
+++ b/backend/plugins/tapd/api/remote_api.go
@@ -94,8 +94,12 @@ func listTapdRemoteScopes(
 		}
 	}
 	generateFullNames(root, "")
-	// select the current group
+	// failback to the root
 	if current == nil {
+		// the parentId in the first page is always nil
+		for _, child := range root.children {
+			child.entry.ParentId = nil
+		}
 		current = root
 	}
 	// sort children


### PR DESCRIPTION
### Summary
fix: the parentIds in the first page of tapd remote scopes should be nil


