### PR TITLE
feat: check pipelines' tokens before executing/creating pipeline

### DIFF
--- a/backend/core/plugin/plugin_api.go
+++ b/backend/core/plugin/plugin_api.go
@@ -73,6 +73,10 @@ type PluginApi interface {
 	ApiResources() map[string]map[string]ApiResourceHandler
 }
 
+type PluginTestConnectionAPI interface {
+	TestConnection(id uint64) errors.Error
+}
+
 const wrapResponseError = "WRAP_RESPONSE_ERROR"
 
 func WrapTestConnectionErrResp(basicRes context.BasicRes, err errors.Error) errors.Error {

--- a/backend/core/plugin/plugin_blueprint.go
+++ b/backend/core/plugin/plugin_blueprint.go
@@ -93,6 +93,16 @@ type ProjectMapper interface {
 	MapProject(projectName string, scopes []Scope) (models.PipelinePlan, errors.Error)
 }
 
+type ProjectTokenCheckerConnection struct {
+	PluginName   string
+	ConnectionId uint64
+}
+
+// ProjectTokenChecker is implemented by the plugin org, which generate a task tp check all connection's tokens
+type ProjectTokenChecker interface {
+	MakePipeline(skipCollectors bool, projectName string, scopes []ProjectTokenCheckerConnection) (models.PipelinePlan, errors.Error)
+}
+
 // CompositeDataSourcePluginBlueprintV200 is for unit test
 type CompositeDataSourcePluginBlueprintV200 interface {
 	PluginMeta

--- a/backend/helpers/pluginhelper/api/misc_helpers.go
+++ b/backend/helpers/pluginhelper/api/misc_helpers.go
@@ -18,9 +18,11 @@ limitations under the License.
 package api
 
 import (
+	"fmt"
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models"
+	"github.com/apache/incubator-devlake/core/plugin"
 )
 
 // CallDB wraps DB calls with this signature, and handles the case if the struct is wrapped in a models.DynamicTabler.
@@ -30,4 +32,12 @@ func CallDB(f func(any, ...dal.Clause) errors.Error, x any, clauses ...dal.Claus
 		x = dynamic.Unwrap()
 	}
 	return f(x, clauses...)
+}
+
+func GenerateTestingConnectionApiResourceInput(connectionID uint64) *plugin.ApiResourceInput {
+	return &plugin.ApiResourceInput{
+		Params: map[string]string{
+			"connectionId": fmt.Sprintf("%d", connectionID),
+		},
+	}
 }

--- a/backend/plugins/ae/impl/impl.go
+++ b/backend/plugins/ae/impl/impl.go
@@ -130,6 +130,11 @@ func (p AE) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p AE) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p AE) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/azuredevops_go/impl/impl.go
+++ b/backend/plugins/azuredevops_go/impl/impl.go
@@ -255,6 +255,11 @@ func (p Azuredevops) ApiResources() map[string]map[string]plugin.ApiResourceHand
 	}
 }
 
+func (p Azuredevops) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Azuredevops) MakeDataSourcePipelinePlanV200(
 	connectionId uint64,
 	scopes []*coreModels.BlueprintScope,

--- a/backend/plugins/bamboo/impl/impl.go
+++ b/backend/plugins/bamboo/impl/impl.go
@@ -209,6 +209,11 @@ func (p Bamboo) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Bamboo) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Bamboo) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/bitbucket/impl/impl.go
+++ b/backend/plugins/bitbucket/impl/impl.go
@@ -207,6 +207,11 @@ func (p Bitbucket) MakeDataSourcePipelinePlanV200(
 	return api.MakeDataSourcePipelinePlanV200(p.SubTaskMetas(), connectionId, scopes, skipCollectors)
 }
 
+func (p Bitbucket) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Bitbucket) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/bitbucket_server/impl/impl.go
+++ b/backend/plugins/bitbucket_server/impl/impl.go
@@ -170,6 +170,11 @@ func (p BitbucketServer) MakeDataSourcePipelinePlanV200(
 	return api.MakeDataSourcePipelinePlanV200(p.SubTaskMetas(), connectionId, scopes, skipCollectors)
 }
 
