### PR TITLE
fix: non-git users can build devlake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@
 # https://stackoverflow.com/questions/920413/make-error-missing-separator
 # https://tutorialedge.net/golang/makefiles-for-go-developers/
 
-SHA ?= $(shell git show -s --format=%h)
-TAG ?= $(shell git tag --points-at HEAD)
+SHA := $(shell if [ -d .git ]; then git show -s --format=%h; else echo "default_SHA"; fi)
+TAG := $(shell if [ -d .git ]; then git tag --points-at HEAD; else echo "default_TAG"; fi)
 IMAGE_REPO ?= "apache"
 VERSION = $(TAG)@$(SHA)
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -17,8 +17,8 @@
 # https://stackoverflow.com/questions/920413/make-error-missing-separator
 # https://tutorialedge.net/golang/makefiles-for-go-developers/
 
-SHA ?= $(shell git show -s --format=%h)
-TAG ?= $(shell git tag --points-at HEAD)
+SHA := $(shell if [ -d .git ]; then git show -s --format=%h; else echo "default_SHA"; fi)
+TAG := $(shell if [ -d .git ]; then git tag --points-at HEAD; else echo "default_TAG"; fi)
 IMAGE_REPO ?= "apache"
 VERSION = $(TAG)@$(SHA)
 PYTHON_DIR ?= "./python"


### PR DESCRIPTION
### Summary
fix: non-git users can build devlake

### Does this close any open issues?
Closes #7668 

### Screenshots
![image](https://github.com/user-attachments/assets/8d6bfae5-9cfb-4d61-ae0b-1a2356d27c7d)
![image](https://github.com/user-attachments/assets/3978b50e-9bb8-426d-b799-b46b4777700a)



### Other Information
Any other information that is important to this PR.
