### PR TITLE
fix(tapd): correct field mapping for TapdScopeConfig

### DIFF
--- a/backend/plugins/tapd/tasks/task_data.go
+++ b/backend/plugins/tapd/tasks/task_data.go
@@ -31,7 +31,7 @@ type TapdOptions struct {
 	PageSize      uint64                  `json:"pageSize,omitempty" mapstructure:"pageSize,omitempty"`
 	CstZone       *time.Location          `json:"cstZone,omitempty" mapstructure:"cstZone,omitempty"`
 	ScopeConfigId uint64                  `json:"scopeConfigId,omitempty" mapstructure:"scopeConfigId,omitempty"`
-	ScopeConfig   *models.TapdScopeConfig `json:"scopeConfig,omitempty" mapstructure:"pageSize,omitempty"`
+	ScopeConfig   *models.TapdScopeConfig `json:"scopeConfig,omitempty" mapstructure:"scopeConfig,omitempty"`
 }
 
 type TapdTaskData struct {


### PR DESCRIPTION
- Update the mapstructure tag for ScopeConfig field from "pageSize" to "scopeConfig"
- This change ensures proper deserialization of ScopeConfig data in TapdOptions struct

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
