### PR TITLE
fix: updating bitbucket server reference URLs to the working url

### DIFF
--- a/config-ui/src/release/v0.21.ts
+++ b/config-ui/src/release/v0.21.ts
@@ -43,10 +43,10 @@ const URLS = {
         'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket#step-3---adding-transformation-rules-optional',
     },
     BITBUCKET_SERVER: {
-      BASIS: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket-Server',
-      RATE_LIMIT: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket-Server#fixed-rate-limit-optional',
+      BASIS: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucketServer',
+      RATE_LIMIT: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucketServer#fixed-rate-limit-optional',
       TRANSFORMATION:
-        'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket-Server#step-3---adding-transformation-rules-optional',
+        'https://devlake.apache.org/docs/v0.21/Configuration/BitBucketServer#step-3---adding-transformation-rules-optional',
     },
     CIRCLECI: {
       RATE_LIMIT: 'https://devlake.apache.org/docs/v0.21/Configuration/CircleCI#fixed-rate-limit-optional',

--- a/config-ui/src/release/v0.21.ts
+++ b/config-ui/src/release/v0.21.ts
@@ -43,10 +43,10 @@ const URLS = {
         'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket#step-3---adding-transformation-rules-optional',
     },
     BITBUCKET_SERVER: {
-      BASIS: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucketServer',
-      RATE_LIMIT: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucketServer#fixed-rate-limit-optional',
+      BASIS: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket',
+      RATE_LIMIT: 'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket#fixed-rate-limit-optional',
       TRANSFORMATION:
-        'https://devlake.apache.org/docs/v0.21/Configuration/BitBucketServer#step-3---adding-transformation-rules-optional',
+        'https://devlake.apache.org/docs/v0.21/Configuration/BitBucket#step-3---adding-transformation-rules-optional',
     },
     CIRCLECI: {
       RATE_LIMIT: 'https://devlake.apache.org/docs/v0.21/Configuration/CircleCI#fixed-rate-limit-optional',

--- a/config-ui/src/release/v1.0.ts
+++ b/config-ui/src/release/v1.0.ts
@@ -50,10 +50,10 @@ const URLS = {
         'https://devlake.apache.org/docs/v1.0/Configuration/BitBucket#step-3---adding-transformation-rules-optional',
     },
     BITBUCKET_SERVER: {
-      BASIS: 'https://devlake.apache.org/docs/v1.0/Configuration/BitBucket-Server',
-      RATE_LIMIT: 'https://devlake.apache.org/docs/v1.0/Configuration/BitBucket-Server#fixed-rate-limit-optional',
+      BASIS: 'https://devlake.apache.org/docs/v1.0/Configuration/BitBucketServer',
+      RATE_LIMIT: 'https://devlake.apache.org/docs/v1.0/Configuration/BitBucketServer#fixed-rate-limit-optional',
       TRANSFORMATION:
-        'https://devlake.apache.org/docs/v1.0/Configuration/BitBucket-Server#step-3---adding-transformation-rules-optional',
+        'https://devlake.apache.org/docs/v1.0/Configuration/BitBucketServer#step-3---adding-transformation-rules-optional',
     },
     CIRCLECI: {
       RATE_LIMIT: 'https://devlake.apache.org/docs/v1.0/Configuration/CircleCI#fixed-rate-limit-optional',


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Updates a broken link.
"Check out this doc" link for Bitbucket Server "Manage Connections" page takes you to a `404` `https://devlake.apache.org/docs/Configuration/BitBucket-Server`
It looks like the correct link is `https://devlake.apache.org/docs/Configuration/BitBucketServer/`

### Does this close any open issues?
Closes xx
