### PR TITLE
fix: prevent updates to provisioned dashboards to avoid overwriting user modifications

### DIFF
--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -33,7 +33,7 @@ providers:
   # <int> how often Grafana will scan for changed dashboards
   updateIntervalSeconds: 5
   # <bool> allow updating provisioned dashboards from the UI
-  allowUiUpdates: true
+  allowUiUpdates: false
   options:
     # <string, required> path to dashboard files on disk. Required
     path: /etc/grafana/dashboards


### PR DESCRIPTION
# Summary

Currently, users may edit the provisioned dashboards and save them to the database, this may look nice but the modification from the user will get overwritten if the dashboards have been changed in the newer version of Apache DevLake during an upgrade.

To address the problem, we came to a conclusion: **All provisioned dashboards can be edited but should not be saved, it makes more sense for users to save the edited dashboard as a new one.**

This PR achieves the goal by simply forbidding updating the provisioned dashboards according to https://grafana.com/docs/grafana/latest/administration/provisioning/


# Screenshots

I tested it on my local machine and it seems to be working as expected:



1. When users click on the "Save" button, a window pops up instead of saving it to the database
![image](https://github.com/user-attachments/assets/86ab65a8-3fc1-41b6-b961-30c134b0d348)
2. Users may go to dashboard settings and click the "Save as" to make a copy
![image](https://github.com/user-attachments/assets/ebc9309a-a7fb-4333-8048-f15d42f1be31)
![image](https://github.com/user-attachments/assets/140fddc3-e01a-49d7-9f23-22f9871d074f)
3. The provisioned dashboard was updated as expected while the copied one stayed intact
![image](https://github.com/user-attachments/assets/8b2d8752-72c5-4212-a91d-fc6157b25028)
![image](https://github.com/user-attachments/assets/85b485ba-85fc-4255-9af9-1291834fdf09)
