### PR TITLE
fix: incorrect LOC of the first commit in a given time range

### DIFF
--- a/backend/plugins/gitextractor/gitextractor.go
+++ b/backend/plugins/gitextractor/gitextractor.go
@@ -36,7 +36,7 @@ func main() {
 	// pkPass := cmd.Flags().StringP("privateKeyPassPhrase", "P", "", "passphrase for private key")
 	proxy := cmd.Flags().StringP("proxy", "x", "", "proxy")
 	useGoGit := cmd.Flags().BoolP("useGoGit", "g", false, "use go-git instead of libgit2")
-	skipCommitStat := cmd.Flags().BoolP("skipCommitStat", "S", true, "")
+	skipCommitStat := cmd.Flags().BoolP("skipCommitStat", "S", false, "")
 	skipCommitFiles := cmd.Flags().BoolP("skipCommitFiles", "F", true, "")
 	timeAfter := cmd.Flags().StringP("timeAfter", "a", "", "collect data that are created after specified time, ie 2006-01-02T15:04:05Z")
 	_ = cmd.MarkFlagRequired("url")

--- a/backend/plugins/gitextractor/parser/clone_gitcli.go
+++ b/backend/plugins/gitextractor/parser/clone_gitcli.go
@@ -90,6 +90,13 @@ func (g *GitcliCloner) CloneRepo(ctx plugin.SubTaskContext, localDir string) err
 		}
 		return err
 	}
+	// deepen the commits by 1 more step to avoid https://github.com/apache/incubator-devlake/issues/7426
+	if since != nil {
+		cmd := exec.CommandContext(ctx.GetContext(), "git", "-C", localDir, "fetch", "--deepen=1")
+		if err := cmd.Run(); err != nil {
+			return errors.Default.Wrap(err, "failed to deepen the cloned repo")
+		}
+	}
 
 	// save state
 	if g.stateManager != nil {


### PR DESCRIPTION
### Summary
fix: incorrect LOC of the first commit in a given time range

### Does this close any open issues?
Closes #7426

### Screenshots

Before
<img width="408" alt="PixPin_2024-05-11_16-11-49" src="https://github.com/apache/incubator-devlake/assets/61080/63470f39-f400-4f53-9fc9-d5de8dd80dda">


After
<img width="545" alt="PixPin_2024-05-11_16-19-53" src="https://github.com/apache/incubator-devlake/assets/61080/3ee311e1-a22a-42ad-9d03-0e77457c9e0c">
