### PR TITLE
fix: nginx api proxy path should not be decoded

### DIFF
--- a/config-ui/nginx.conf
+++ b/config-ui/nginx.conf
@@ -18,13 +18,16 @@ ${SERVER_CONF}
     try_files $uri /index.html;
   }
 
-  location ^~/api/ {
+  location /api/ {
     resolver ${DNS} valid=${DNS_VALID};
     resolver_timeout 3s;
     set $target "${DEVLAKE_ENDPOINT}";
+    rewrite ^ $request_uri;
+    rewrite ^/api/(.*) $1 break;
+    return 400;
     proxy_send_timeout 60s;
     proxy_read_timeout 60s;
-    proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target/;
+    proxy_pass ${DEVLAKE_ENDPOINT_PROTO}://$target/$uri;
     proxy_http_version 1.1;
     proxy_set_header   "Connection" "";
   }


### PR DESCRIPTION
### Summary

Fixes incorrect nginx configuration


### Screenshots

![img_v3_02am_67e9e836-a8c3-4d85-b6b5-e54a06d256dg](https://github.com/apache/incubator-devlake/assets/61080/b75864e2-9803-4c72-a9df-60429fb89057)


