### PR TITLE
fix: bitbucket remote api swallows errors sliently

### DIFF
--- a/backend/plugins/bitbucket/api/remote_api.go
+++ b/backend/plugins/bitbucket/api/remote_api.go
@@ -19,6 +19,7 @@ package api
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -115,6 +116,13 @@ func listBitbucketRepos(
 	}, nil)
 	if err != nil {
 		return
+	}
+	if res.StatusCode > 299 {
+		body, e := io.ReadAll(res.Body)
+		if e != nil {
+			return nil, nil, errors.BadInput.Wrap(e, "failed to read response body")
+		}
+		return nil, nil, errors.BadInput.New(string(body))
 	}
 	var resBody models.ReposResponse
 	err = api.UnmarshalResponse(res, &resBody)


### PR DESCRIPTION
The `remote api` ignores errors returned by Bitbucket API and outputs an empty `children` in the response which is really bad.

This  PR fixes the problem, now users should be able to see what went wrong:

![image](https://github.com/apache/incubator-devlake/assets/61080/d034a549-3413-4b22-88c6-96f362e883ed)
