### PR TITLE
fix(zentao): make `gitcommited` a valiad action

### DIFF
--- a/backend/plugins/zentao/tasks/bug_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/bug_commits_extractor.go
@@ -60,8 +60,8 @@ func ExtractBugCommits(taskCtx plugin.SubTaskContext) errors.Error {
 			if err != nil {
 				return nil, errors.Default.WrapRaw(err)
 			}
-			// only linked2revision action is valid
-			if res.Action != "linked2revision" {
+			// only linked2revision and gitcommited action is valid
+			if res.Action != "linked2revision" && res.Action != "gitcommited" {
 				return nil, nil
 			}
 

--- a/backend/plugins/zentao/tasks/story_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/story_commits_extractor.go
@@ -56,8 +56,8 @@ func ExtractStoryCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, errors.Default.WrapRaw(err)
 			}
 
-			// only linked2revision action is valid
-			if res.Action != "linked2revision" {
+			// only linked2revision and gitcommited action is valid
+			if res.Action != "linked2revision" && res.Action != "gitcommited" {
 				return nil, nil
 			}
 

--- a/backend/plugins/zentao/tasks/task_commits_extractor.go
+++ b/backend/plugins/zentao/tasks/task_commits_extractor.go
@@ -56,8 +56,8 @@ func ExtractTaskCommits(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, errors.Default.WrapRaw(err)
 			}
 
-			// only linked2revision action is valid
-			if res.Action != "linked2revision" {
+			// only linked2revision and gitcommited action is valid
+			if res.Action != "linked2revision" && res.Action != "gitcommited" {
 				return nil, nil
 			}
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Action `gitcommited` is legal in Zentao plugin.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
