### PR TITLE
fix(gitextractor): subtask Clone Git Repo ended unexpectedly

### DIFF
--- a/backend/plugins/gitextractor/impl/impl.go
+++ b/backend/plugins/gitextractor/impl/impl.go
@@ -20,7 +20,6 @@ package impl
 import (
 	"fmt"
 	"net/url"
-	"strings"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -151,25 +150,4 @@ func (p GitExtractor) RootPkgPath() string {
 
 func (p GitExtractor) TestConnection(id uint64) errors.Error {
 	return nil
-}
-
-func replaceAcessTokenInUrl(gitURL, newCredential string) (string, errors.Error) {
-	atIndex := strings.Index(gitURL, "@")
-	if atIndex == -1 {
-		return "", errors.Default.New("Invalid Git URL")
-	}
-
-	protocolIndex := strings.Index(gitURL, "://")
-	if protocolIndex == -1 {
-		return "", errors.Default.New("Invalid Git URL")
-	}
-
-	// Extract the base URL (e.g., "https://git:")
-	baseURL := gitURL[:protocolIndex+7]
-
-	repoURL := gitURL[atIndex+1:]
-
-	modifiedURL := fmt.Sprintf("%s%s@%s", baseURL, newCredential, repoURL)
-
-	return modifiedURL, nil
 }

--- a/backend/plugins/gitextractor/impl/impl.go
+++ b/backend/plugins/gitextractor/impl/impl.go
@@ -73,18 +73,16 @@ func (p GitExtractor) PrepareTaskData(taskCtx plugin.TaskContext, options map[st
 		return nil, err
 	}
 
-
 	if op.PluginName != "" {
 		pluginInstance, err := plugin.GetPlugin(op.PluginName)
 		if err != nil {
 			return nil, errors.Default.Wrap(err, fmt.Sprintf("failed to get plugin instance for plugin: %s", op.PluginName))
-
 		}
 
 		if pluginGit, ok := pluginInstance.(DynamicGitUrl); ok {
 			gitUrl, err := pluginGit.GetDynamicGitUrl(taskCtx, op.ConnectionId, op.Url)
 			if err != nil {
-					return nil, errors.Default.Wrap(err, "failed to get Git URL")
+				return nil, errors.Default.Wrap(err, "failed to get Git URL")
 			}
 
 			op.Url = gitUrl

--- a/backend/plugins/gitextractor/impl/impl.go
+++ b/backend/plugins/gitextractor/impl/impl.go
@@ -18,7 +18,9 @@ limitations under the License.
 package impl
 
 import (
+	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -26,6 +28,7 @@ import (
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/parser"
 	"github.com/apache/incubator-devlake/plugins/gitextractor/tasks"
+	"github.com/apache/incubator-devlake/plugins/github/models"
 	giturls "github.com/chainguard-dev/git-urls"
 )
 
@@ -68,9 +71,33 @@ func (p GitExtractor) PrepareTaskData(taskCtx plugin.TaskContext, options map[st
 		return nil, err
 	}
 
-	parsedURL, err := giturls.Parse(op.Url)
+	connectionHelper := helper.NewConnectionHelper(
+		taskCtx,
+		nil,
+		p.Name(),
+	)
+	connection := &models.GithubConnection{}
+	err := connectionHelper.FirstById(connection, op.ConnectionId)
 	if err != nil {
-		return nil, errors.BadInput.Wrap(err, "failed to parse git url")
+		return nil, errors.Default.Wrap(err, "unable to get github connection by the given connection ID")
+	}
+
+	apiClient, err := helper.NewApiClient(taskCtx.GetContext(), connection.GetEndpoint(), nil, 0, connection.GetProxy(), taskCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	connection.PrepareApiClient(apiClient)
+
+	newUrl, err := replaceAcessTokenInUrl(op.Url, connection.Token)
+	if err != nil {
+		return nil, err
+	}
+	op.Url = newUrl
+
+	parsedURL, errParse := giturls.Parse(op.Url)
+	if errParse != nil {
+		return nil, errors.BadInput.Wrap(errParse, "failed to parse git url")
 	}
 
 	// append username to the git url
@@ -125,4 +152,25 @@ func (p GitExtractor) RootPkgPath() string {
 
 func (p GitExtractor) TestConnection(id uint64) errors.Error {
 	return nil
+}
+
+func replaceAcessTokenInUrl(gitURL, newCredential string) (string, errors.Error) {
+	atIndex := strings.Index(gitURL, "@")
+	if atIndex == -1 {
+		return "", errors.Default.New("Invalid Git URL")
+	}
+
+	protocolIndex := strings.Index(gitURL, "://")
+	if protocolIndex == -1 {
+		return "", errors.Default.New("Invalid Git URL")
+	}
+
+	// Extract the base URL (e.g., "https://git:")
+	baseURL := gitURL[:protocolIndex+7]
+
+	repoURL := gitURL[atIndex+1:]
+
+	modifiedURL := fmt.Sprintf("%s%s@%s", baseURL, newCredential, repoURL)
+
+	return modifiedURL, nil
 }

--- a/backend/plugins/gitextractor/parser/taskdata.go
+++ b/backend/plugins/gitextractor/parser/taskdata.go
@@ -46,4 +46,5 @@ type GitExtractorOptions struct {
 	SkipCommitFiles       *bool  `json:"skipCommitFiles" mapstructure:"skipCommitFiles"`
 	NoShallowClone        bool   `json:"noShallowClone" mapstructure:"noShallowClone"`
 	ConnectionId					uint64 `json:"connectionId" mapstructure:"connectionId,omitempty"`
+	PluginName						string `json:"pluginName" mapstructure:"pluginName,omitempty"`
 }

--- a/backend/plugins/gitextractor/parser/taskdata.go
+++ b/backend/plugins/gitextractor/parser/taskdata.go
@@ -45,4 +45,5 @@ type GitExtractorOptions struct {
 	SkipCommitStat        *bool  `json:"skipCommitStat" mapstructure:"skipCommitStat" comment:"skip all commit stat including added/deleted lines and commit files as well"`
 	SkipCommitFiles       *bool  `json:"skipCommitFiles" mapstructure:"skipCommitFiles"`
 	NoShallowClone        bool   `json:"noShallowClone" mapstructure:"noShallowClone"`
+	ConnectionId					uint64 `json:"connectionId" mapstructure:"connectionId,omitempty"`
 }

--- a/backend/plugins/gitextractor/parser/taskdata.go
+++ b/backend/plugins/gitextractor/parser/taskdata.go
@@ -45,6 +45,6 @@ type GitExtractorOptions struct {
 	SkipCommitStat        *bool  `json:"skipCommitStat" mapstructure:"skipCommitStat" comment:"skip all commit stat including added/deleted lines and commit files as well"`
 	SkipCommitFiles       *bool  `json:"skipCommitFiles" mapstructure:"skipCommitFiles"`
 	NoShallowClone        bool   `json:"noShallowClone" mapstructure:"noShallowClone"`
-	ConnectionId					uint64 `json:"connectionId" mapstructure:"connectionId,omitempty"`
-	PluginName						string `json:"pluginName" mapstructure:"pluginName,omitempty"`
+	ConnectionId          uint64 `json:"connectionId" mapstructure:"connectionId,omitempty"`
+	PluginName            string `json:"pluginName" mapstructure:"pluginName,omitempty"`
 }

--- a/backend/plugins/github/api/blueprint_v200.go
+++ b/backend/plugins/github/api/blueprint_v200.go
@@ -131,13 +131,13 @@ func makeDataSourcePipelinePlanV200(
 			stage = append(stage, &coreModels.PipelineTask{
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{
-					"url":      cloneUrl.String(),
-					"name":     githubRepo.FullName,
-					"fullName": githubRepo.FullName,
-					"repoId":   didgen.NewDomainIdGenerator(&models.GithubRepo{}).Generate(connection.ID, githubRepo.GithubId),
-					"proxy":    connection.Proxy,
+					"url":          cloneUrl.String(),
+					"name":         githubRepo.FullName,
+					"fullName":     githubRepo.FullName,
+					"repoId":       didgen.NewDomainIdGenerator(&models.GithubRepo{}).Generate(connection.ID, githubRepo.GithubId),
+					"proxy":        connection.Proxy,
 					"connectionId": githubRepo.ConnectionId,
-					"pluginName": 	"github",
+					"pluginName":   "github",
 				},
 			})
 

--- a/backend/plugins/github/api/blueprint_v200.go
+++ b/backend/plugins/github/api/blueprint_v200.go
@@ -137,6 +137,7 @@ func makeDataSourcePipelinePlanV200(
 					"repoId":   didgen.NewDomainIdGenerator(&models.GithubRepo{}).Generate(connection.ID, githubRepo.GithubId),
 					"proxy":    connection.Proxy,
 					"connectionId": githubRepo.ConnectionId,
+					"pluginName": 	"github",
 				},
 			})
 

--- a/backend/plugins/github/api/blueprint_v200.go
+++ b/backend/plugins/github/api/blueprint_v200.go
@@ -136,6 +136,7 @@ func makeDataSourcePipelinePlanV200(
 					"fullName": githubRepo.FullName,
 					"repoId":   didgen.NewDomainIdGenerator(&models.GithubRepo{}).Generate(connection.ID, githubRepo.GithubId),
 					"proxy":    connection.Proxy,
+					"connectionId": githubRepo.ConnectionId,
 				},
 			})
 

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -177,7 +177,6 @@ func (p Github) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 		if err = regexEnricher.TryAdd(devops.ENV_NAME_PATTERN, op.ScopeConfig.EnvNamePattern); err != nil {
 			return nil, errors.BadInput.Wrap(err, "invalid value for `envNamePattern`")
 		}
-
 	}
 	taskData.RegexEnricher = regexEnricher
 
@@ -292,7 +291,10 @@ func (p Github) GetDynamicGitUrl(taskCtx plugin.TaskContext, connectionId uint64
 		return "", err
 	}
 
-	connection.PrepareApiClient(apiClient)
+	err = connection.PrepareApiClient(apiClient)
+	if err != nil {
+		return "", err
+	}
 
 	newUrl, err := replaceAcessTokenInUrl(repoUrl, connection.Token)
 	if err != nil {
@@ -304,7 +306,8 @@ func (p Github) GetDynamicGitUrl(taskCtx plugin.TaskContext, connectionId uint64
 
 func EnrichOptions(taskCtx plugin.TaskContext,
 	op *tasks.GithubOptions,
-	apiClient *helper.ApiClient) errors.Error {
+	apiClient *helper.ApiClient,
+) errors.Error {
 	var githubRepo models.GithubRepo
 	// validate the op and set name=owner/repo if this is from advanced mode or bpV100
 	err := tasks.ValidateTaskOptions(op)

--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -19,6 +19,7 @@ package impl
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/subtaskmeta/sorter"
 
@@ -273,6 +274,34 @@ func (p Github) Close(taskCtx plugin.TaskContext) errors.Error {
 	return nil
 }
 
+func (p Github) GetDynamicGitUrl(taskCtx plugin.TaskContext, connectionId uint64, repoUrl string) (string, errors.Error) {
+	connectionHelper := helper.NewConnectionHelper(
+		taskCtx,
+		nil,
+		p.Name(),
+	)
+
+	connection := &models.GithubConnection{}
+	err := connectionHelper.FirstById(connection, connectionId)
+	if err != nil {
+		return "", errors.Default.Wrap(err, "unable to get github connection by the given connection ID")
+	}
+
+	apiClient, err := helper.NewApiClient(taskCtx.GetContext(), connection.GetEndpoint(), nil, 0, connection.GetProxy(), taskCtx)
+	if err != nil {
+		return "", err
+	}
+
+	connection.PrepareApiClient(apiClient)
+
+	newUrl, err := replaceAcessTokenInUrl(repoUrl, connection.Token)
+	if err != nil {
+		return "", err
+	}
+
+	return newUrl, nil
+}
+
 func EnrichOptions(taskCtx plugin.TaskContext,
 	op *tasks.GithubOptions,
 	apiClient *helper.ApiClient) errors.Error {
@@ -341,4 +370,25 @@ func convertApiRepoToScope(repo *tasks.GithubApiRepo, connectionId uint64) *mode
 	scope.FullName = repo.FullName
 	scope.CloneUrl = repo.CloneUrl
 	return &scope
+}
+
+func replaceAcessTokenInUrl(gitURL, newCredential string) (string, errors.Error) {
+	atIndex := strings.Index(gitURL, "@")
+	if atIndex == -1 {
+		return "", errors.Default.New("Invalid Git URL")
+	}
+
+	protocolIndex := strings.Index(gitURL, "://")
+	if protocolIndex == -1 {
+		return "", errors.Default.New("Invalid Git URL")
+	}
+
+	// Extract the base URL (e.g., "https://git:")
+	baseURL := gitURL[:protocolIndex+7]
+
+	repoURL := gitURL[atIndex+1:]
+
+	modifiedURL := fmt.Sprintf("%s%s@%s", baseURL, newCredential, repoURL)
+
+	return modifiedURL, nil
 }

--- a/backend/plugins/gitlab/api/blueprint_V200_test.go
+++ b/backend/plugins/gitlab/api/blueprint_V200_test.go
@@ -130,6 +130,9 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 					Name:              gitlabProjectName,
 					PathWithNamespace: pathWithNamespace,
 					HttpUrlToRepo:     httpUrlToRepo,
+					Scope: common.Scope{
+						ConnectionId:		connectionID,
+					},
 				},
 				ScopeConfig: scopeConfig,
 			},
@@ -166,6 +169,8 @@ func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 					"name":     gitlabProjectName,
 					"fullName": pathWithNamespace,
 					"url":      "https://git:nddtf@this_is_cloneUrl",
+					"connectionId": connectionID,
+					"pluginName": pluginName,
 				},
 			},
 		},

--- a/backend/plugins/gitlab/api/blueprint_v200.go
+++ b/backend/plugins/gitlab/api/blueprint_v200.go
@@ -136,13 +136,13 @@ func makePipelinePlanV200(
 			stage = append(stage, &coreModels.PipelineTask{
 				Plugin: "gitextractor",
 				Options: map[string]interface{}{
-					"url":      cloneUrl.String(),
-					"name":     gitlabProject.Name,
-					"fullName": gitlabProject.PathWithNamespace,
-					"repoId":   didgen.NewDomainIdGenerator(&models.GitlabProject{}).Generate(connection.ID, gitlabProject.GitlabId),
-					"proxy":    connection.Proxy,
+					"url":          cloneUrl.String(),
+					"name":         gitlabProject.Name,
+					"fullName":     gitlabProject.PathWithNamespace,
+					"repoId":       didgen.NewDomainIdGenerator(&models.GitlabProject{}).Generate(connection.ID, gitlabProject.GitlabId),
+					"proxy":        connection.Proxy,
 					"connectionId": gitlabProject.ConnectionId,
-					"pluginName": 	"gitlab",
+					"pluginName":   "gitlab",
 				},
 			})
 		}

--- a/backend/plugins/gitlab/api/blueprint_v200.go
+++ b/backend/plugins/gitlab/api/blueprint_v200.go
@@ -141,6 +141,8 @@ func makePipelinePlanV200(
 					"fullName": gitlabProject.PathWithNamespace,
 					"repoId":   didgen.NewDomainIdGenerator(&models.GitlabProject{}).Generate(connection.ID, gitlabProject.GitlabId),
 					"proxy":    connection.Proxy,
+					"connectionId": gitlabProject.ConnectionId,
+					"pluginName": 	"gitlab",
 				},
 			})
 		}


### PR DESCRIPTION
### Summary
- According to [github documentation](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app) the installation access token expire after 1 hour. This commit generates a new installation access token at the start of each gitextractor task avoiding the auth error that happens for pipelines that last more than 1 hour.

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/7958

### Screenshots
Before the fix:
<img width="1461" alt="image" src="https://github.com/user-attachments/assets/37725c81-a8a4-4369-9ede-b22a13bc9df9">

After the fix: The pipeline lasts more than 1 hour and the gitextractor tasks keep working
<img width="801" alt="image" src="https://github.com/user-attachments/assets/80e09387-69e6-46b5-8fd4-b26e18771fcb">


### Other Information
I understand that this solution is not the most efficient, since for each gitextractor task it will generate new tokens even when the current token is still valid. However, I believe it can be used as a temporary solution to enable the use of Github App without problems.

For a more efficient solution, we could generate a new token only when it has reached its expiration time.
Analyzing the code, I believe that the expiration time of this token needs to be persisted in the database in order to be accessed when preparing the task. What do you think? I may be evolving this solution in another new PR.
