### PR TITLE
fix: onboard / configure connection's plugin name is fixed to GitHub

### DIFF
--- a/config-ui/src/routes/onboard/step-2.tsx
+++ b/config-ui/src/routes/onboard/step-2.tsx
@@ -108,17 +108,23 @@ export const Step2 = () => {
     return null;
   }
 
+  const platformNames: Record<string, string> = {
+    github: 'GitHub',
+    gitlab: 'GitLab',
+    azuredevops: 'Azure DevOps',
+  }
+
   return (
     <>
       <S.StepContent>
-        {['github', 'gitlab', 'azuredevops'].includes(plugin) && (
+        {platformNames[plugin] && (
           <div className="content">
             <ConnectionToken
               type="create"
               label="Personal Access Token"
               subLabel={
                 <p>
-                  Create a personal access token in GitHub. For self-managed {config.name}, please skip the onboarding
+                  Create a personal access token in {platformNames[plugin]}. For self-managed {config.name}, please skip the onboarding
                   and configure via <Link to={'/connections'}>Data Connections</Link>.
                 </p>
               }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/4f6b3fb6-6cc2-4564-8f69-e1f936602ba1)
