### PR TITLE
fix(zentao): use correct `DecodeMapStruct` function

### DIFF
--- a/backend/helpers/pluginhelper/api/model_api_helper.go
+++ b/backend/helpers/pluginhelper/api/model_api_helper.go
@@ -65,7 +65,7 @@ func NewModelApiHelper[M dal.Tabler](
 
 func (self *ModelApiHelper[M]) Post(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
 	model := new(M)
-	err := utils.DecodeMapStruct(input.Body, model, false)
+	err := DecodeMapStruct(input.Body, model, false)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +145,7 @@ func (self *ModelApiHelper[M]) PatchModel(input *plugin.ApiResourceInput, zeroFi
 			return nil, err
 		}
 	} else {
-		err = utils.DecodeMapStruct(input.Body, model, zeroFields)
+		err = DecodeMapStruct(input.Body, model, zeroFields)
 		if err != nil {
 			return nil, errors.BadInput.Wrap(err, fmt.Sprintf("faled to patch %s", self.modelName))
 		}
@@ -194,7 +194,7 @@ func (self *ModelApiHelper[M]) PutMultipleCb(input *plugin.ApiResourceInput, bef
 	var req struct {
 		Data []*M `json:"data"`
 	}
-	err := utils.DecodeMapStruct(input.Body, &req, false)
+	err := DecodeMapStruct(input.Body, &req, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?

Fix errors when adding a scope in zentao connection.
errors are like:
```
"1 error(s) decoding:\n  |\n  | * 'Data[0].progress' expected a map, got 'float64'\nWraps: (2) 1 error(s) decoding:\n  |\n  | * 'Data[0].progress' expected a map, got 'float64'\nError types: (1) *hintdetail.withDetail (2) *mapstructure.Error"
```

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

![image](https://github.com/apache/incubator-devlake/assets/5844806/9ba3c62b-ed20-41bf-a734-fe36ee65a1c1)


### Other Information
Any other information that is important to this PR.
