### PR TITLE
fix(webhook): rollback database when webhook's name is same

### DIFF
--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -44,6 +44,9 @@ func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 	tx := basicRes.GetDal().Begin()
 	err := connectionHelper.CreateWithTx(tx, connection, input)
 	if err != nil {
+		if err := tx.Rollback(); err != nil {
+			logger.Error(err, "transaction Rollback")
+		}
 		return nil, err
 	}
 	logger.Info("connection: %+v", connection)

--- a/backend/plugins/webhook/api/connection.go
+++ b/backend/plugins/webhook/api/connection.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -46,6 +47,9 @@ func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput,
 	if err != nil {
 		if err := tx.Rollback(); err != nil {
 			logger.Error(err, "transaction Rollback")
+		}
+		if strings.Contains(err.Error(), "the connection name already exists (400)") {
+			return nil, errors.BadInput.New(fmt.Sprintf("A webhook with name %s already exists.", connection.Name))
 		}
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Rollback database transaction when webhook's name is same.

### Does this close any open issues?
Closes N/A.

### Screenshots
Include any relevant screenshots here.
![image](https://github.com/user-attachments/assets/d4365d02-5b5b-4984-b9a7-1a471b86bbf8)


### Other Information
Any other information that is important to this PR.
