### PR TITLE
fix(helpers): use `isIncremental`  instead of `SyncPolicy.FullSync`

### DIFF
--- a/backend/helpers/pluginhelper/api/api_collector_stateful.go
+++ b/backend/helpers/pluginhelper/api/api_collector_stateful.go
@@ -190,8 +190,7 @@ func NewStatefulApiCollectorForFinalizableEntity(args FinalizableApiCollectorArg
 		return nil, err
 	}
 
-	syncPolicy := args.Ctx.TaskContext().SyncPolicy()
-	if args.CollectUnfinishedDetails == nil || (syncPolicy != nil && syncPolicy.FullSync) {
+	if args.CollectUnfinishedDetails == nil || !isIncremental {
 		return manager, nil
 	}
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Use `isIncremental` instead of `SyncPolicy.FullSync`.

Var `syncPolicy` in code ` := args.Ctx.TaskContext().SyncPolicy()` comes from `_devlake_pipelines`.
When we collect data, then change its time range, set an early start time, collect data again. It should collect data fully, but `_devlake_pipelines.full_sync` is zero, which stands for false. So in `NewStatefulApiCollectorForFinalizableEntity` we should use `isIncremental`.

### Does this close any open issues?
Closes #7772 #7766. 
Maybe related #7739.

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
