### PR TITLE
fix(tapd): ignore step changes in story changelog

### DIFF
--- a/backend/plugins/tapd/models/story_changelog.go
+++ b/backend/plugins/tapd/models/story_changelog.go
@@ -49,6 +49,9 @@ type TapdStoryChangelogItemRes struct {
 	ValueAfter        json.RawMessage `json:"value_after"`
 	IterationIdFrom   int64
 	IterationIdTo     int64
+	IsStepChange      bool   `json:"is_step_change"`
+	Step              string `json:"step"`
+	StepAlias         string `json:"step_alias"`
 	common.NoPKModel
 }
 

--- a/backend/plugins/tapd/tasks/story_changelog_extractor.go
+++ b/backend/plugins/tapd/tasks/story_changelog_extractor.go
@@ -55,6 +55,11 @@ func ExtractStoryChangelog(taskCtx plugin.SubTaskContext) errors.Error {
 
 			storyChangelog.ConnectionId = data.Options.ConnectionId
 			for _, fc := range storyChangelog.FieldChanges {
+				if fc.IsStepChange {
+					// ignore step change
+					// https://github.com/apache/incubator-devlake/issues/8355#issuecomment-2756726463
+					continue
+				}
 				var item models.TapdStoryChangelogItem
 				var valueAfterMap interface{}
 				var valueBeforeMap interface{}


### PR DESCRIPTION
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
- Add IsStepChange, Step, and StepAlias fields to TapdStoryChangelogItemRes
- Modify ExtractStoryChangelog task to skip step change events

### Does this close any open issues?
- This change addresses the issue described in https://github.com/apache/incubator-devlake/issues/8355
Closes #8355

### Screenshots
Include any relevant screenshots here.
