### PR TITLE
fix(tapd): fix overflow when converting lead time minutes

### DIFF
--- a/backend/plugins/tapd/tasks/bug_converter.go
+++ b/backend/plugins/tapd/tasks/bug_converter.go
@@ -18,6 +18,7 @@ limitations under the License.
 package tasks
 
 import (
+	"math"
 	"reflect"
 	"strconv"
 	"time"
@@ -88,8 +89,12 @@ func ConvertBug(taskCtx plugin.SubTaskContext) errors.Error {
 				results = append(results, issueAssignee)
 			}
 			if domainL.ResolutionDate != nil && domainL.CreatedDate != nil {
-				temp := uint(domainL.ResolutionDate.Sub(*domainL.CreatedDate).Minutes())
-				domainL.LeadTimeMinutes = &temp
+				durationInMinutes := domainL.ResolutionDate.Sub(*domainL.CreatedDate).Minutes()
+				// we have found some issues' ResolutionDate is earlier than CreatedDate in tapd.
+				if durationInMinutes > 0 && durationInMinutes < math.MaxUint {
+					temp := uint(durationInMinutes)
+					domainL.LeadTimeMinutes = &temp
+				}
 			}
 			boardIssue := &ticket.BoardIssue{
 				BoardId: getWorkspaceIdGen().Generate(toolL.ConnectionId, toolL.WorkspaceId),


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
fix overflow when converting lead time minutes.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
