### PR TITLE
fix(github_graphql): Update Extract Jobs task to use Check Run instea…

### DIFF
--- a/backend/plugins/github_graphql/tasks/job_collector.go
+++ b/backend/plugins/github_graphql/tasks/job_collector.go
@@ -55,36 +55,38 @@ type GraphqlQueryCheckSuite struct {
 				EndCursor   string `graphql:"endCursor"`
 				HasNextPage bool   `graphql:"hasNextPage"`
 			}
-			Nodes []struct {
-				Id          string
-				Name        string
-				DetailsUrl  string
-				DatabaseId  int
-				Status      string
-				StartedAt   *time.Time
-				Conclusion  string
-				CompletedAt *time.Time
-				//ExternalId   string
-				//Url          string
-				//Title        interface{}
-				//Text         interface{}
-				//Summary      interface{}
-
-				Steps struct {
-					TotalCount int
-					Nodes      []struct {
-						CompletedAt         *time.Time `json:"completed_at"`
-						Conclusion          string     `json:"conclusion"`
-						Name                string     `json:"name"`
-						Number              int        `json:"number"`
-						SecondsToCompletion int        `json:"seconds_to_completion"`
-						StartedAt           *time.Time `json:"started_at"`
-						Status              string     `json:"status"`
-					}
-				} `graphql:"steps(first: 50)"`
-			}
+			Nodes []GraphqlQueryCheckRun
 		} `graphql:"checkRuns(first: $pageSize, after: $skipCursor)"`
 	} `graphql:"... on CheckSuite"`
+}
+
+type GraphqlQueryCheckRun struct {
+	Id          string
+	Name        string
+	DetailsUrl  string
+	DatabaseId  int
+	Status      string
+	StartedAt   *time.Time
+	Conclusion  string
+	CompletedAt *time.Time
+	//ExternalId   string
+	//Url          string
+	//Title        interface{}
+	//Text         interface{}
+	//Summary      interface{}
+
+	Steps struct {
+		TotalCount int
+		Nodes      []struct {
+			CompletedAt         *time.Time `json:"completed_at"`
+			Conclusion          string     `json:"conclusion"`
+			Name                string     `json:"name"`
+			Number              int        `json:"number"`
+			SecondsToCompletion int        `json:"seconds_to_completion"`
+			StartedAt           *time.Time `json:"started_at"`
+			Status              string     `json:"status"`
+		}
+	} `graphql:"steps(first: 50)"`
 }
 
 type SimpleWorkflowRun struct {


### PR DESCRIPTION
…d of Check Suite

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
Refactors CheckRun into separate struct for use in Extract Jobs task.
Uses CheckRun to marshal raw collected jobs instead of CheckSuite
### Does this close any open issues?
Closes #8383

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
