### PR TITLE
fix: scope config api token leaking

### DIFF
--- a/backend/helpers/srvhelper/scope_service_helper.go
+++ b/backend/helpers/srvhelper/scope_service_helper.go
@@ -220,6 +220,9 @@ func (scopeSrv *ScopeSrvHelper[C, S, SC]) getAllBlueprinsByScope(connectionId ui
 			scopeId,
 		),
 	))
+	for _, bp := range blueprints {
+		bp.Plan = nil
+	}
 	return blueprints
 }
 


### PR DESCRIPTION
### Summary
Remove the plan field from the blueprint when outputting scope.

### Does this close any open issues?
Closes #8215

