### PR TITLE
refactor: upgrade grafana to v11.6.0

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -23,7 +23,7 @@
 #While incubation status is not necessarily a reflection of the completeness or stability of the code,
 #it does indicate that the project has yet to be fully endorsed by the ASF.
 
-FROM grafana/grafana:11.2.0
+FROM grafana/grafana:11.6.0
 COPY ./provisioning/dashboards /etc/grafana/provisioning/dashboards
 COPY ./provisioning/datasources /etc/grafana/provisioning/datasources
 COPY ./dashboards /etc/grafana/dashboards


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### Summary
Upgrade Grafana to version 11.6.0

### Does this close any open issues?
No

### Screenshots
N.A

### Other Information
It fixes a previous bug in grafana (currently used) to compute median directly in grafana
https://github.com/grafana/grafana/issues/98140
It may offer options to refactor SQL queries in the dashboard (especially the DORA metrics) to gain in performance by moving the median computation in grafana.