### PR TITLE
bugfix: Data too long for _tool_sonarqube_issue_code_blocks.component

### DIFF
--- a/backend/core/utils/strings.go
+++ b/backend/core/utils/strings.go
@@ -19,9 +19,10 @@ package utils
 
 import (
 	"crypto/rand"
-	"github.com/apache/incubator-devlake/core/errors"
 	"math/big"
 	"strings"
+
+	"github.com/apache/incubator-devlake/core/errors"
 )
 
 const letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
@@ -80,4 +81,19 @@ func SanitizeString(s string) string {
 		prefixLen, suffixLen = 1, 1
 	}
 	return strings.Replace(s, s[prefixLen:strLen-suffixLen], strings.Repeat("*", strLen-prefixLen-suffixLen), -1)
+}
+
+// from https://stackoverflow.com/questions/12311033/extracting-substrings-in-go
+func Substr(input string, start int, length int) string {
+	asRunes := []rune(input)
+
+	if start >= len(asRunes) {
+		return ""
+	}
+
+	if start+length > len(asRunes) {
+		length = len(asRunes) - start
+	}
+
+	return string(asRunes[start : start+length])
 }

--- a/backend/core/utils/strings_test.go
+++ b/backend/core/utils/strings_test.go
@@ -119,3 +119,10 @@ func TestSanitizeString(t *testing.T) {
 		})
 	}
 }
+
+func TestSubstr(t *testing.T) {
+	assert.Equalf(t, "😂😂😂", Substr("😂😂😂a", 0, 3), "substr on utf8")
+	assert.Equalf(t, "c", Substr("😂😂c😂", 2, 1), "substr on lattin + unicode")
+	assert.Equalf(t, "abcde", Substr("abcde", 0, 100), "specified length greater than actual length")
+	assert.Equalf(t, "", Substr("abcde", 100, 100), "specified start greater than actual length")
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -129,6 +129,6 @@ require (
 	golang.org/x/mod v0.17.0
 )
 
-replace github.com/chenzhuoyu/iasm => github.com/cloudwego/iasm v0.2.0
+// replace github.com/chenzhuoyu/iasm => github.com/cloudwego/iasm v0.2.0
 
 //replace github.com/apache/incubator-devlake => ./

--- a/backend/plugins/sonarqube/tasks/issues_extractor.go
+++ b/backend/plugins/sonarqube/tasks/issues_extractor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/utils"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/sonarqube/models"
 )
@@ -81,7 +82,7 @@ func ExtractIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			codeBlockInIssue := &models.SonarqubeIssueCodeBlock{
 				ConnectionId: data.Options.ConnectionId,
 				IssueKey:     sonarqubeIssue.IssueKey,
-				Component:    sonarqubeIssue.Component,
+				Component:    utils.Substr(sonarqubeIssue.Component, 0, 500),
 				Msg:          sonarqubeIssue.Message,
 				StartLine:    sonarqubeIssue.StartLine,
 				EndLine:      sonarqubeIssue.EndLine,


### PR DESCRIPTION
### Summary
Pipeline fails when the SonarQube issue component field exceeds 500.
This PR adds a `Substr`  function to help with similar situations.


### Does this close any open issues?
Closes #8471
