### PR TITLE
feat: add deployment URL mapping to webhook plugin

### DIFF
--- a/backend/plugins/webhook/api/deployments.go
+++ b/backend/plugins/webhook/api/deployments.go
@@ -43,6 +43,7 @@ type WebhookDeploymentReq struct {
 	Result       string `mapstructure:"result"`
 	Environment  string `validate:"omitempty,oneof=PRODUCTION STAGING TESTING DEVELOPMENT"`
 	Name         string `mapstructure:"name"`
+	Url          string `mapstructure:"url"`
 	// DeploymentCommits is used for multiple commits in one deployment
 	DeploymentCommits []WebhookDeploymentCommitReq `mapstructure:"deploymentCommits" validate:"omitempty,dive"`
 	CreatedDate       *time.Time                   `mapstructure:"createdDate"`
@@ -209,6 +210,7 @@ func CreateDeploymentAndDeploymentCommits(connection *models.WebhookConnection, 
 	deployment.StartedDate = request.StartedDate
 	deployment.FinishedDate = request.FinishedDate
 	deployment.Result = request.Result
+	deployment.Url = request.Url
 	if err := tx.CreateOrUpdate(deployment); err != nil {
 		logger.Error(err, "failed to save deployment")
 		return err

--- a/config-ui/src/plugins/register/webhook/components/utils.ts
+++ b/config-ui/src/plugins/register/webhook/components/utils.ts
@@ -41,6 +41,7 @@ export const transformURI = (prefix: string, webhook: IWebhook, apiKey: string) 
       "startedDate": "2023-01-01T12:00:00+00:00",
       "finishedDate": "2023-01-01T12:00:00+00:00",
       "result": "SUCCESS",
+      "url": "Optional. The URL of the deployment",
       "deploymentCommits":[
         {
           "repoUrl": "your-git-url",


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This PR add mapping for deployment URL when creating a deployment through web hook plugin.

I'm planning a second merge request on the documentation repository if accepted

I did not see any relevant tests for the web hook plugin but I am willing to contribute as to this as I'm planning to propose other changes (a fix on the deployment name computation which can exceed 255 chars when multiple commits are present and the ability to delete issues created from the web hook)

### Does this close any open issues?
No open issues for this change

