### PR TITLE
chore: resetting main to v1.0 - remove main protection

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -48,14 +48,14 @@ github:
   # delete origin branch after merged
   del_branch_on_merge: true
   protected_branches:
-    main:
-      required_status_checks:
-        # strict means "Require branches to be up to date before merging".
-        strict: true
-        # contexts are the names of checks that must pass
-        #contexts:
-        #  - gh-infra/jenkins
-        #  - another/build-that-must-pass
+    # main:
+    #   required_status_checks:
+    #     # strict means "Require branches to be up to date before merging".
+    #     strict: true
+    #     # contexts are the names of checks that must pass
+    #     #contexts:
+    #     #  - gh-infra/jenkins
+    #     #  - another/build-that-must-pass
 
       required_pull_request_reviews:
         dismiss_stale_reviews: true


### PR DESCRIPTION
# Summary

Currently, the default `main` branch points to the `development` branch which confuses new contributors when they try to fix some minor issues during setup. After some discussion, we decided to switch it to the `stable` branch to make things easier for everybody.

# Plan

1. Remove protection from `main` branch
2. Reset it to `release-v1.0` branch
3. Publish a new branch named `next` (for development)

# Impact

1. Bugfixes go to the `main` branch, then optionally create another PR to the `next` branch.
2. New features go to the `next` branch
3. Maintainer would cherry-pick necessary bugfixes to the `next` branch before releasing.