### PR TITLE
fix: patching blueprint with `timeAfter=null` not working

### DIFF
--- a/backend/server/services/blueprint.go
+++ b/backend/server/services/blueprint.go
@@ -221,6 +221,9 @@ func PatchBlueprint(id uint64, body map[string]interface{}) (*models.Blueprint, 
 	if err != nil {
 		return nil, err
 	}
+	if blueprint.SyncPolicy.TimeAfter != nil && blueprint.SyncPolicy.TimeAfter.IsZero() {
+		blueprint.SyncPolicy.TimeAfter = nil
+	}
 
 	blueprint, err = saveBlueprint(blueprint)
 	if err != nil {


### PR DESCRIPTION
### Summary
Patching blueprint with `timeAfter = null` ends up with Zero-Value instead of `nil`

### Does this close any open issues?
Closes #8516

