### PR TITLE
refactor: refactor StatefulApiExtractor to fix busy buffer and EOF errors

### DIFF
--- a/backend/helpers/pluginhelper/api/api_extractor_stateful.go
+++ b/backend/helpers/pluginhelper/api/api_extractor_stateful.go
@@ -125,27 +125,11 @@ func (extractor *StatefulApiExtractor[InputType]) Execute() errors.Error {
 	}
 	logger.Info("get data from %s where params=%s and got %d with clauses %+v", table, params, count, clauses)
 
-	// get cursor for IDs only
-	cursor, err := db.Cursor(clauses...)
-	if err != nil {
-		return errors.Default.Wrap(err, "error running DB query for IDs")
-	}
-	defer cursor.Close()
-
-	// collect all IDs
+	// get all IDs
 	var ids []uint64
-	for cursor.Next() {
-		var row struct {
-			ID uint64 `gorm:"column:id"`
-		}
-		err = db.Fetch(cursor, &row)
-		if err != nil {
-			return errors.Default.Wrap(err, "error fetching ID")
-		}
-		ids = append(ids, row.ID)
-	}
-	if err := cursor.Err(); err != nil {
-		return errors.Default.Wrap(err, "error during ID cursor iteration")
+	err = db.Pluck("id", &ids, clauses...)
+	if err != nil {
+		return errors.Default.Wrap(err, "error getting IDs")
 	}
 
 	// batch save divider


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

### Summary
This PR updates the `StatefulApiExtractor.Execute()` method to avoid using a long-lived cursor while writing to the database. Previously, the cursor was kept open during data iteration and insertions, which led to errors like `unexpected EOF` and `busy buffer`. This change introduces a two-phase process: first, we collect all raw data IDs using a cursor and then close it. After that, each row is loaded individually by ID and processed safely. This avoids concurrency issues with the database connection and improves stability for high-volume data extractions.

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/7826

### Screenshots
Testing with Github connection
![image](https://github.com/user-attachments/assets/f8bd5350-e03b-4bab-9e99-3a6d0a3eb4b8)

Testing with Jira connection
![image](https://github.com/user-attachments/assets/02389f49-2519-491e-9175-74407e00c36d)



### Other Information
This issue was observed during the `extractIssues` step in the Jira plugin. It occurred consistently on subsequent executions of the task, but not on the first run after restarting the application.
This change ensures a more robust extraction flow without requiring increased `max_allowed_packet` settings or other MySQL tuning.


