### PR TITLE
fix(migration): fix unexpected `defer unlock`

### DIFF
--- a/backend/server/services/init.go
+++ b/backend/server/services/init.go
@@ -123,11 +123,12 @@ var statusLock sync.Mutex
 // This might be called concurrently across multiple API requests
 func ExecuteMigration() errors.Error {
 	statusLock.Lock()
-	defer statusLock.Unlock()
 	if serviceStatus == SERVICE_STATUS_MIGRATING {
+		statusLock.Unlock()
 		return errors.BadInput.New("already migrating")
 	}
 	if serviceStatus == SERVICE_STATUS_READY {
+		statusLock.Unlock()
 		return nil
 	}
 	serviceStatus = SERVICE_STATUS_MIGRATING
@@ -146,6 +147,7 @@ func ExecuteMigration() errors.Error {
 	pipelineServiceInit()
 	statusLock.Lock()
 	serviceStatus = SERVICE_STATUS_READY
+	statusLock.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
If  err from `err := migrator.Execute()` is  not nil, it will panic with `fatal error: sync: unlock of unlocked mutex`.
This PR just fix it, and panic with the correct error.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
