### PR TITLE
feat(customize): clean up qa_apis and qa_test_case_executions when no…

### DIFF
--- a/backend/plugins/customize/e2e/raw_tables/qa_full_test_cases_input.csv
+++ b/backend/plugins/customize/e2e/raw_tables/qa_full_test_cases_input.csv
@@ -1,0 +1,7 @@
+id,name,create_time,creator_name,type,qa_api_id
+tc-1,Full Test Case 1,2023-02-01T10:00:00.000+00:00,user-a,functional,
+tc-2,Full Test Case 2 API,2023-02-02T11:00:00.000+00:00,user-b,api,api-1
+api-1,Test API 1,2023-02-01T10:00:00.000+00:00,user-a,GET,/api/v1/test
+api-2,Test API 2,2023-02-02T11:00:00.000+00:00,user-b,POST,/api/v1/test
+exec-1,tc-1,2023-02-01T10:30:00.000+00:00,2023-02-01T10:35:00.000+00:00,passed,user-a
+exec-2,tc-2,2023-02-02T11:30:00.000+00:00,2023-02-02T11:40:00.000+00:00,failed,user-b

--- a/backend/plugins/customize/e2e/raw_tables/qa_non_api_test_cases.csv
+++ b/backend/plugins/customize/e2e/raw_tables/qa_non_api_test_cases.csv
@@ -1,0 +1,3 @@
+id,name,create_time,creator_name,type,qa_api_id
+tc-1,Functional Test Case 1,2023-02-01T10:00:00.000+00:00,user-a,functional,
+tc-2,Functional Test Case 2,2023-02-02T11:00:00.000+00:00,user-b,functional,

--- a/backend/plugins/customize/service/service.go
+++ b/backend/plugins/customize/service/service.go
@@ -453,11 +453,21 @@ func (s *Service) qaApiHandler(qaProjectId string) func(record map[string]interf
 func (s *Service) ImportQaTestCases(qaProjectId, qaProjectName string, file io.ReadCloser, incremental bool) errors.Error {
 	if !incremental {
 		// delete old data associated with this qaProjectId
+		// delete qa_test_cases
 		err := s.dal.Delete(&qa.QaTestCase{}, dal.Where("qa_project_id = ?", qaProjectId))
 		if err != nil {
 			return errors.Default.Wrap(err, fmt.Sprintf("failed to delete old qa_test_cases for qaProjectId %s", qaProjectId))
 		}
-		// using ImportQaApis to delete data in qa_apis
+		// delete qa_apis
+		err = s.dal.Delete(&qa.QaApi{}, dal.Where("qa_project_id = ?", qaProjectId))
+		if err != nil {
+			return errors.Default.Wrap(err, fmt.Sprintf("failed to delete old qa_apis for qaProjectId %s", qaProjectId))
+		}
+		// delete qa_test_case_executions
+		err = s.dal.Delete(&qa.QaTestCaseExecution{}, dal.Where("qa_project_id = ?", qaProjectId))
+		if err != nil {
+			return errors.Default.Wrap(err, fmt.Sprintf("failed to delete old qa_test_case_executions for qaProjectId %s", qaProjectId))
+		}
 		// never delete data in qa_projects
 	}
 	// create or update qa_projects


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
clean up qa_apis and qa_test_case_executions when non-incremental import qa_test_cases  
- Implement new e2e test case for QA data cleanup functionality
- Add test data files for QA test cases, APIs, and test case executions
- Update ImportQaTestCases method to delete old data for non-incremental imports
- Verify that API data, test cases, and test case executions are properly cleaned up

### Does this close any open issues?
Closes #8444

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
