### PR TITLE
fix(zentao): make sure connection uncacheable

### DIFF
--- a/backend/core/plugin/plugin_datasource.go
+++ b/backend/core/plugin/plugin_datasource.go
@@ -41,6 +41,11 @@ type CacheableConnection interface {
 	GetHash() string
 }
 
+type UnCacheableConnection interface {
+	ApiConnection
+	UncCacheable() bool
+}
+
 // ApiAuthenticator is to be implemented by a Concreate Connection if Authorization is required
 type ApiAuthenticator interface {
 	// SetupAuthentication is a hook function for connection to set up authentication for the HTTP request

--- a/backend/core/plugin/plugin_datasource.go
+++ b/backend/core/plugin/plugin_datasource.go
@@ -41,11 +41,6 @@ type CacheableConnection interface {
 	GetHash() string
 }
 
-type UnCacheableConnection interface {
-	ApiConnection
-	UncCacheable() bool
-}
-
 // ApiAuthenticator is to be implemented by a Concreate Connection if Authorization is required
 type ApiAuthenticator interface {
 	// SetupAuthentication is a hook function for connection to set up authentication for the HTTP request

--- a/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
+++ b/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
@@ -40,7 +40,7 @@ type DsRemoteApiProxyHelper[C plugin.ToolLayerApiConnection] struct {
 
 // NewDsRemoteApiProxyHelper creates a new DsRemoteApiProxyHelper
 func NewDsRemoteApiProxyHelper[
-	C plugin.ToolLayerApiConnection,
+C plugin.ToolLayerApiConnection,
 ](
 	modelApiHelper *ModelApiHelper[C],
 ) *DsRemoteApiProxyHelper[C] {
@@ -67,7 +67,7 @@ func (rap *DsRemoteApiProxyHelper[C]) prepare(input *plugin.ApiResourceInput) (*
 func (rap *DsRemoteApiProxyHelper[C]) getApiClient(connection *C) (*ApiClient, errors.Error) {
 	c := interface{}(connection)
 	key := ""
-	var cacheable bool = false
+	cacheable := true
 	if unCacheableConnection, ok := c.(plugin.UnCacheableConnection); ok {
 		cacheable = !unCacheableConnection.UncCacheable()
 	}

--- a/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
+++ b/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
@@ -39,11 +39,7 @@ type DsRemoteApiProxyHelper[C plugin.ToolLayerApiConnection] struct {
 }
 
 // NewDsRemoteApiProxyHelper creates a new DsRemoteApiProxyHelper
-func NewDsRemoteApiProxyHelper[
-	C plugin.ToolLayerApiConnection,
-](
-	modelApiHelper *ModelApiHelper[C],
-) *DsRemoteApiProxyHelper[C] {
+func NewDsRemoteApiProxyHelper[C plugin.ToolLayerApiConnection](modelApiHelper *ModelApiHelper[C]) *DsRemoteApiProxyHelper[C] {
 	return &DsRemoteApiProxyHelper[C]{
 		ModelApiHelper:       modelApiHelper,
 		logger:               modelApiHelper.basicRes.GetLogger().Nested("remote_api_helper"),
@@ -67,7 +63,7 @@ func (rap *DsRemoteApiProxyHelper[C]) prepare(input *plugin.ApiResourceInput) (*
 func (rap *DsRemoteApiProxyHelper[C]) getApiClient(connection *C) (*ApiClient, errors.Error) {
 	c := interface{}(connection)
 	key := ""
-	var cacheable bool = false
+	var cacheable = false
 	if unCacheableConnection, ok := c.(plugin.UnCacheableConnection); ok {
 		cacheable = !unCacheableConnection.UncCacheable()
 	}

--- a/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
+++ b/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
@@ -40,7 +40,7 @@ type DsRemoteApiProxyHelper[C plugin.ToolLayerApiConnection] struct {
 
 // NewDsRemoteApiProxyHelper creates a new DsRemoteApiProxyHelper
 func NewDsRemoteApiProxyHelper[
-C plugin.ToolLayerApiConnection,
+	C plugin.ToolLayerApiConnection,
 ](
 	modelApiHelper *ModelApiHelper[C],
 ) *DsRemoteApiProxyHelper[C] {
@@ -67,7 +67,7 @@ func (rap *DsRemoteApiProxyHelper[C]) prepare(input *plugin.ApiResourceInput) (*
 func (rap *DsRemoteApiProxyHelper[C]) getApiClient(connection *C) (*ApiClient, errors.Error) {
 	c := interface{}(connection)
 	key := ""
-	cacheable := true
+	var cacheable bool = false
 	if unCacheableConnection, ok := c.(plugin.UnCacheableConnection); ok {
 		cacheable = !unCacheableConnection.UncCacheable()
 	}

--- a/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
+++ b/backend/helpers/pluginhelper/api/ds_remote_api_proxy_api.go
@@ -63,15 +63,11 @@ func (rap *DsRemoteApiProxyHelper[C]) prepare(input *plugin.ApiResourceInput) (*
 func (rap *DsRemoteApiProxyHelper[C]) getApiClient(connection *C) (*ApiClient, errors.Error) {
 	c := interface{}(connection)
 	key := ""
-	var cacheable = false
-	if unCacheableConnection, ok := c.(plugin.UnCacheableConnection); ok {
-		cacheable = !unCacheableConnection.UncCacheable()
-	}
 	if cacheableConn, ok := c.(plugin.CacheableConnection); ok {
 		key = cacheableConn.GetHash()
 	}
 	// try to reuse api client
-	if key != "" && cacheable {
+	if key != "" {
 		rap.httpClientCacheMutex.RLock()
 		client, ok := rap.httpClientCache[key]
 		rap.httpClientCacheMutex.RUnlock()
@@ -86,7 +82,7 @@ func (rap *DsRemoteApiProxyHelper[C]) getApiClient(connection *C) (*ApiClient, e
 		return nil, err
 	}
 	// cache the client if key is not empty
-	if key != "" && cacheable {
+	if key != "" {
 		rap.httpClientCacheMutex.Lock()
 		rap.httpClientCache[key] = client
 		rap.httpClientCacheMutex.Unlock()

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -73,9 +73,9 @@ type ZentaoConn struct {
 	DbMaxConns     int    `json:"dbMaxConns" mapstructure:"dbMaxConns"`
 }
 
-func (connection ZentaoConn) UncCacheable() bool {
+func (connection ZentaoConn) GetHash() string {
 	// zentao's token will expire after about 24min, so api client cannot be cached.
-	return true
+	return ""
 }
 
 func (connection ZentaoConn) Sanitize() ZentaoConn {
@@ -111,8 +111,8 @@ func (connection ZentaoConn) SanitizeDbUrl() string {
 	return dbUrl
 }
 
-func (connection ZentaoConnection) UncCacheable() bool {
-	return connection.ZentaoConn.UncCacheable()
+func (connection ZentaoConnection) GetHash() string {
+	return connection.ZentaoConn.GetHash()
 }
 
 func (connection ZentaoConnection) Sanitize() ZentaoConnection {

--- a/backend/plugins/zentao/models/connection.go
+++ b/backend/plugins/zentao/models/connection.go
@@ -73,6 +73,11 @@ type ZentaoConn struct {
 	DbMaxConns     int    `json:"dbMaxConns" mapstructure:"dbMaxConns"`
 }
 
+func (connection ZentaoConn) UncCacheable() bool {
+	// zentao's token will expire after about 24min, so api client cannot be cached.
+	return true
+}
+
 func (connection ZentaoConn) Sanitize() ZentaoConn {
 	connection.Password = ""
 	if connection.DbUrl != "" {
@@ -104,6 +109,10 @@ func (connection ZentaoConn) SanitizeDbUrl() string {
 		dbUrl = ""
 	}
 	return dbUrl
+}
+
+func (connection ZentaoConnection) UncCacheable() bool {
+	return connection.ZentaoConn.UncCacheable()
 }
 
 func (connection ZentaoConnection) Sanitize() ZentaoConnection {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
According to https://www.zentao.net/book/api/664.html#6, zentao's token will expire after 24 min. If users try to list scopes after 24 min, the api client will get a response with http status code 401.
This PR just makes sure zentao connections uncacheable.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
