### PR TITLE
fix: unable to get project detail when name ends with /

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -18,14 +18,13 @@ ${SERVER_CONF}
     try_files $uri /index.html;
   }
 
-  location /api/ {
+  location ^~/api/ {
     resolver ${DNS} valid=${DNS_VALID};
     resolver_timeout 3s;
     set $target "${DEVLAKE_ENDPOINT}";
-    rewrite /api/(.*) /$1  break;
     proxy_send_timeout 60s;
     proxy_read_timeout 60s;
-    proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target;
+    proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target/;
     proxy_http_version 1.1;
     proxy_set_header   "Connection" "";
   }


### PR DESCRIPTION
### Summary

Fixes the problem of `curl http://localhost:4000/api/projects/hello%2F` receiving a `301` status code

