### PR TITLE
fix(ui): correct documentation urls

### DIFF
--- a/config-ui/src/release/stable.ts
+++ b/config-ui/src/release/stable.ts
@@ -50,10 +50,10 @@ const URLS = {
         'https://devlake.apache.org/docs/Configuration/BitBucket#step-3---adding-transformation-rules-optional',
     },
     BITBUCKET_SERVER: {
-      BASIS: 'https://devlake.apache.org/docs/Configuration/BitBucket-Server',
-      RATE_LIMIT: 'https://devlake.apache.org/docs/Configuration/BitBucket-Server#fixed-rate-limit-optional',
+      BASIS: 'https://devlake.apache.org/docs/Configuration/BitBucketServer',
+      RATE_LIMIT: 'https://devlake.apache.org/docs/Configuration/BitBucketServer#fixed-rate-limit-optional',
       TRANSFORMATION:
-        'https://devlake.apache.org/docs/Configuration/BitBucket-Server#step-3---adding-transformation-rules-optional',
+        'https://devlake.apache.org/docs/Configuration/BitBucketServer#step-3---adding-transformation-rules-optional',
     },
     CIRCLECI: {
       RATE_LIMIT: 'https://devlake.apache.org/docs/Configuration/CircleCI#fixed-rate-limit-optional',


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc. -> looks like I can not do that, maybe adapt the template?

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
fix correct urls, I also noticed that the bamboo documentation no longer exists on the website, not sure what to do about that

### Does this close any open issues?
no

### Screenshots


### Other Information

