### PR TITLE
fix(framework): sanitize gitextractor plugin options correctly

### DIFF
--- a/backend/server/services/project.go
+++ b/backend/server/services/project.go
@@ -416,8 +416,10 @@ func makeProjectOutput(project *models.Project, withLastPipeline bool) (*models.
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "Error to get blueprint by project")
 	}
-	if err := SanitizeBlueprint(projectOutput.Blueprint); err != nil {
-		return nil, errors.Convert(err)
+	if projectOutput.Blueprint != nil {
+		if err := SanitizeBlueprint(projectOutput.Blueprint); err != nil {
+			return nil, errors.Convert(err)
+		}
 	}
 	if withLastPipeline {
 		if projectOutput.Blueprint == nil {

--- a/backend/server/services/project.go
+++ b/backend/server/services/project.go
@@ -416,6 +416,9 @@ func makeProjectOutput(project *models.Project, withLastPipeline bool) (*models.
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "Error to get blueprint by project")
 	}
+	if err := SanitizeBlueprint(projectOutput.Blueprint); err != nil {
+		return nil, errors.Convert(err)
+	}
 	if withLastPipeline {
 		if projectOutput.Blueprint == nil {
 			logger.Warn(fmt.Errorf("blueprint is nil"), "want to get latest pipeline, but blueprint is nil")


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?

### Does this close any open issues?
Closes #7597

### Screenshots
Include any relevant screenshots here.
#### Get a project detail
![image](https://github.com/apache/incubator-devlake/assets/5844806/82eb5b36-caf7-41a1-9fc2-77472e931e34)

#### Get a blueprint detail
![image](https://github.com/apache/incubator-devlake/assets/5844806/fc505403-1154-4e2f-b0b3-85de031e104a)

#### Trigger a blueprint
![image](https://github.com/apache/incubator-devlake/assets/5844806/caab804c-1721-4b14-ad68-78e4911b3e0b)

#### List all projects
![image](https://github.com/apache/incubator-devlake/assets/5844806/0a741d4d-4777-4526-a210-1dc5e9f575f4)

### Other Information
Any other information that is important to this PR.
