### PR TITLE
fix(zentao): make sure close_date must be before opened_date

### DIFF
--- a/backend/plugins/zentao/tasks/bug_convertor.go
+++ b/backend/plugins/zentao/tasks/bug_convertor.go
@@ -105,8 +105,10 @@ func ConvertBug(taskCtx plugin.SubTaskContext) errors.Error {
 			if toolEntity.AssignedToId != 0 {
 				domainEntity.AssigneeId = accountIdGen.Generate(data.Options.ConnectionId, toolEntity.AssignedToId)
 			}
-			if toolEntity.ClosedDate != nil {
-				temp := uint(toolEntity.ClosedDate.ToNullableTime().Sub(toolEntity.OpenedDate.ToTime()).Minutes())
+			closedDate := toolEntity.ClosedDate
+			openedDate := toolEntity.OpenedDate
+			if closedDate != nil && closedDate.ToTime().After(openedDate.ToTime()) {
+				temp := uint(closedDate.ToNullableTime().Sub(openedDate.ToTime()).Minutes())
 				domainEntity.LeadTimeMinutes = &temp
 			}
 			var results []interface{}

--- a/backend/plugins/zentao/tasks/story_convertor.go
+++ b/backend/plugins/zentao/tasks/story_convertor.go
@@ -117,8 +117,10 @@ func ConvertStory(taskCtx plugin.SubTaskContext) errors.Error {
 				results = append(results, issueAssignee)
 			}
 
-			if toolEntity.ClosedDate != nil {
-				temp := uint(toolEntity.ClosedDate.ToNullableTime().Sub(toolEntity.OpenedDate.ToTime()).Minutes())
+			closedDate := toolEntity.ClosedDate
+			openedDate := toolEntity.OpenedDate
+			if closedDate != nil && closedDate.ToTime().After(openedDate.ToTime()) {
+				temp := uint(closedDate.ToNullableTime().Sub(openedDate.ToTime()).Minutes())
 				domainEntity.LeadTimeMinutes = &temp
 			}
 

--- a/backend/plugins/zentao/tasks/task_convertor.go
+++ b/backend/plugins/zentao/tasks/task_convertor.go
@@ -108,8 +108,10 @@ func ConvertTask(taskCtx plugin.SubTaskContext) errors.Error {
 			if toolEntity.AssignedToId != 0 {
 				domainEntity.AssigneeId = accountIdGen.Generate(data.Options.ConnectionId, toolEntity.AssignedToId)
 			}
-			if toolEntity.ClosedDate != nil {
-				temp := uint(toolEntity.ClosedDate.ToNullableTime().Sub(toolEntity.OpenedDate.ToTime()).Minutes())
+			closedDate := toolEntity.ClosedDate
+			openedDate := toolEntity.OpenedDate
+			if closedDate != nil && closedDate.ToTime().After(openedDate.ToTime()) {
+				temp := uint(closedDate.ToNullableTime().Sub(openedDate.ToTime()).Minutes())
 				domainEntity.LeadTimeMinutes = &temp
 			}
 			var results []interface{}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
We found some data in zentao is unexpected,  its closed_date is before opened_data, just like:
![image](https://github.com/apache/incubator-devlake/assets/5844806/e418878e-86b2-408c-8c0e-e128464d98a7)
This PR just makes sure `close_date` must be before `opened_date`.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
