### PR TITLE
fix(backend): update Makefile to include version prefix in go-dep command

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -26,7 +26,7 @@ PYTHON_DIR ?= "./python"
 all: build
 
 go-dep:
-	go install github.com/vektra/mockery/v2@2.43.0
+	go install github.com/vektra/mockery/v2@v2.43.0
 	go install github.com/swaggo/swag/cmd/swag@v1.16.1
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.53.3
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Fixes the issue in the `go-dep` make command where the version prefix was missing, ensuring consistent dependency installation.

### How to Reproduce?
```
cd backend
make go-dep                                                                        
go install github.com/vektra/mockery/v2@2.43.0
go: github.com/vektra/mockery/v2@2.43.0: github.com/vektra/mockery/v2@2.43.0: invalid version: unknown revision 2.43.0
make: *** [go-dep] Error 1
```