### PR TITLE
fix(github-plugin): removes the processed org check to return all the…

### DIFF
--- a/backend/plugins/github/api/remote_api.go
+++ b/backend/plugins/github/api/remote_api.go
@@ -202,18 +202,25 @@ func listGithubAppInstalledRepos(
 	}
 	var appRepos GithubAppRepo
 	errors.Must(api.UnmarshalResponse(resApp, &appRepos))
-	processedOrgs := make(map[string]struct{})
 	for _, r := range appRepos.Repositories {
 		orgName := r.Owner.Login
-		if _, exists := processedOrgs[orgName]; !exists && orgName != "" {
+		if orgName != "" {
 			children = append(children, dsmodels.DsRemoteApiScopeListEntry[models.GithubRepo]{
 				Type:     api.RAS_ENTRY_TYPE_SCOPE,
 				ParentId: &orgName,
 				Id:       fmt.Sprintf("%v", r.ID),
 				Name:     fmt.Sprintf("%v", r.Name),
 				FullName: fmt.Sprintf("%v", r.FullName),
+				Data: &models.GithubRepo{
+					GithubId:    r.ID,
+					Name:        r.Name,
+					FullName:    r.FullName,
+					HTMLUrl:     r.HTMLURL,
+					Description: r.Description,
+					OwnerId:     r.Owner.ID,
+					CloneUrl:    r.CloneURL,
+				},
 			})
-			processedOrgs[orgName] = struct{}{}
 		}
 	}
 	if len(appRepos.Repositories) == page.PerPage {


### PR DESCRIPTION
… org repos, and pulls the repository data when adding scope

previous behavior would return a single repository. Also no repo data was returned so the user could not add the repo to devlake

fixes part of my issue in #7655

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Removees the processed org check which was preventing multiple repositories from being pulled. The processed org check would trigger after a single repo was returned.  Also I've added in the repo data model because it wasn't returning data, and therefore data couldn't be added to the  scope!

### Does this close any open issues?
Partial fix for #7655 

### Screenshots
Include any relevant screenshots here.

### Other Information
I'm not sure what the initial purpose the processedOrgs check had, so deleting it entirely might be aggressive. But since the app connection is scoped to a single org I don't see a direct downside to removing it. 
