### PR TITLE
fix(extractIssues): return error when mysql connection error happens

### DIFF
--- a/backend/core/dal/dal.go
+++ b/backend/core/dal/dal.go
@@ -241,6 +241,10 @@ type Rows interface {
 	// ColumnTypes returns column information such as column type, length,
 	// and nullable. Some information may not be available from some drivers.
 	ColumnTypes() ([]*sql.ColumnType, error)
+
+	// Err returns the error, if any, that was encountered during iteration.
+	// Err may be called after an explicit or implicit Close method.
+	Err() error
 }
 
 // GetColumnNames returns table Column Names in database

--- a/backend/helpers/pluginhelper/api/api_extractor_stateful.go
+++ b/backend/helpers/pluginhelper/api/api_extractor_stateful.go
@@ -124,7 +124,8 @@ func (extractor *StatefulApiExtractor[InputType]) Execute() errors.Error {
 	if err != nil {
 		return errors.Default.Wrap(err, "error running DB query")
 	}
-	logger.Info("get data from %s where params=%s and got %d", table, params, count)
+	logger.Info("get data from %s where params=%s and got %d with clauses %+v", table, params, count, clauses)
+
 	defer cursor.Close()
 	// batch save divider
 	divider := NewBatchSaveDivider(extractor.SubTaskContext, extractor.GetBatchSize(), table, params)
@@ -182,6 +183,9 @@ func (extractor *StatefulApiExtractor[InputType]) Execute() errors.Error {
 			}
 		}
 		extractor.IncProgress(1)
+	}
+	if err := cursor.Err(); err != nil {
+		return errors.Default.Wrap(err, "error occurred during database cursor iteration in StatefulApiExtractor")
 	}
 
 	// save the last batches


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This PR adds error handling for the database cursor in the `StatefulApiExtractor` by checking for any error that might have occurred during cursor iteration using `cursor.Err()`.
It ensures that any internal cursor error is not silently ignored and properly propagated, improving the reliability and debuggability of the data extraction process.

To support this, the `Err() error` method was added to the Rows interface, allowing concrete cursor implementations to expose iteration errors.

### Does this close any open issues?
https://github.com/apache/incubator-devlake/issues/8198
https://github.com/apache/incubator-devlake/issues/7826


### Screenshots
![image](https://github.com/user-attachments/assets/40d71949-3432-4691-8f4c-218b6be2b64c)


### Other Information
This change was motivated by recurring but hard-to-diagnose errors such as `unexpected EOF` and `busy buffer`, which have been observed during the `extractIssues` step.
These errors do **not** appear in the downloadable pipeline logs, making them difficult to trace, as they are only visible in the application logs.

By explicitly capturing `cursor.Err()`, this PR helps make such issues more visible and traceable in standard pipeline output, improving the overall observability and robustness of the extraction process.
