### PR TITLE
fix(migration): panic when `ExecuteMigration` fails

### DIFF
--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -122,12 +122,7 @@ func SetupApiServer(router *gin.Engine) {
 	// Endpoint to proceed database migration
 	router.GET("/proceed-db-migration", func(ctx *gin.Context) {
 		// Execute database migration
-		err := services.ExecuteMigration()
-		if err != nil {
-			// Return error response
-			shared.ApiOutputError(ctx, errors.Default.Wrap(err, "error executing migration"))
-			return
-		}
+		errors.Must(services.ExecuteMigration())
 		// Return success response
 		shared.ApiOutputSuccess(ctx, nil, http.StatusOK)
 	})

--- a/backend/server/services/init.go
+++ b/backend/server/services/init.go
@@ -96,7 +96,7 @@ func registerPluginsMigrationScripts() {
 
 func InitExecuteMigration() {
 	// check if there are pending migration
-	logger.Info("has pending scripts? %v, FORCE_MIGRATION: %s", migrator.HasPendingScripts(), cfg.GetBool("FORCE_MIGRATION"))
+	logger.Info("has pending scripts? %v, FORCE_MIGRATION: %v", migrator.HasPendingScripts(), cfg.GetBool("FORCE_MIGRATION"))
 	if migrator.HasPendingScripts() {
 		if cfg.GetBool("FORCE_MIGRATION") {
 			errors.Must(ExecuteMigration())


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Panic when `ExecuteMigration` fails.

#### Why?
`ExecuteMigration` is regared as a function that will succeed always, because if it return an error, backend will panic directly.
<img width="341" alt="image" src="https://github.com/user-attachments/assets/7d0516cb-a681-42a4-895f-f9aa477f56a2">

#### What problems can be solved?
In these code:
```
    router.GET("/proceed-db-migration", func(ctx *gin.Context) {
		// Execute database migration
		err := services.ExecuteMigration()
		if err != nil {
			// Return error response
			shared.ApiOutputError(ctx, errors.Default.Wrap(err, "error executing migration"))
			return
		}
		// Return success response
		shared.ApiOutputSuccess(ctx, nil, http.StatusOK)
	})
```
`ExecuteMigration` will return an error and the main program will go on.

If there is a new migration script which will return an error when executing ,  user will have to process db migration.
When this API is called,  it returns an error.
But errors are different.
The frist time, it will return from  https://github.com/apache/incubator-devlake/blob/main/backend/server/services/init.go#L157.
The second and following times, it will return from https://github.com/apache/incubator-devlake/blob/main/backend/server/services/init.go#L146.

Users can never handle this expect for a reboot.

I think it's unreasonable and this PR just try to fix this.


### Does this close any open issues?
There are some related issues #8018  #7992 , but this fix is not the root cause of them.

### Screenshots
Include any relevant screenshots here.

#### It will not return `There is a migration in progress.` The backend will panic and recover(by gin framework if it's in release mode) directly.
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/e5c91465-dd1a-4093-9ff6-eca9e90145ac">


### Other Information
Any other information that is important to this PR.
