### PR TITLE
fix(github): Exclude Draft Releases in the ReleaseExtractor

### DIFF
--- a/backend/plugins/github_graphql/tasks/release_extractor.go
+++ b/backend/plugins/github_graphql/tasks/release_extractor.go
@@ -55,7 +55,9 @@ func ExtractReleases(taskCtx plugin.SubTaskContext) errors.Error {
 			if err != nil {
 				return nil, err
 			}
-
+			if release.IsDraft {
+				return nil, nil
+			}
 			var results []interface{}
 			githubRelease, err := convertGitHubRelease(release, data.Options.ConnectionId, data.Options.GithubId)
 			if err != nil {


### PR DESCRIPTION
### Summary
Exclude Draft Releases in ReleaseExtractor to avoid bug due to malformed PublishedAt field.

### Does this close any open issues?
Closes #8148

