### PR TITLE
fix(migrator): save migration script before executing it

### DIFF
--- a/backend/core/migration/migrator.go
+++ b/backend/core/migration/migrator.go
@@ -98,7 +98,7 @@ func (m *migratorImpl) Execute() errors.Error {
 		scriptId := getScriptId(swc.script.Name(), swc.script.Version())
 		m.logger.Info("applying migration script %s", scriptId)
 		tx := db.Begin()
-		err := db.Create(&MigrationHistory{
+		err := tx.Create(&MigrationHistory{
 			ScriptVersion: swc.script.Version(),
 			ScriptName:    swc.script.Name(),
 			Comment:       swc.comment,

--- a/backend/server/services/init.go
+++ b/backend/server/services/init.go
@@ -96,7 +96,7 @@ func registerPluginsMigrationScripts() {
 
 func InitExecuteMigration() {
 	// check if there are pending migration
-	logger.Info("has pending scripts? %v, FORCE_MIGRATION: %s", migrator.HasPendingScripts(), cfg.GetBool("FORCE_MIGRATION"))
+	logger.Info("has pending scripts? %v, FORCE_MIGRATION: %v", migrator.HasPendingScripts(), cfg.GetBool("FORCE_MIGRATION"))
 	if migrator.HasPendingScripts() {
 		if cfg.GetBool("FORCE_MIGRATION") {
 			errors.Must(ExecuteMigration())


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Save migration script before executing it

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