+func (p BitbucketServer) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p BitbucketServer) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"connections/:connectionId/test": {

--- a/backend/plugins/circleci/impl/impl.go
+++ b/backend/plugins/circleci/impl/impl.go
@@ -172,6 +172,11 @@ func (p Circleci) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Circleci) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Circleci) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/customize/impl/impl.go
+++ b/backend/plugins/customize/impl/impl.go
@@ -110,3 +110,7 @@ func (p Customize) ApiResources() map[string]map[string]plugin.ApiResourceHandle
 		},
 	}
 }
+
+func (p Customize) TestConnection(id uint64) errors.Error {
+	return nil
+}

--- a/backend/plugins/dbt/impl/impl.go
+++ b/backend/plugins/dbt/impl/impl.go
@@ -74,3 +74,7 @@ func (p Dbt) RootPkgPath() string {
 func (p Dbt) Name() string {
 	return "dbt"
 }
+
+func (p Dbt) TestConnection(id uint64) errors.Error {
+	return nil
+}

--- a/backend/plugins/dora/impl/impl.go
+++ b/backend/plugins/dora/impl/impl.go
@@ -19,7 +19,6 @@ package impl
 
 import (
 	"encoding/json"
-
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	coreModels "github.com/apache/incubator-devlake/core/models"
@@ -167,4 +166,8 @@ func (p Dora) MakeMetricPluginPipelinePlanV200(projectName string, options json.
 		},
 	}
 	return plan, nil
+}
+
+func (p Dora) TestConnection(id uint64) errors.Error {
+	return nil
 }

--- a/backend/plugins/feishu/impl/impl.go
+++ b/backend/plugins/feishu/impl/impl.go
@@ -132,6 +132,11 @@ func (p Feishu) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Feishu) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Feishu) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/gitee/impl/impl.go
+++ b/backend/plugins/gitee/impl/impl.go
@@ -187,6 +187,11 @@ func (p Gitee) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Gitee) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Gitee) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/gitextractor/impl/impl.go
+++ b/backend/plugins/gitextractor/impl/impl.go
@@ -122,3 +122,7 @@ func (p GitExtractor) Close(taskCtx plugin.TaskContext) errors.Error {
 func (p GitExtractor) RootPkgPath() string {
 	return "github.com/apache/incubator-devlake/plugins/gitextractor"
 }
+
+func (p GitExtractor) TestConnection(id uint64) errors.Error {
+	return nil
+}

--- a/backend/plugins/github/api/shared.go
+++ b/backend/plugins/github/api/shared.go
@@ -1,0 +1,42 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"fmt"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+func TestExistingConnectionForTokenCheck(input *plugin.ApiResourceInput) errors.Error {
+	connection, err := dsHelper.ConnApi.GetMergedConnection(input)
+	if err != nil {
+		return err
+	}
+	testConnectionResult, testConnectionErr := testExistingConnection(context.TODO(), connection.GithubConn)
+	if testConnectionErr != nil {
+		return testConnectionErr
+	}
+	for _, token := range testConnectionResult.Tokens {
+		if !token.Success {
+			return errors.Default.New(fmt.Sprintf("token %s failed with msg: %s", token.Token, token.Message))
+		}
+	}
+	return nil
+}

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -181,8 +181,7 @@ func (p Github) MigrationScripts() []plugin.MigrationScript {
 }
 
 func (p Github) TestConnection(id uint64) errors.Error {
-	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
-	return err
+	return api.TestExistingConnectionForTokenCheck(helper.GenerateTestingConnectionApiResourceInput(id))
 }
 
 func (p Github) ApiResources() map[string]map[string]plugin.ApiResourceHandler {

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -180,6 +180,11 @@ func (p Github) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Github) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Github) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -233,6 +233,11 @@ func (p Gitlab) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Gitlab) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Gitlab) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/icla/impl/impl.go
+++ b/backend/plugins/icla/impl/impl.go
@@ -104,6 +104,10 @@ func (p Icla) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return nil
 }
 
