### PR TITLE
feat(framework): skip to update progress of subtasks

### DIFF
--- a/backend/core/runner/run_task.go
+++ b/backend/core/runner/run_task.go
@@ -351,6 +351,9 @@ func RunPluginSubTasks(
 
 // UpdateProgressDetail FIXME ...
 func UpdateProgressDetail(basicRes context.BasicRes, taskId uint64, progressDetail *models.TaskProgressDetail, p *plugin.RunningProgress) {
+	cfg := basicRes.GetConfigReader()
+	skipSubtaskProgressUpdate := cfg.GetBool("SKIP_SUBTASK_PROGRESS")
+
 	task := &models.Task{
 		Model: common.Model{ID: taskId},
 	}
@@ -377,6 +380,9 @@ func UpdateProgressDetail(basicRes context.BasicRes, taskId uint64, progressDeta
 		progressDetail.SubTaskNumber = p.SubTaskNumber
 		// reset finished records
 		progressDetail.FinishedRecords = 0
+	}
+	if skipSubtaskProgressUpdate {
+		return
 	}
 	currentFinishedRecords := progressDetail.FinishedRecords
 	currentTotalRecords := progressDetail.TotalRecords

--- a/env.example
+++ b/env.example
@@ -27,6 +27,8 @@ DB_URL=mysql://merico:merico@mysql:3306/lake?charset=utf8mb4&parseTime=True&loc=
 E2E_DB_URL=mysql://merico:merico@mysql:3306/lake_test?charset=utf8mb4&parseTime=True&loc=UTC
 # Silent Error Warn Info
 DB_LOGGING_LEVEL=Error
+# Skip to update progress of subtasks, default is false (#8142)
+SKIP_SUBTASK_PROGRESS=false
 
 # Lake REST API
 PORT=8080


### PR DESCRIPTION
- add env SKIP_SUBTASK_PROGRESS to decide wether skip subtask progress updating to db

#8142

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
To further reduce the impact caused by the expansion of the subtask table, I have added another environment variable that allows selectively skipping the subtask progress update operation.

#8142 

### Screenshots
set `SKIP_SUBTASK_PROGRESS=true`  
![image](https://github.com/user-attachments/assets/9cd6884a-3d07-4995-a555-3a7460b988d4)  
![image](https://github.com/user-attachments/assets/847f61d7-0c43-4333-af61-989e1786e1f0)

unset `SKIP_SUBTASK_PROGRESS`  
![image](https://github.com/user-attachments/assets/0a4dd020-2df2-4aee-9692-7e9dcb011141)


### Other Information
There were too many logs `skip subtask progress update`, so I removed the log finally.
