### PR TITLE
chore: update nginx

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -31,7 +31,7 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM nginxinc/nginx-unprivileged:1.25
+FROM nginxinc/nginx-unprivileged:1.29
 USER 0
 #ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 #RUN chmod +x /wait


### PR DESCRIPTION
Brings in a batch of security fixes (as 1.25 is slowly getting flagged as outdated by security teams)

### Summary
Update nginx to the latest version

### Does this close any open issues?
No

### Screenshots
N/A

### Other Information
N/A
