### PR TITLE
fix: pagerduty scope api listing service without related projects

### DIFF
--- a/backend/plugins/pagerduty/models/service.go
+++ b/backend/plugins/pagerduty/models/service.go
@@ -35,7 +35,7 @@ type Service struct {
 }
 
 func (s Service) ScopeId() string {
-	return s.Name
+	return s.Id
 }
 
 func (s Service) ScopeName() string {


### PR DESCRIPTION
### Summary

Phenomenon: services under connection detail always show no related projects

### Screenshots
![image](https://github.com/apache/incubator-devlake/assets/61080/1dab4b32-88b8-4e56-9a1f-2326775b5045)

