### PR TITLE
fix(teambition): declare TeambitionRepo struct for Swagger

### DIFF
--- a/backend/plugins/teambition/api/scope_api.go
+++ b/backend/plugins/teambition/api/scope_api.go
@@ -34,7 +34,7 @@ type ScopeDetail api.ScopeDetail[models.TeambitionProject, models.TeambitionScop
 // @Accept application/json
 // @Param connectionId path int true "connection ID"
 // @Param scope body PutScopesReqBody true "json"
-// @Success 200  {object} []models.teambitionRepo
+// @Success 200  {object} []models.TeambitionProject
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/teambition/connections/{connectionId}/scopes [PUT]
@@ -49,8 +49,8 @@ func PutScopes(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, error
 // @Accept application/json
 // @Param connectionId path int true "connection ID"
 // @Param scopeId path int true "scope ID"
-// @Param scope body models.teambitionRepo true "json"
-// @Success 200  {object} models.teambitionRepo
+// @Param scope body models.TeambitionProject true "json"
+// @Success 200  {object} models.TeambitionProject
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 500  {object} shared.ApiBody "Internal Error"
 // @Router /plugins/teambition/connections/{connectionId}/scopes/{scopeId} [PATCH]
@@ -97,7 +97,7 @@ func GetScope(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors
 // @Param connectionId path int true "connection ID"
 // @Param scopeId path int true "scope ID"
 // @Param delete_data_only query bool false "Only delete the scope data, not the scope itself"
-// @Success 200  {object} models.teambitionRepo
+// @Success 200  {object} models.TeambitionProject
 // @Failure 400  {object} shared.ApiBody "Bad Request"
 // @Failure 409  {object} srvhelper.DsRefs "References exist to this scope"
 // @Failure 500  {object} shared.ApiBody "Internal Error"


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
This PR fixes a Swagger generation issue in the teambition plugin caused by a missing or incorrectly referenced type (models.TeambitionRepo).
The TeambitionRepo struct is now properly defined and exported in the models package, allowing swag init to succeed and generate valid API documentation.

-> Helps unblock CI pipelines

### Does this close any open issues?
Closes https://github.com/apache/incubator-devlake/issues/8482

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
