### PR TITLE
fix(project): project cannot be deleted when its pipelines are not finished

### DIFF
--- a/backend/core/models/task.go
+++ b/backend/core/models/task.go
@@ -34,7 +34,10 @@ const (
 	TASK_PARTIAL   = "TASK_PARTIAL"
 )
 
-var PendingTaskStatus = []string{TASK_CREATED, TASK_RERUN, TASK_RUNNING}
+var (
+	PendingTaskStatus  = []string{TASK_CREATED, TASK_RERUN, TASK_RUNNING}
+	FinishedTaskStatus = []string{TASK_PARTIAL, TASK_CANCELLED, TASK_FAILED, TASK_COMPLETED}
+)
 
 type TaskProgressDetail struct {
 	TotalSubTasks        int    `json:"totalSubTasks"`

--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -238,6 +238,13 @@ func DeleteBlueprint(id uint64) errors.Error {
 	if err != nil {
 		return err
 	}
+	pipelinesAreUnfinished, err := thereAreUnfinishedPipelinesUnderBlueprint(bp.ID)
+	if err != nil {
+		return err
+	}
+	if pipelinesAreUnfinished {
+		return errors.Default.New("There are unfinished pipelines under current blueprint. It can not be deleted now.")
+	}
 	err = bpManager.DeleteBlueprint(bp.ID)
 	if err != nil {
 		return errors.Default.Wrap(err, "Failed to delete the blueprint")


### PR DESCRIPTION


<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Project and blueprint cannot be deleted when their pipelines are not finished

### Does this close any open issues?
Closes #7771 

### Screenshots
Include any relevant screenshots here.
![WX20240920-113358@2x](https://github.com/user-attachments/assets/48e37559-365c-4d09-bcc6-57a0b256455a)


### Other Information
Any other information that is important to this PR.
