### PR TITLE
fix(zentao): update storyID field in tasks reponse, make it compatiab…

### DIFF
--- a/backend/core/models/common/string_int64.go
+++ b/backend/core/models/common/string_int64.go
@@ -1,0 +1,78 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cast"
+)
+
+type StringInt64 struct {
+	v int64
+}
+
+func NewStringInt64FromAny(f interface{}) *StringInt64 {
+	return &StringInt64{
+		v: cast.ToInt64(f),
+	}
+}
+
+func (f *StringInt64) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.v)
+}
+
+func (f *StringInt64) String() string {
+	return fmt.Sprintf("%v", f.v)
+}
+
+func (f *StringInt64) UnmarshalJSON(data []byte) error {
+	var i interface{}
+	if err := json.Unmarshal(data, &i); err != nil {
+		return err
+	}
+	if v, ok := i.(string); ok && v == "" {
+		return nil
+	}
+	value, err := cast.ToInt64E(i)
+	if err != nil {
+		return err
+	}
+	f.v = value
+	return nil
+}
+
+func (f *StringInt64) Value() (driver.Value, error) {
+	if f == nil {
+		return nil, nil
+	}
+	return f.v, nil
+}
+
+func (f *StringInt64) Scan(v interface{}) error {
+	int64value, err := cast.ToInt64E(v)
+	if err != nil {
+		return err
+
+	}
+	*f = StringInt64{
+		v: int64value,
+	}
+	return nil
+}

--- a/backend/helpers/pluginhelper/api/graphql_collector.go
+++ b/backend/helpers/pluginhelper/api/graphql_collector.go
@@ -90,7 +90,7 @@ type GraphqlCollector struct {
 	workerErrors []error
 }
 
-// ErrFinishCollect is a error which will finish this collector
+// ErrFinishCollect is an error which will finish this collector
 var ErrFinishCollect = errors.Default.New("finish collect")
 
 // NewGraphqlCollector allocates a new GraphqlCollector with the given args.

--- a/backend/plugins/zentao/models/task.go
+++ b/backend/plugins/zentao/models/task.go
@@ -75,7 +75,7 @@ type ZentaoTaskRes struct {
 	V1             string              `json:"v1"`
 	V2             string              `json:"v2"`
 	Vision         string              `json:"vision"`
-	StoryID        int64               `json:"storyID"`
+	StoryID        *common.StringInt64 `json:"storyID"`
 	StoryTitle     string              `json:"storyTitle"`
 	Branch         interface {
 	} `json:"branch"`


### PR DESCRIPTION
…le with oss 18.11

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
In Zentao OOS 18.11, `storyID` field's type is string, we try to make our plugin compatiable with it.

Therotically, we can use `json.Number`, but it will return an error if `storyID` is an empty string:
```
json: invalid number literal, trying to unmarshal "\"\"" into Number
```

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.
<img width="1266" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/d677c00a-4e21-401e-97b9-b1ff3fcffc2b">

<img width="170" alt="image" src="https://github.com/apache/incubator-devlake/assets/5844806/2670ba20-bc12-466e-b183-6a89cb249821">

### Other Information
Any other information that is important to this PR.
