### PR TITLE
fix: should not throwing error on empty repo

### DIFF
--- a/backend/plugins/gitextractor/tasks/repo_cloner.go
+++ b/backend/plugins/gitextractor/tasks/repo_cloner.go
@@ -60,6 +60,9 @@ func CloneGitRepo(subTaskCtx plugin.SubTaskContext) errors.Error {
 			taskData.SkipAllSubtasks = true
 			return nil
 		}
+		if errors.Is(err, parser.ErrShallowInfoProcessing) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
### Summary

Gitextractor would throw an error on an empty repo which is likely to happen with the `--shallow-since` option.
This PR silently ignores the error to avoid confusing users.


### Does this close any open issues?
Closes #7370
