### PR TITLE
fixing running git clone multiple times

### DIFF
--- a/backend/plugins/dbt/tasks/git.go
+++ b/backend/plugins/dbt/tasks/git.go
@@ -18,9 +18,11 @@ limitations under the License.
 package tasks
 
 import (
+	"os"
+	"os/exec"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
-	"os/exec"
 )
 
 func Git(taskCtx plugin.SubTaskContext) errors.Error {

--- a/backend/plugins/dbt/tasks/git.go
+++ b/backend/plugins/dbt/tasks/git.go
@@ -29,7 +29,16 @@ func Git(taskCtx plugin.SubTaskContext) errors.Error {
 	if data.Options.ProjectGitURL == "" {
 		return nil
 	}
-	cmd := exec.Command("git", "clone", data.Options.ProjectGitURL)
+
+	// clean ProjectPath
+	err := os.RemoveAll(data.Options.ProjectPath)
+	if err != nil {
+		logger.Error(err, "cleanup before clone dbt project failed")
+		return errors.Convert(err)
+	}
+
+	// git clone from ProjectGitURL into ProjectPath
+	cmd := exec.Command("git", "clone", data.Options.ProjectGitURL, data.Options.ProjectPath)
 	logger.Info("start clone dbt project: %v", cmd)
 	out, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
It cleans up the project path for the DBT plugin before running the git clone so that the clone succeeds even if the path already exists

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/8377

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
