### PR TITLE
Support human readable project name

### DIFF
--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -93,6 +93,8 @@ func CreateApiServer() *gin.Engine {
 func SetupApiServer(router *gin.Engine) {
 	// Set gin mode
 	gin.SetMode(basicRes.GetConfig("MODE"))
+	router.UseRawPath = true
+	// router.UnescapePathValues = false
 
 	// Endpoint to proceed database migration
 	router.GET("/proceed-db-migration", func(ctx *gin.Context) {

--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -93,8 +93,9 @@ func CreateApiServer() *gin.Engine {
 func SetupApiServer(router *gin.Engine) {
 	// Set gin mode
 	gin.SetMode(basicRes.GetConfig("MODE"))
+	// Required for `/projects/hello%20%2F%20world` to be parsed properly with `/projects/:projectName`
+	// end up with `name = "hello / world"`
 	router.UseRawPath = true
-	// router.UnescapePathValues = false
 
 	// Endpoint to proceed database migration
 	router.GET("/proceed-db-migration", func(ctx *gin.Context) {

--- a/backend/server/api/project/project.go
+++ b/backend/server/api/project/project.go
@@ -144,7 +144,7 @@ func PostProject(c *gin.Context) {
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /projects/:projectName [patch]
 func PatchProject(c *gin.Context) {
-	projectName := c.Param("projectName")[1:]
+	projectName := c.Param("projectName")
 
 	var body map[string]interface{}
 	err := c.ShouldBind(&body)
@@ -171,7 +171,7 @@ func PatchProject(c *gin.Context) {
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /projects/:projectName [delete]
 func DeleteProject(c *gin.Context) {
-	projectName := c.Param("projectName")[1:]
+	projectName := c.Param("projectName")
 	err := services.DeleteProject(projectName)
 	if err != nil {
 		shared.ApiOutputError(c, errors.Default.Wrap(err, "error deleting project"))

--- a/backend/server/api/router.go
+++ b/backend/server/api/router.go
@@ -72,8 +72,8 @@ func RegisterRouter(r *gin.Engine, basicRes context.BasicRes) {
 	// project api
 	r.GET("/projects/:projectName", project.GetProject)
 	r.GET("/projects/:projectName/check", project.GetProjectCheck)
-	r.PATCH("/projects/*projectName", project.PatchProject)
-	r.DELETE("/projects/*projectName", project.DeleteProject)
+	r.PATCH("/projects/:projectName", project.PatchProject)
+	r.DELETE("/projects/:projectName", project.DeleteProject)
 	r.POST("/projects", project.PostProject)
 	r.GET("/projects", project.GetProjects)
 	// on board api


### PR DESCRIPTION
### Summary

Apache DevLake does not support special characters in Project names properly, lets solve it once and for all.

The solution is simple: Whenever calling an API with `projectName` in the `path`, i.e. `GET /projects/:projectName`, it must be `encodeURIComponent`.

There are 4 API endpoints:
```
	r.GET("/projects/:projectName", project.GetProject)
	r.GET("/projects/:projectName/check", project.GetProjectCheck)
	r.PATCH("/projects/:projectName", project.PatchProject)
	r.DELETE("/projects/:projectName", project.DeleteProject)
```


### Does this close any open issues?
BE Part for #7217
related discussion: https://github.com/apache/incubator-devlake/commit/e9c25792fea4226a5f7d9b9e611e6b0062b1c7e0

### Screenshots

The `get detail` API
```
curl http://localhost:4000/api/projects/hello%20%2F%20world
{"name":"hello / world","description":"","createdAt":"2024-04-22T14:42:51.814+08:00","updatedAt":"2024-04-22T14:42:51.814+08:00","_raw_data_params":"","_raw_data_table":"","_raw_data_id":0,"_raw_data_remark":"","metrics":null,"blueprint":null}
```

The `check existing` API
```
curl http://localhost:4000/api/projects/hello%20%2F%20world/check
{"exist":true}
```


