### PR TITLE
fix: reference zentao instead of gitlab

### DIFF
--- a/backend/plugins/zentao/api/scope_api.go
+++ b/backend/plugins/zentao/api/scope_api.go
@@ -58,10 +58,10 @@ func PatchScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, erro
 	return dsHelper.ScopeApi.Patch(input)
 }
 
-// GetScopes get Gitlab projects
-// @Summary get Gitlab projects
-// @Description get Gitlab projects
-// @Tags plugins/gitlab
+// GetScopes get zentao scopes
+// @Summary get zentao scopes
+// @Description get zentao scopes
+// @Tags plugins/zentao
 // @Param connectionId path int false "connection ID"
 // @Param searchTerm query string false "search term for scope name"
 // @Param blueprints query bool false "also return blueprints using these scopes as part of the payload"


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Two path specifications are clashing, where one of them obviously belongs to another devlake plugin. This PR fixes the zentao plugin documentation. Seems to have originated in #5604.