+func (p Icla) TestConnection(id uint64) errors.Error {
+	return nil
+}
+
 func (p Icla) Close(taskCtx plugin.TaskContext) errors.Error {
 	data, ok := taskCtx.GetData().(*tasks.IclaTaskData)
 	if !ok {

--- a/backend/plugins/issue_trace/impl/enricher.go
+++ b/backend/plugins/issue_trace/impl/enricher.go
@@ -19,7 +19,6 @@ package impl
 
 import (
 	"encoding/json"
-
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -149,6 +148,10 @@ func (p IssueTrace) GetTablesInfo() []dal.Tabler {
 		&models.IssueAssigneeHistory{},
 		&models.IssueStatusHistory{},
 	}
+}
+
+func (p IssueTrace) TestConnection(id uint64) errors.Error {
+	return nil
 }
 
 func (p IssueTrace) MakeMetricPluginPipelinePlanV200(projectName string, options json.RawMessage) (coreModels.PipelinePlan, errors.Error) {

--- a/backend/plugins/jenkins/impl/impl.go
+++ b/backend/plugins/jenkins/impl/impl.go
@@ -176,6 +176,11 @@ func (p Jenkins) MakeDataSourcePipelinePlanV200(
 	return api.MakeDataSourcePipelinePlanV200(p.SubTaskMetas(), connectionId, scopes, skipCollectors)
 }
 
+func (p Jenkins) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Jenkins) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/jira/impl/impl.go
+++ b/backend/plugins/jira/impl/impl.go
@@ -285,6 +285,11 @@ func (p Jira) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Jira) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Jira) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/linker/impl/impl.go
+++ b/backend/plugins/linker/impl/impl.go
@@ -125,3 +125,7 @@ func (p Linker) MakeMetricPluginPipelinePlanV200(projectName string, options jso
 	}
 	return plan, nil
 }
+
+func (p Linker) TestConnection(id uint64) errors.Error {
+	return nil
+}

--- a/backend/plugins/opsgenie/impl/impl.go
+++ b/backend/plugins/opsgenie/impl/impl.go
@@ -155,6 +155,11 @@ func (p Opsgenie) Close(taskCtx plugin.TaskContext) errors.Error {
 	return nil
 }
 
