### PR TITLE
feat(gitlab): add toggle for collecting all users

### DIFF
--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -207,7 +207,11 @@ func (p Gitlab) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	if err := regexEnricher.TryAdd(devops.ENV_NAME_PATTERN, op.ScopeConfig.EnvNamePattern); err != nil {
 		return nil, errors.BadInput.Wrap(err, "invalid value for `envNamePattern`")
 	}
-
+	cfg := taskCtx.GetConfigReader()
+	op.CollectAllUsers = true
+	if cfg.IsSet("GITLAB_SERVER_COLLECT_ALL_USERS") {
+		op.CollectAllUsers = cfg.GetBool("GITLAB_SERVER_COLLECT_ALL_USERS")
+	}
 	taskData := tasks.GitlabTaskData{
 		Options:       op,
 		ApiClient:     apiClient,

--- a/backend/plugins/gitlab/tasks/account_collector.go
+++ b/backend/plugins/gitlab/tasks/account_collector.go
@@ -50,15 +50,15 @@ func CollectAccounts(taskCtx plugin.SubTaskContext) errors.Error {
 	rawDataSubTaskArgs, data := CreateRawDataSubTaskArgs(taskCtx, RAW_USER_TABLE)
 	logger := taskCtx.GetLogger()
 	logger.Info("collect gitlab users")
-
-	// it means we can not use /members/all to get the data
+	options := taskCtx.GetData().(*GitlabTaskData).Options
 	urlTemplate := "/projects/{{ .Params.ProjectId }}/members/all"
 	if semver.Compare(data.ApiClient.GetData(models.GitlabApiClientData_ApiVersion).(string), "v13.11") < 0 {
+		// it means we can not use /members/all to get the data
 		urlTemplate = "/projects/{{ .Params.ProjectId }}/members/"
 	}
 
-	// Collect all users if endpoint is private gitlab instance
-	if !strings.HasPrefix(data.ApiClient.GetEndpoint(), "https://gitlab.com") && !strings.HasPrefix(data.ApiClient.GetEndpoint(), "https://jihulab.com") {
+	// Collect all users if endpoint is private gitlab instance and GITLAB_SERVER_COLLECT_ALL_USERS
+	if !strings.HasPrefix(data.ApiClient.GetEndpoint(), "https://gitlab.com") && !strings.HasPrefix(data.ApiClient.GetEndpoint(), "https://jihulab.com") && options.CollectAllUsers {
 		urlTemplate = "/users"
 	}
 

--- a/backend/plugins/gitlab/tasks/task_data.go
+++ b/backend/plugins/gitlab/tasks/task_data.go
@@ -24,11 +24,12 @@ import (
 )
 
 type GitlabOptions struct {
-	ConnectionId  uint64                    `mapstructure:"connectionId" json:"connectionId"`
-	ProjectId     int                       `mapstructure:"projectId" json:"projectId"`
-	FullName      string                    `mapstructure:"fullName" json:"fullName"`
-	ScopeConfigId uint64                    `mapstructure:"scopeConfigId" json:"scopeConfigId"`
-	ScopeConfig   *models.GitlabScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
+	ConnectionId    uint64                    `mapstructure:"connectionId" json:"connectionId"`
+	ProjectId       int                       `mapstructure:"projectId" json:"projectId"`
+	FullName        string                    `mapstructure:"fullName" json:"fullName"`
+	ScopeConfigId   uint64                    `mapstructure:"scopeConfigId" json:"scopeConfigId"`
+	ScopeConfig     *models.GitlabScopeConfig `mapstructure:"scopeConfig" json:"scopeConfig"`
+	CollectAllUsers bool
 }
 
 type GitlabTaskData struct {

--- a/env.example
+++ b/env.example
@@ -70,6 +70,11 @@ ENDPOINT_CIDR_BLACKLIST=
 FORBID_REDIRECTION=false
 
 ##########################
+# Plugin settings
+##########################
+GITLAB_SERVER_COLLECT_ALL_USERS=true
+
+##########################
 # In plugin gitextractor, use go-git to collector repo's data
 ##########################
 USE_GO_GIT_IN_GIT_EXTRACTOR=false


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
- Add GITLAB_SERVER_COLLECT_ALL_USERS configuration option
- Implement logic to collect all users when enabled
- Update task data and configuration reader to support new option
- Modify account collector to use new option

### Does this close any open issues?
Closes #8523

### Screenshots
#### Default(no GITLAB_SERVER_COLLECT_ALL_USERS set)  
<img width="1228" height="256" alt="image" src="https://github.com/user-attachments/assets/dd8ad5a2-8029-4116-848b-a41a8febfc9e" />
<img width="1738" height="370" alt="image" src="https://github.com/user-attachments/assets/7b7c25cd-b22b-4c1a-8eed-9885f096563e" />

#### When set GITLAB_SERVER_COLLECT_ALL_USERS to false
<img width="1734" height="614" alt="image" src="https://github.com/user-attachments/assets/51a59041-4120-4658-a91d-bfa67bf1cc27" />

### Other Information
Any other information that is important to this PR.
