### PR TITLE
fix: updating jira storypoint field should refresh all records

### DIFF
--- a/backend/plugins/jira/e2e/issue_relationship_test.go
+++ b/backend/plugins/jira/e2e/issue_relationship_test.go
@@ -36,6 +36,7 @@ func TestIssueRelationshipDataFlow(t *testing.T) {
 		Options: &tasks.JiraOptions{
 			ConnectionId: 2,
 			BoardId:      8,
+			ScopeConfig:  &models.JiraScopeConfig{},
 		},
 	}
 

--- a/backend/plugins/jira/tasks/issue_extractor.go
+++ b/backend/plugins/jira/tasks/issue_extractor.go
@@ -70,7 +70,10 @@ func ExtractIssues(subtaskCtx plugin.SubTaskContext) errors.Error {
 				ConnectionId: data.Options.ConnectionId,
 				BoardId:      data.Options.BoardId,
 			},
-			SubtaskConfig: mappings,
+			SubtaskConfig: map[string]any{
+				"typeMappings":    mappings,
+				"storyPointField": data.Options.ScopeConfig.StoryPointField,
+			},
 		},
 		Extract: func(row *api.RawData) ([]interface{}, errors.Error) {
 			return extractIssues(data, mappings, row, userFieldMap)


### PR DESCRIPTION
### Summary
Changing storypoint field for jira scope config should refresh all records in the next run.