+func (p Opsgenie) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Opsgenie) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/org/impl/impl.go
+++ b/backend/plugins/org/impl/impl.go
@@ -59,9 +59,31 @@ func (p Org) Name() string {
 
 func (p Org) SubTaskMetas() []plugin.SubTaskMeta {
 	return []plugin.SubTaskMeta{
+		tasks.TaskCheckTokenMeta,
 		tasks.ConnectUserAccountsExactMeta,
 		tasks.SetProjectMappingMeta,
 	}
+}
+
+func (p Org) MakePipeline(skipCollectors bool, projectName string, connections []plugin.ProjectTokenCheckerConnection) (coreModels.PipelinePlan, errors.Error) {
+	var plan coreModels.PipelinePlan
+	var stage coreModels.PipelineStage
+
+	// construct task options for Org
+	options := make(map[string]interface{})
+	if !skipCollectors {
+		options["projectConnections"] = connections
+	}
+
+	stage = append(stage, &coreModels.PipelineTask{
+		Plugin: p.Name(),
+		Subtasks: []string{
+			tasks.TaskCheckTokenMeta.Name,
+		},
+		Options: options,
+	})
+	plan = append(plan, stage)
+	return plan, nil
 }
 
 func (p Org) MapProject(projectName string, scopes []plugin.Scope) (coreModels.PipelinePlan, errors.Error) {

--- a/backend/plugins/org/tasks/check_token.go
+++ b/backend/plugins/org/tasks/check_token.go
@@ -1,0 +1,76 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"golang.org/x/sync/errgroup"
+)
+
+var TaskCheckTokenMeta = plugin.SubTaskMeta{
+	Name:             "checkTokens",
+	EntryPoint:       checkProjectTokens,
+	EnabledByDefault: true,
+	Description:      "set project mapping",
+	DomainTypes:      []string{plugin.DOMAIN_TYPE_CROSS},
+}
+
+func checkProjectTokens(taskCtx plugin.SubTaskContext) errors.Error {
+	logger := taskCtx.GetLogger()
+	taskData := taskCtx.GetData().(*TaskData)
+	connections := taskData.Options.ProjectConnections
+	logger.Debug("connections %+v", connections)
+	if len(connections) == 0 {
+		return nil
+	}
+
+	g := new(errgroup.Group)
+	for _, connection := range connections {
+		conn := connection
+		logger.Debug("check conn: %+v", conn)
+		g.Go(func() error {
+			if err := checkConnectionToken(conn.ConnectionId, conn.PluginName); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Convert(err)
+	}
+	return nil
+}
+
+func checkConnectionToken(connectionID uint64, pluginName string) errors.Error {
+	pluginEntry, err := plugin.GetPlugin(pluginName)
+	if err != nil {
+		return err
+	}
+	if v, ok := pluginEntry.(plugin.PluginTestConnectionAPI); ok {
+		if err := v.TestConnection(connectionID); err != nil {
+			return err
+		}
+		return nil
+	} else {
+		msg := fmt.Sprintf("plugin: %s doesn't impl test connection api", pluginName)
+		return errors.Default.New(msg)
+	}
+	return nil
+}

--- a/backend/plugins/org/tasks/check_token.go
+++ b/backend/plugins/org/tasks/check_token.go
@@ -72,5 +72,4 @@ func checkConnectionToken(connectionID uint64, pluginName string) errors.Error {
 		msg := fmt.Sprintf("plugin: %s doesn't impl test connection api", pluginName)
 		return errors.Default.New(msg)
 	}
-	return nil
 }

--- a/backend/plugins/org/tasks/task_data.go
+++ b/backend/plugins/org/tasks/task_data.go
@@ -20,8 +20,14 @@ package tasks
 import "github.com/apache/incubator-devlake/core/plugin"
 
 type Options struct {
-	ConnectionId    uint64           `json:"connectionId"`
-	ProjectMappings []ProjectMapping `json:"projectMappings"`
+	ConnectionId       uint64              `json:"connectionId"`
+	ProjectMappings    []ProjectMapping    `json:"projectMappings"`
+	ProjectConnections []ProjectConnection `json:"projectConnections"`
+}
+
+type ProjectConnection struct {
+	PluginName   string
+	ConnectionId uint64
 }
 
 // ProjectMapping represents the relations between project and scopes

--- a/backend/plugins/pagerduty/impl/impl.go
+++ b/backend/plugins/pagerduty/impl/impl.go
@@ -138,6 +138,11 @@ func (p PagerDuty) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p PagerDuty) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p PagerDuty) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/refdiff/impl/impl.go
+++ b/backend/plugins/refdiff/impl/impl.go
@@ -110,3 +110,7 @@ func (p RefDiff) RootPkgPath() string {
 func (p RefDiff) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return nil
 }
+
+func (p RefDiff) TestConnection(id uint64) errors.Error {
+	return nil
+}

--- a/backend/plugins/slack/impl/impl.go
+++ b/backend/plugins/slack/impl/impl.go
@@ -131,6 +131,11 @@ func (p Slack) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Slack) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Slack) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/sonarqube/impl/impl.go
+++ b/backend/plugins/sonarqube/impl/impl.go
@@ -170,6 +170,11 @@ func (p Sonarqube) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Sonarqube) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Sonarqube) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/starrocks/impl/impl.go
+++ b/backend/plugins/starrocks/impl/impl.go
@@ -68,6 +68,6 @@ func (s StarRocks) RootPkgPath() string {
 	return "github.com/merico-dev/lake/plugins/starrocks"
 }
 
