### PR TITLE
feat(pipeline): add external notifications for pipeline creation and start

### DIFF
--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -292,6 +292,14 @@ func dequeuePipeline(runningParallelLabels []string) (pipeline *models.Pipeline,
 		if err != nil {
 			panic(err)
 		}
+
+		// Notify that the pipeline has started
+		go func(pipelineId uint64) {
+			if notifyErr := NotifyExternal(pipelineId); notifyErr != nil {
+				globalPipelineLog.Error(notifyErr, "failed to send pipeline started notification for pipeline #%d", pipelineId)
+			}
+		}(pipeline.ID)
+
 		return
 	}
 	if tx.IsErrorNotFound(err) {
@@ -363,6 +371,7 @@ func getProjectName(pipeline *models.Pipeline) (string, errors.Error) {
 	}
 	blueprintId := pipeline.BlueprintId
 	if blueprintId == 0 {
+		// skip get project name if pipeline is not bound to a blueprint
 		return "", nil
 	}
 	dbBlueprint := &models.Blueprint{}

--- a/backend/server/services/pipeline_helper.go
+++ b/backend/server/services/pipeline_helper.go
@@ -110,6 +110,14 @@ func CreateDbPipeline(newPipeline *models.NewPipeline) (pipeline *models.Pipelin
 	// update tasks state
 	errors.Must(tx.Update(dbPipeline))
 	dbPipeline.Labels = newPipeline.Labels
+
+	// Notify that the pipeline has been created
+	go func(pipelineId uint64) {
+		if notifyErr := NotifyExternal(pipelineId); notifyErr != nil {
+			globalPipelineLog.Error(notifyErr, "failed to send pipeline created notification for pipeline #%d", pipelineId)
+		}
+	}(dbPipeline.ID)
+
 	return dbPipeline, nil
 }
 


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
- Send notification when a pipeline is created
- Send notification when a pipeline starts
- Notifications are sent asynchronously to avoid delays
- Error logging is implemented for failed notifications

### Does this close any open issues?
Closes #8408

### Screenshots
#### Pipeline created by api.  
![image](https://github.com/user-attachments/assets/2e2a67f9-a86b-431d-8e67-e36e537bbe0a)
![image](https://github.com/user-attachments/assets/508d4d7a-076c-4fcd-bf8e-46493da69d74)
![image](https://github.com/user-attachments/assets/32c3a576-c6c2-478f-8428-b2d713e0f928)

#### Pipeline created cronly
![image](https://github.com/user-attachments/assets/eb142e80-9811-4c08-ad09-e041eeec4bfc)
![image](https://github.com/user-attachments/assets/95a0351f-65b3-430f-a068-ee2d13832c18)
![image](https://github.com/user-attachments/assets/d6516182-b095-43b9-b7cf-00e642c8e4d2)


### Other Information
Any other information that is important to this PR.
