### PR TITLE
fix: jenkins jobs are mislabeled as production deployments

### DIFF
--- a/backend/plugins/jenkins/tasks/build_cicd_convertor.go
+++ b/backend/plugins/jenkins/tasks/build_cicd_convertor.go
@@ -155,6 +155,10 @@ func ConvertBuildsToCicdTasks(taskCtx plugin.SubTaskContext) (err errors.Error) 
 					Environment: data.RegexEnricher.ReturnNameIfOmittedOrMatched(devops.PRODUCTION, jenkinsBuild.FullName),
 					PipelineId:  buildIdGen.Generate(jenkinsBuild.ConnectionId, jenkinsBuild.FullName),
 				}
+				// if the task is not executed, set the result to default, so that it will not be calculated in the dora
+				if jenkinsTask.OriginalStatus == "NOT_EXECUTED" {
+					jenkinsTask.Result = devops.RESULT_DEFAULT
+				}
 				results = append(results, jenkinsTask)
 
 			}

--- a/backend/plugins/jenkins/tasks/stage_convertor.go
+++ b/backend/plugins/jenkins/tasks/stage_convertor.go
@@ -155,6 +155,10 @@ func ConvertStages(taskCtx plugin.SubTaskContext) (err errors.Error) {
 				Type:           data.RegexEnricher.ReturnNameIfMatched(devops.DEPLOYMENT, body.Name),
 				Environment:    data.RegexEnricher.ReturnNameIfOmittedOrMatched(devops.PRODUCTION, body.Name),
 			}
+			// if the task is not executed, set the result to default, so that it will not be calculated in the dora
+			if jenkinsTask.OriginalStatus == "NOT_EXECUTED" {
+				jenkinsTask.Result = devops.RESULT_DEFAULT
+			}
 			results = append(results, jenkinsTask)
 			return results, nil
 		},


### PR DESCRIPTION
### Summary
fix: jenkins jobs are mislabeled as production deployments when they are skipped

### Does this close any open issues?
Closes #7097 

### Screenshots
previous:
![img_v3_02am_84c01119-a47b-48b0-bfc7-61ae7ded9edg](https://github.com/apache/incubator-devlake/assets/101256042/6c1d4f23-df32-4cae-ac56-a063325eac36)

now:
![img_v3_02am_02747e2f-d8c8-42de-b4d2-56b6147e1b4g](https://github.com/apache/incubator-devlake/assets/101256042/433be477-62b8-40fc-a208-defac6573bb5)


### Other Information
Any other information that is important to this PR.