-func (p StarRocks) TestConnection(id uint64) errors.Error {
+func (s StarRocks) TestConnection(id uint64) errors.Error {
 	return nil
 }

--- a/backend/plugins/starrocks/impl/impl.go
+++ b/backend/plugins/starrocks/impl/impl.go
@@ -67,3 +67,7 @@ func (s StarRocks) Name() string {
 func (s StarRocks) RootPkgPath() string {
 	return "github.com/merico-dev/lake/plugins/starrocks"
 }
+
+func (p StarRocks) TestConnection(id uint64) errors.Error {
+	return nil
+}

--- a/backend/plugins/tapd/impl/impl.go
+++ b/backend/plugins/tapd/impl/impl.go
@@ -265,6 +265,11 @@ func (p Tapd) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Tapd) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Tapd) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/teambition/impl/impl.go
+++ b/backend/plugins/teambition/impl/impl.go
@@ -169,6 +169,11 @@ func (p Teambition) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Teambition) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Teambition) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/trello/impl/impl.go
+++ b/backend/plugins/trello/impl/impl.go
@@ -151,6 +151,11 @@ func (p Trello) ScopeConfig() dal.Tabler {
 	return &models.TrelloScopeConfig{}
 }
 
+func (p Trello) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Trello) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/plugins/webhook/impl/impl.go
+++ b/backend/plugins/webhook/impl/impl.go
@@ -77,6 +77,10 @@ func (p Webhook) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Webhook) TestConnection(id uint64) errors.Error {
+	return nil
+}
+
 func (p Webhook) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"connections": {

--- a/backend/plugins/zentao/impl/impl.go
+++ b/backend/plugins/zentao/impl/impl.go
@@ -277,6 +277,11 @@ func (p Zentao) MigrationScripts() []plugin.MigrationScript {
 	return migrationscripts.All()
 }
 
+func (p Zentao) TestConnection(id uint64) errors.Error {
+	_, err := api.TestExistingConnection(helper.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p Zentao) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"test": {

--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -20,6 +20,9 @@ package services
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/apache/incubator-devlake/core/log"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"golang.org/x/sync/errgroup"
 	"strings"
 	"sync"
 
@@ -412,6 +415,11 @@ func TriggerBlueprint(id uint64, triggerSyncPolicy *models.TriggerSyncPolicy, sh
 	}
 	blueprint.SkipCollectors = triggerSyncPolicy.SkipCollectors
 	blueprint.FullSync = triggerSyncPolicy.FullSync
+
+	if err := checkBlueprintTokens(blueprint, triggerSyncPolicy); err != nil {
+		return nil, errors.Default.Wrap(err, "check blue print tokens")
+	}
+
 	pipeline, err := createPipelineByBlueprint(blueprint, &models.SyncPolicy{
 		SkipOnFail:        false,
 		TimeAfter:         nil,
@@ -426,4 +434,71 @@ func TriggerBlueprint(id uint64, triggerSyncPolicy *models.TriggerSyncPolicy, sh
 		}
 	}
 	return pipeline, nil
+}
+
+func needToCheckToken(triggerSyncPolicy *models.TriggerSyncPolicy) bool {
+	// case1: retransform
+	if triggerSyncPolicy.SkipCollectors && triggerSyncPolicy.FullSync == false {
+		return false
+	}
+	// case2: collect data
+	if triggerSyncPolicy.SkipCollectors == false && triggerSyncPolicy.FullSync == false {
+		return true
+	}
+	// case3: collect data with fullsync
+	if triggerSyncPolicy.SkipCollectors == false && triggerSyncPolicy.FullSync == true {
+		return true
+	}
+	// case4: others
+	return true
+}
+
+func checkBlueprintTokens(blueprint *models.Blueprint, triggerSyncPolicy *models.TriggerSyncPolicy) errors.Error {
+	if blueprint == nil {
+		return errors.Default.New("blueprint is nil")
+	}
+	if triggerSyncPolicy == nil {
+		return errors.Default.New("triggerSyncPolicy is nil")
+	}
+
+	if !needToCheckToken(triggerSyncPolicy) {
+		return nil
+	}
+
+	if len(blueprint.Connections) == 0 {
+		return nil
+	}
+
+	g := new(errgroup.Group)
+	for _, connection := range blueprint.Connections {
+		conn := *connection
+		g.Go(func() error {
+			if err := checkConnectionToken(logger, conn); err != nil {
+				return err
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return errors.Convert(err)
+	}
+
+	return nil
+}
+
+func checkConnectionToken(logger log.Logger, connection models.BlueprintConnection) errors.Error {
+	pluginEntry, err := plugin.GetPlugin(connection.PluginName)
+	if err != nil {
+		return err
+	}
+	if v, ok := pluginEntry.(plugin.PluginTestConnectionAPI); ok {
+		if err := v.TestConnection(connection.ConnectionId); err != nil {
+			logger.Error(err, "plugin: %s, id: %d", connection.PluginName, connection.ConnectionId)
+			return err
+		}
+		return nil
+	} else {
+		msg := fmt.Sprintf("plugin: %s doesn't impl test connection api", connection.PluginName)
+		return errors.Default.New(msg)
+	}
 }

--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -438,17 +438,11 @@ func TriggerBlueprint(id uint64, triggerSyncPolicy *models.TriggerSyncPolicy, sh
 
 func needToCheckToken(triggerSyncPolicy *models.TriggerSyncPolicy) bool {
 	// case1: retransform
-	if triggerSyncPolicy.SkipCollectors && triggerSyncPolicy.FullSync == false {
+	if triggerSyncPolicy.SkipCollectors && !triggerSyncPolicy.FullSync {
 		return false
 	}
-	// case2: collect data
-	if triggerSyncPolicy.SkipCollectors == false && triggerSyncPolicy.FullSync == false {
-		return true
-	}
-	// case3: collect data with fullsync
-	if triggerSyncPolicy.SkipCollectors == false && triggerSyncPolicy.FullSync == true {
-		return true
-	}
+	// case2: collect data: triggerSyncPolicy.SkipCollectors == false && triggerSyncPolicy.FullSync == false
+	// case3: collect data with fullsync: triggerSyncPolicy.SkipCollectors == false && triggerSyncPolicy.FullSync == true
 	// case4: others
 	return true
 }

--- a/backend/server/services/project.go
+++ b/backend/server/services/project.go
@@ -217,7 +217,7 @@ func PatchProject(name string, body map[string]interface{}) (*models.ApiOutputPr
 		return nil, err
 	}
 
-	// allowed to changed the name
+	// allowed to change the name
 	if projectInput.Name == "" {
 		projectInput.Name = name
 	}

--- a/backend/server/services/remote/models/plugin_remote.go
+++ b/backend/server/services/remote/models/plugin_remote.go
@@ -30,4 +30,5 @@ type RemotePlugin interface {
 	plugin.PluginModel
 	plugin.PluginMigration
 	plugin.PluginSource
+	plugin.PluginTestConnectionAPI
 }

--- a/backend/server/services/remote/plugin/plugin_impl.go
+++ b/backend/server/services/remote/plugin/plugin_impl.go
@@ -230,6 +230,11 @@ func (p *remotePluginImpl) ApiResources() map[string]map[string]plugin.ApiResour
 	return p.resources
 }
 
+func (p *remotePluginImpl) TestConnection(id uint64) errors.Error {
+	_, err := p.resources["connections/:connectionId/test"]["POST"](api.GenerateTestingConnectionApiResourceInput(id))
+	return err
+}
+
 func (p *remotePluginImpl) OpenApiSpec() string {
 	return p.openApiSpec
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
1. Check tokens before creating pipelines
2. Restranform will succeed regardless of whether the tokens are  legal or not

### Does this close any open issues?
Related #8017 

### Screenshots
Include any relevant screenshots here.

#### Github
##### Collect data with wrong token
![image](https://github.com/user-attachments/assets/977b5b3e-8dcf-42fd-97c6-95707db74bf0)

##### restransform can be executed successfully
![image](https://github.com/user-attachments/assets/aa735c98-f382-4d6c-8176-2561a17da513)

##### Collect Data In Full Refresh Mode
![image](https://github.com/user-attachments/assets/e5cb5816-df28-49c7-977c-35956fa17922)


### Other Information
Any other information that is important to this PR.
