### PR TITLE
fix: start date of sprint is empty

### DIFF
--- a/backend/plugins/jira/e2e/sprint_test.go
+++ b/backend/plugins/jira/e2e/sprint_test.go
@@ -44,6 +44,7 @@ func TestSprintDataFlow(t *testing.T) {
 	// verify sprint extraction
 	dataflowTester.FlushTabler(&models.JiraSprint{})
 	dataflowTester.FlushTabler(&models.JiraBoardSprint{})
+	dataflowTester.FlushTabler(&models.JiraServerInfo{})
 	dataflowTester.Subtask(tasks.ExtractSprintsMeta, taskData)
 	dataflowTester.VerifyTable(
 		models.JiraSprint{},

--- a/backend/plugins/jira/tasks/apiv2models/sprint.go
+++ b/backend/plugins/jira/tasks/apiv2models/sprint.go
@@ -37,22 +37,17 @@ type Sprint struct {
 
 func (s Sprint) ToToolLayer(connectionId uint64, isServer bool) *models.JiraSprint {
 	sprint := &models.JiraSprint{
-		ConnectionId: connectionId,
-		SprintId:     s.ID,
-		Self:         s.Self,
-		State:        s.State,
-		Name:         s.Name,
-		// StartDate:     s.StartDate,
+		ConnectionId:  connectionId,
+		SprintId:      s.ID,
+		Self:          s.Self,
+		State:         s.State,
+		Name:          s.Name,
+		StartDate:     s.StartDate,
 		EndDate:       s.EndDate,
 		CompleteDate:  s.CompleteDate,
 		OriginBoardID: s.OriginBoardID,
 	}
-	// jira cloud
-	if !isServer {
-		sprint.StartDate = s.StartDate
-	}
-	// jira server
-	if isServer && s.ActivatedDate != nil {
+	if s.ActivatedDate != nil {
 		sprint.StartDate = s.ActivatedDate
 	}
 	return sprint


### PR DESCRIPTION
[Bug][Jira] start_date Field Empty in sprint Table After Upgrading DevLake from 0.21 to 1.0 with Jira Plugin #8221

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?

### Does this close any open issues?
Closes #8221 

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
