### PR TITLE
fix(framework): fix data in _devlake_subtasks

### DIFF
--- a/backend/impls/context/default_subtask_context.go
+++ b/backend/impls/context/default_subtask_context.go
@@ -46,7 +46,7 @@ func (c *DefaultSubTaskContext) IncProgress(quantity int) {
 	c.defaultExecContext.IncProgress(plugin.SubTaskIncProgress, quantity)
 	if c.LastProgressTime.IsZero() || c.LastProgressTime.Add(3*time.Second).Before(time.Now()) || c.current%1000 == 0 {
 		c.LastProgressTime = time.Now()
-		c.BasicRes.GetLogger().Info("finished records: %d", c.current)
+		c.BasicRes.GetLogger().Info("finished records: %d(not exactly)", c.current)
 	} else {
 		c.BasicRes.GetLogger().Debug("finished records: %d", c.current)
 	}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. Fix `finished_records` field, make sure it is correct
2. Update `_devlake_subtasks` only when it does exist, fix null fields such as `began_at`.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

#### finished_records
<img width="1908" alt="image" src="https://github.com/user-attachments/assets/dfdfdf83-bbac-4aad-98dd-c9765b08a403">
<img width="1597" alt="image" src="https://github.com/user-attachments/assets/74bd1c2e-029b-4215-97ee-a74c2f293c01">



### Other Information
Any other information that is important to this PR.
