### PR TITLE
fix: trigger tapd collect throws 500 error

### DIFF
--- a/backend/plugins/tapd/api/blueprint_v200.go
+++ b/backend/plugins/tapd/api/blueprint_v200.go
@@ -98,7 +98,7 @@ func makeScopesV200(
 
 		// add wrokspace to scopes
 		if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_TICKET) {
-			id := idgen.Generate(connection.ID, tapdWorkspace)
+			id := idgen.Generate(connection.ID, tapdWorkspace.Id)
 			board := ticket.NewBoard(id, tapdWorkspace.Name)
 			board.Type = "scrum"
 			scopes = append(scopes, board)


### PR DESCRIPTION
### Summary

Fixes the following error:
```
[GIN] 2024/05/23 - 07:56:46 | 500 |   10.923852ms |       10.42.0.9 | POST     "/blueprints/9/trigger"


2024/05/23 07:56:46 [Recovery] 2024/05/23 - 07:56:46 panic recovered:
POST /blueprints/9/trigger HTTP/1.1
Host: devlake-lake.default.svc.cluster.local:8080
Accept: application/json, text/plain, */*
Accept-Encoding: gzip, deflate
Accept-Language: en-US,en;q=0.9,zh-CN;q=0.8,zh;q=0.7
Content-Length: 41
Content-Type: application/json
Origin: http://172.27.90.118:32001
Referer: http://172.27.90.118:32001/projects/TAPD?tab=configuration
User-Agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36


primary key type does not match: Id is TapdWorkspace type, and it should be uint64 type
/app/core/models/domainlayer/didgen/domain_id_generator.go:82 (0x7fa1f48aa947)
/app/plugins/tapd/api/blueprint_v200.go:101 (0x7fa1f48ddf04)
/app/plugins/tapd/api/blueprint_v200.go:50 (0x7fa1f48dd94a)
/app/plugins/tapd/impl/impl.go:251 (0x7fa1f4911e66)
/app/server/services/blueprint_makeplan_v200.go:56 (0x15bc7ba)
/app/server/services/blueprint.go:366 (0x15bc1be)
/app/server/services/blueprint.go:306 (0x15bba64)
/app/server/services/blueprint.go:415 (0x15bc426)
/app/server/api/blueprints/blueprints.go:192 (0x15d2bf2)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x15d8262)
/app/server/api/middlewares.go:95 (0x15d8246)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x15d8707)
/app/server/api/middlewares.go:117 (0x15d85a2)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x1232ac1)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 (0x1232aac)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x1231be6)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/logger.go:240 (0x1231bc9)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 (0x1230a6a)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 (0x12306f1)
/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 (0x123021c)
/usr/local/go/src/net/http/server.go:2936 (0xccd095)
/usr/local/go/src/net/http/server.go:1995 (0xcc8231)
/usr/local/go/src/runtime/asm_amd64.s:1598 (0x9b7ac0)
```


