### PR TITLE
fix: add notifications to discussions

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -77,3 +77,4 @@ notifications:
   commits: commits@devlake.apache.org
   issues:  dev@devlake.apache.org
   pullrequests: commits@devlake.apache.org
+  discussions: dev@devlake.apache.org


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
fix: add notifications to discussions

### Does this close any open issues?
Closes #8347 

### Screenshots
![image](https://github.com/user-attachments/assets/67a347a8-1f2a-435c-9c93-0360e08e4936)
