### PR TITLE
Tidy up Webhook APIs

### DIFF
--- a/backend/plugins/webhook/api/deployments.go
+++ b/backend/plugins/webhook/api/deployments.go
@@ -39,18 +39,18 @@ import (
 )
 
 type WebhookDeploymentReq struct {
-	Id           string `mapstructure:"id"`
+	Id           string `mapstructure:"id" validate:"required"`
 	DisplayTitle string `mapstructure:"displayTitle"`
-	PipelineId   string `mapstructure:"pipelineId" validate:"required"`
+	PipelineId   string `mapstructure:"pipelineId"`
 	Result       string `mapstructure:"result"`
 	Environment  string `validate:"omitempty,oneof=PRODUCTION STAGING TESTING DEVELOPMENT"`
 	Name         string `mapstructure:"name"`
 	// DeploymentCommits is used for multiple commits in one deployment
 	DeploymentCommits []WebhookDeploymentCommitReq `mapstructure:"deploymentCommits" validate:"omitempty,dive"`
-	CreatedDate       *time.Time                   `mapstructure:"createdTime"`
+	CreatedDate       *time.Time                   `mapstructure:"createdDate"`
 	// QueuedDate   *time.Time `mapstructure:"queue_time"`
-	StartedDate  *time.Time `mapstructure:"startedTime" validate:"required"`
-	FinishedDate *time.Time `mapstructure:"endedTime"`
+	StartedDate  *time.Time `mapstructure:"startedDate" validate:"required"`
+	FinishedDate *time.Time `mapstructure:"finishedDate"`
 }
 
 type WebhookDeploymentCommitReq struct {
@@ -63,10 +63,10 @@ type WebhookDeploymentCommitReq struct {
 	CommitMsg    string     `mapstructure:"commitMsg"`
 	Result       string     `mapstructure:"result"`
 	Status       string     `mapstructure:"status"`
-	CreatedDate  *time.Time `mapstructure:"createdTime"`
+	CreatedDate  *time.Time `mapstructure:"createdDate"`
 	// QueuedDate   *time.Time `mapstructure:"queue_time"`
-	StartedDate  *time.Time `mapstructure:"startedTime"`
-	FinishedDate *time.Time `mapstructure:"endedTime"`
+	StartedDate  *time.Time `mapstructure:"startedDate" validate:"required"`
+	FinishedDate *time.Time `mapstructure:"finishedDate"`
 }
 
 // PostDeployments
@@ -121,9 +121,6 @@ func CreateDeploymentAndDeploymentCommits(connection *models.WebhookConnection, 
 	}
 	// set default values for optional fields
 	deploymentId := request.Id
-	if deploymentId == "" {
-		deploymentId = request.PipelineId
-	}
 	scopeId := fmt.Sprintf("%s:%d", "webhook", connection.ID)
 	if request.CreatedDate == nil {
 		request.CreatedDate = request.StartedDate

--- a/backend/plugins/webhook/api/deployments.go
+++ b/backend/plugins/webhook/api/deployments.go
@@ -41,7 +41,6 @@ import (
 type WebhookDeploymentReq struct {
 	Id           string `mapstructure:"id" validate:"required"`
 	DisplayTitle string `mapstructure:"displayTitle"`
-	PipelineId   string `mapstructure:"pipelineId"`
 	Result       string `mapstructure:"result"`
 	Environment  string `validate:"omitempty,oneof=PRODUCTION STAGING TESTING DEVELOPMENT"`
 	Name         string `mapstructure:"name"`

--- a/backend/plugins/webhook/api/issues.go
+++ b/backend/plugins/webhook/api/issues.go
@@ -35,27 +35,27 @@ import (
 
 type WebhookIssueRequest struct {
 	Url                     string     `mapstructure:"url"`
-	IssueKey                string     `mapstructure:"issue_key" validate:"required"`
+	IssueKey                string     `mapstructure:"issueKey" validate:"required"`
 	Title                   string     `mapstructure:"title" validate:"required"`
 	Description             string     `mapstructure:"description"`
-	EpicKey                 string     `mapstructure:"epic_key"`
+	EpicKey                 string     `mapstructure:"epicKey"`
 	Type                    string     `mapstructure:"type"`
 	Status                  string     `mapstructure:"status" validate:"oneof=TODO DONE IN_PROGRESS"`
-	OriginalStatus          string     `mapstructure:"original_status" validate:"required"`
-	StoryPoint              float64    `mapstructure:"story_point"`
-	ResolutionDate          *time.Time `mapstructure:"resolution_date"`
-	CreatedDate             *time.Time `mapstructure:"created_date" validate:"required"`
-	UpdatedDate             *time.Time `mapstructure:"updated_date"`
-	LeadTimeMinutes         uint       `mapstructure:"lead_time_minutes"`
-	ParentIssueKey          string     `mapstructure:"parent_issue_key"`
+	OriginalStatus          string     `mapstructure:"originalStatus" validate:"required"`
+	StoryPoint              float64    `mapstructure:"storyPoint"`
+	ResolutionDate          *time.Time `mapstructure:"resolutionDate"`
+	CreatedDate             *time.Time `mapstructure:"createdDate" validate:"required"`
+	UpdatedDate             *time.Time `mapstructure:"updatedDate"`
+	LeadTimeMinutes         uint       `mapstructure:"leadTimeMinutes"`
+	ParentIssueKey          string     `mapstructure:"parentIssueKey"`
 	Priority                string     `mapstructure:"priority"`
-	OriginalEstimateMinutes int64      `mapstructure:"original_estimate_minutes"`
-	TimeSpentMinutes        int64      `mapstructure:"time_spent_minutes"`
-	TimeRemainingMinutes    int64      `mapstructure:"time_remaining_minutes"`
-	CreatorId               string     `mapstructure:"creator_id"`
-	CreatorName             string     `mapstructure:"creator_name"`
-	AssigneeId              string     `mapstructure:"assignee_id"`
-	AssigneeName            string     `mapstructure:"assignee_name"`
+	OriginalEstimateMinutes int64      `mapstructure:"originalEstimateMinutes"`
+	TimeSpentMinutes        int64      `mapstructure:"timeSpentMinutes"`
+	TimeRemainingMinutes    int64      `mapstructure:"timeRemainingMinutes"`
+	CreatorId               string     `mapstructure:"creatorId"`
+	CreatorName             string     `mapstructure:"creatorName"`
+	AssigneeId              string     `mapstructure:"assigneeId"`
+	AssigneeName            string     `mapstructure:"assigneeName"`
 	Severity                string     `mapstructure:"severity"`
 	Component               string     `mapstructure:"component"`
 	//IconURL               string


### PR DESCRIPTION
### Summary
Fine-grain #7545 according to the discussion with @Startrekzky 

1. Change field names of Webhook Issues API request body to camelCase
2. Webhook Deployment API:
   - Removed `pipelineId` and use `id` as the replacement
   - Renamed `createdTime` to `createdDate`, `startedTime` to `startedDate` and `endedTime` to `finishedDate` to align with the DB schema