### PR TITLE
fix(gitlab): register `ConvertIssueAssigneeMeta`

### DIFF
--- a/backend/plugins/gitlab/tasks/issue_assignee_convertor.go
+++ b/backend/plugins/gitlab/tasks/issue_assignee_convertor.go
@@ -29,12 +29,18 @@ import (
 	"github.com/apache/incubator-devlake/plugins/gitlab/models"
 )
 
+func init() {
+	RegisterSubtaskMeta(&ConvertIssueAssigneeMeta)
+}
+
 var ConvertIssueAssigneeMeta = plugin.SubTaskMeta{
 	Name:             "convert Issue Assignees",
 	EntryPoint:       ConvertIssueAssignee,
 	EnabledByDefault: true,
 	Description:      "Convert tool layer table _tool_gitlab_issue_assignees into  domain layer table issue_assignees",
 	DomainTypes:      []string{plugin.DOMAIN_TYPE_TICKET},
+	DependencyTables: []string{models.GitlabIssueAssignee{}.TableName()},
+	Dependencies:     []*plugin.SubTaskMeta{&ExtractApiIssuesMeta},
 }
 
 func ConvertIssueAssignee(taskCtx plugin.SubTaskContext) errors.Error {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Register task `ConvertIssueAssigneeMeta`, make sure `issue_assignees` has enough data in GitLab plugin.

### Does this close any open issues?
Related #7652 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
