### PR TITLE
fix(jira): fix account id when there is no from/to values

### DIFF
--- a/backend/plugins/jira/tasks/issue_changelog_convertor.go
+++ b/backend/plugins/jira/tasks/issue_changelog_convertor.go
@@ -159,33 +159,13 @@ func ConvertIssueChangelogs(subtaskCtx plugin.SubTaskContext) errors.Error {
 					changelog.ToValue = getStdStatus(toStatus.StatusCategory)
 				}
 			default:
-				// process other account-like fields, it works on jira9 and jira cloud.
-				if row.TmpFromAccountId != "" {
-					if row.FromValue != "" {
-						changelog.OriginalFromValue = accountIdGen.Generate(connectionId, row.FromValue)
-					} else {
-						changelog.OriginalFromValue = accountIdGen.Generate(connectionId, row.TmpFromAccountId)
-					}
+				fromAccountId := tryToResolveAccountIdFromAccountLikeField(row.Field, row.TmpFromAccountId, row.FromValue, issueFieldMap)
+				if fromAccountId != "" {
+					changelog.OriginalFromValue = accountIdGen.Generate(connectionId, fromAccountId)
 				}
-				if row.TmpToAccountId != "" {
-					if row.ToValue != "" {
-						changelog.OriginalToValue = accountIdGen.Generate(connectionId, row.ToValue)
-					} else {
-						changelog.OriginalToValue = accountIdGen.Generate(connectionId, row.TmpToAccountId)
-					}
-				}
-				if row.TmpFromAccountId == "" && row.TmpToAccountId == "" {
-					// it works on jira8
-					// notice: field name is not unique, but we cannot fetch field id here.
-					if v, ok := issueFieldMap[row.Field]; ok && v.SchemaType == "user" {
-						// field type is account
-						if row.FromValue != "" {
-							changelog.OriginalFromValue = accountIdGen.Generate(connectionId, row.FromValue)
-						}
-						if row.ToValue != "" {
-							changelog.OriginalToValue = accountIdGen.Generate(connectionId, row.ToValue)
-						}
-					}
+				toAccountId := tryToResolveAccountIdFromAccountLikeField(row.Field, row.TmpFromAccountId, row.FromValue, issueFieldMap)
+				if toAccountId != "" {
+					changelog.OriginalToValue = accountIdGen.Generate(connectionId, toAccountId)
 				}
 			}
 
@@ -199,6 +179,25 @@ func ConvertIssueChangelogs(subtaskCtx plugin.SubTaskContext) errors.Error {
 	}
 
 	return converter.Execute()
+}
+
+func tryToResolveAccountIdFromAccountLikeField(fieldName string, tmpAccountId string, fromOrToValue string, issueFieldMap map[string]models.JiraIssueField) string {
+	if tmpAccountId != "" {
+		// process other account-like fields, it works on jira9 and jira cloud.
+		if fromOrToValue != "" {
+			return fromOrToValue
+		} else {
+			return tmpAccountId
+		}
+	} else {
+		// it works on jira8
+		// notice: field name is not unique, but we cannot fetch field id here.
+		if v, ok := issueFieldMap[fieldName]; ok && v.SchemaType == "user" {
+			// field type is account
+			return fromOrToValue
+		}
+	}
+	return ""
 }
 
 func convertIds(ids string, connectionId uint64, sprintIdGenerator *didgen.DomainIdGenerator) (string, errors.Error) {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
When account like fields such as "owner"  is set first time in Jira Cloud, there is no `tmpFromAccountId`, but a `tmpToAccountId`. `convertIssueChangelogs` can handle it correctly now.

### Does this close any open issues?
Related #7708

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
