### PR TITLE
fix(tapd): fix panic when casting fields

### DIFF
--- a/backend/plugins/tapd/tasks/story_changelog_extractor.go
+++ b/backend/plugins/tapd/tasks/story_changelog_extractor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/tapd/models"
+	"github.com/spf13/cast"
 )
 
 var _ plugin.SubTaskEntryPoint = ExtractStoryChangelog
@@ -81,12 +82,13 @@ func ExtractStoryChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 						item.ConnectionId = data.Options.ConnectionId
 						item.ChangelogId = storyChangelog.Id
 						item.Field = k
-						item.ValueAfterParsed = v.(string)
+						item.ValueAfterParsed = cast.ToString(v)
 						switch valueBeforeMap.(type) {
 						case map[string]interface{}:
-							item.ValueBeforeParsed = valueBeforeMap.(map[string]interface{})[k].(string)
+							value := valueBeforeMap.(map[string]interface{})[k]
+							item.ValueBeforeParsed = cast.ToString(value)
 						default:
-							item.ValueBeforeParsed = valueBeforeMap.(string)
+							item.ValueBeforeParsed = cast.ToString(valueBeforeMap)
 						}
 						err = convertUnicode(&item)
 						if err != nil {
@@ -98,9 +100,9 @@ func ExtractStoryChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 					item.ConnectionId = data.Options.ConnectionId
 					item.ChangelogId = storyChangelog.Id
 					item.Field = fc.Field
-					item.ValueAfterParsed = valueAfterMap.(string)
+					item.ValueAfterParsed = cast.ToString(valueAfterMap)
 					// as ValueAfterParsed is string, valueBeforeMap is always string
-					item.ValueBeforeParsed = valueBeforeMap.(string)
+					item.ValueBeforeParsed = cast.ToString(valueBeforeMap)
 				}
 				err = convertUnicode(&item)
 				if err != nil {

--- a/backend/plugins/tapd/tasks/story_changelog_extractor.go
+++ b/backend/plugins/tapd/tasks/story_changelog_extractor.go
@@ -83,9 +83,9 @@ func ExtractStoryChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 						item.ChangelogId = storyChangelog.Id
 						item.Field = k
 						item.ValueAfterParsed = cast.ToString(v)
-						switch valueBeforeMap.(type) {
+						switch v := valueBeforeMap.(type) {
 						case map[string]interface{}:
-							value := valueBeforeMap.(map[string]interface{})[k]
+							value := v[k]
 							item.ValueBeforeParsed = cast.ToString(value)
 						default:
 							item.ValueBeforeParsed = cast.ToString(valueBeforeMap)

--- a/backend/plugins/tapd/tasks/task_changelog_extractor.go
+++ b/backend/plugins/tapd/tasks/task_changelog_extractor.go
@@ -84,9 +84,9 @@ func ExtractTaskChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 						item.ChangelogId = taskChangelog.Id
 						item.Field = k
 						item.ValueAfterParsed = cast.ToString(v)
-						switch valueBeforeMap.(type) {
+						switch v := valueBeforeMap.(type) {
 						case map[string]interface{}:
-							value := valueBeforeMap.(map[string]interface{})[k]
+							value := v[k]
 							item.ValueBeforeParsed = cast.ToString(value)
 						default:
 							item.ValueBeforeParsed = cast.ToString(valueBeforeMap)

--- a/backend/plugins/tapd/tasks/task_changelog_extractor.go
+++ b/backend/plugins/tapd/tasks/task_changelog_extractor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/plugin"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/tapd/models"
+	"github.com/spf13/cast"
 	"strings"
 )
 
@@ -82,12 +83,13 @@ func ExtractTaskChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 						item.ConnectionId = data.Options.ConnectionId
 						item.ChangelogId = taskChangelog.Id
 						item.Field = k
-						item.ValueAfterParsed = v.(string)
+						item.ValueAfterParsed = cast.ToString(v)
 						switch valueBeforeMap.(type) {
 						case map[string]interface{}:
-							item.ValueBeforeParsed = valueBeforeMap.(map[string]interface{})[k].(string)
+							value := valueBeforeMap.(map[string]interface{})[k]
+							item.ValueBeforeParsed = cast.ToString(value)
 						default:
-							item.ValueBeforeParsed = valueBeforeMap.(string)
+							item.ValueBeforeParsed = cast.ToString(valueBeforeMap)
 						}
 						results = append(results, &item)
 					}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Fix panic when casting fields in tapd.

In tapd, some datas are like:
```
"field_changes":
        [
            {
                "field": "secret_root_id",
                "field_label": "label_name",
                "value_after":
                {
                    "allow_list": "dw;1234;dw",
                    "secret_root_id": "1156232825001092299",
                    "participant_fields": "1"
                },
                "value_before":
                {
                    "allow_list": "",
                    "secret_root_id": 0,
                    "participant_fields": "0"
                },
                "secret_root_id": "1234",
                "value_after_parsed":
                {
                    "allow_list": "dw;123;dw",
                    "secret_root_id": "12345",
                    "participant_fields": "1"
                },
                "value_before_parsed":
                {
                    "allow_list": "",
                    "secret_root_id": "0",
                    "participant_fields": "0"
                }
            }
        ]
```
Field `participant_fields` can be float or string type depending on its location.  This PR just handles these cases.

### Does this close any open issues?
Closes N/A

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
