### PR TITLE
fix(github): fix zerotime issues for GraphQL

### DIFF
--- a/backend/core/utils/time.go
+++ b/backend/core/utils/time.go
@@ -15,33 +15,18 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tasks
+package utils
 
-import (
-	"github.com/apache/incubator-devlake/plugins/github/models"
-)
+import "time"
 
-type GithubAccountEdge struct {
-	Login     string
-	Id        int `graphql:"databaseId"`
-	Name      string
-	Company   string
-	Email     string
-	AvatarUrl string
-	HtmlUrl   string `graphql:"url"`
-}
-type GraphqlInlineAccountQuery struct {
-	GithubAccountEdge `graphql:"... on User"`
-}
-
-func extractGraphqlPreAccount(result *[]interface{}, res *GraphqlInlineAccountQuery, repoId int, connId uint64) {
-	if res == nil || res.Id == 0 {
-		return
+// NilIfZeroTime returns nil if t is nil or represents the zero time (0001-01-01...).
+// Otherwise, it returns t unchanged.
+func NilIfZeroTime(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
 	}
-	*result = append(*result, &models.GithubRepoAccount{
-		ConnectionId: connId,
-		RepoGithubId: repoId,
-		Login:        res.Login,
-		AccountId:    res.Id,
-	})
+	if t.IsZero() {
+		return nil
+	}
+	return t
 }

--- a/backend/core/utils/time_test.go
+++ b/backend/core/utils/time_test.go
@@ -6,7 +6,7 @@ The ASF licenses this file to You under the Apache License, Version 2.0
 (the "License"); you may not use this file except in compliance with
 the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,34 +14,38 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-package tasks
+package utils
 
 import (
-	"github.com/apache/incubator-devlake/plugins/github/models"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
-type GithubAccountEdge struct {
-	Login     string
-	Id        int `graphql:"databaseId"`
-	Name      string
-	Company   string
-	Email     string
-	AvatarUrl string
-	HtmlUrl   string `graphql:"url"`
-}
-type GraphqlInlineAccountQuery struct {
-	GithubAccountEdge `graphql:"... on User"`
-}
-
-func extractGraphqlPreAccount(result *[]interface{}, res *GraphqlInlineAccountQuery, repoId int, connId uint64) {
-	if res == nil || res.Id == 0 {
-		return
+func TestNilIfZeroTime(t *testing.T) {
+	type args struct {
+		t *time.Time
 	}
-	*result = append(*result, &models.GithubRepoAccount{
-		ConnectionId: connId,
-		RepoGithubId: repoId,
-		Login:        res.Login,
-		AccountId:    res.Id,
-	})
+	tests := []struct {
+		name string
+		args args
+		want *time.Time
+	}{
+		{
+			name: "Empty date should be nil",
+			args: args{nil},
+			want: nil,
+		},
+		{
+			name: "Zero date should be nil",
+			args: args{&time.Time{}},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, NilIfZeroTime(tt.args.t), "NilIfZeroTime(%v)", tt.args.t)
+		})
+	}
 }

--- a/backend/plugins/github/models/release.go
+++ b/backend/plugins/github/models/release.go
@@ -25,25 +25,25 @@ import (
 
 type GithubRelease struct {
 	common.NoPKModel `json:"-" mapstructure:"-"`
-	ConnectionId     uint64    `json:"connection_id" gorm:"primaryKey"`
-	GithubId         int       `json:"github_id"`
-	Id               string    `json:"id" gorm:"type:varchar(255);primaryKey"`
-	AuthorName       string    `json:"authorName"`
-	AuthorID         string    `json:"authorId"`
-	CreatedAt        time.Time `json:"createdAt"`
-	DatabaseID       int       `json:"databaseId"`
-	Description      string    `json:"description"`
-	DescriptionHTML  string    `json:"descriptionHTML"`
-	IsDraft          bool      `json:"isDraft"`
-	IsLatest         bool      `json:"isLatest"`
-	IsPrerelease     bool      `json:"isPrerelease"`
-	Name             string    `json:"name"`
-	PublishedAt      time.Time `json:"publishedAt"`
-	ResourcePath     string    `json:"resourcePath"`
-	TagName          string    `json:"tagName"`
-	UpdatedAt        time.Time `json:"updatedAt"`
-	CommitSha        string    `json:"commit_sha"`
-	URL              string    `json:"url"`
+	ConnectionId     uint64     `json:"connection_id" gorm:"primaryKey"`
+	GithubId         int        `json:"github_id"`
+	Id               string     `json:"id" gorm:"type:varchar(255);primaryKey"`
+	AuthorName       string     `json:"authorName"`
+	AuthorID         string     `json:"authorId"`
+	CreatedAt        time.Time  `json:"createdAt"`
+	DatabaseID       int        `json:"databaseId"`
+	Description      string     `json:"description"`
+	DescriptionHTML  string     `json:"descriptionHTML"`
+	IsDraft          bool       `json:"isDraft"`
+	IsLatest         bool       `json:"isLatest"`
+	IsPrerelease     bool       `json:"isPrerelease"`
+	Name             string     `json:"name"`
+	PublishedAt      *time.Time `json:"publishedAt"`
+	ResourcePath     string     `json:"resourcePath"`
+	TagName          string     `json:"tagName"`
+	UpdatedAt        time.Time  `json:"updatedAt"`
+	CommitSha        string     `json:"commit_sha"`
+	URL              string     `json:"url"`
 }
 
 func (GithubRelease) TableName() string {

--- a/backend/plugins/github/tasks/release_convertor.go
+++ b/backend/plugins/github/tasks/release_convertor.go
@@ -73,7 +73,7 @@ func ConvertRelease(taskCtx plugin.SubTaskContext) errors.Error {
 				DomainEntity: domainlayer.DomainEntity{
 					Id: releaseIdGen.Generate(githubRelease.ConnectionId, githubRelease.Id),
 				},
-				PublishedAt:  githubRelease.PublishedAt,
+				PublishedAt:  *githubRelease.PublishedAt,
 				CicdScopeId:  releaseScopeIdGen.Generate(githubRelease.ConnectionId, githubRelease.GithubId),
 				Name:         githubRelease.Name,
 				DisplayTitle: githubRelease.Name,

--- a/backend/plugins/github_graphql/tasks/account_collector.go
+++ b/backend/plugins/github_graphql/tasks/account_collector.go
@@ -40,14 +40,13 @@ type GraphqlQueryAccountWrapper struct {
 }
 
 type GraphqlQueryAccount struct {
-	Login     string
-	Id        int `graphql:"databaseId"`
-	Name      string
-	Company   string
-	Email     string
-	AvatarUrl string
-	HtmlUrl   string `graphql:"url"`
-	//Type      string
+	Login         string
+	Id            int `graphql:"databaseId"`
+	Name          string
+	Company       string
+	Email         string
+	AvatarUrl     string
+	HtmlUrl       string `graphql:"url"`
 	Organizations struct {
 		Nodes []struct {
 			Email      string

--- a/backend/plugins/github_graphql/tasks/issue_collector.go
+++ b/backend/plugins/github_graphql/tasks/issue_collector.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/utils"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	githubTasks "github.com/apache/incubator-devlake/plugins/github/tasks"
@@ -134,6 +135,7 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			query := queryWrapper.(*GraphqlQueryIssueWrapper)
 			issues := query.Repository.IssueList.Issues
 			for _, rawL := range issues {
+				rawL.ClosedAt = utils.NilIfZeroTime(rawL.ClosedAt)
 				if since != nil && since.After(rawL.UpdatedAt) {
 					return messages, api.ErrFinishCollect
 				}

--- a/backend/plugins/github_graphql/tasks/issue_extractor.go
+++ b/backend/plugins/github_graphql/tasks/issue_extractor.go
@@ -25,6 +25,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/utils"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	githubTasks "github.com/apache/incubator-devlake/plugins/github/tasks"
@@ -68,6 +69,8 @@ func ExtractIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			if err != nil {
 				return nil, err
 			}
+			// Normalize zero-date to nil for closedAt
+			issue.ClosedAt = utils.NilIfZeroTime(issue.ClosedAt)
 			results := make([]interface{}, 0, 1)
 			githubIssue, err := convertGithubIssue(milestoneMap, issue, data.Options.ConnectionId, data.Options.GithubId)
 			if err != nil {

--- a/backend/plugins/github_graphql/tasks/job_extractor.go
+++ b/backend/plugins/github_graphql/tasks/job_extractor.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/devops"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/utils"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/github/models"
 	githubTasks "github.com/apache/incubator-devlake/plugins/github/tasks"
@@ -57,7 +58,9 @@ func ExtractJobs(taskCtx plugin.SubTaskContext) errors.Error {
 				return nil, err
 			}
 			results := make([]interface{}, 0, 1)
-
+			// Normalize zero-date times to nil
+			checkRun.StartedAt = utils.NilIfZeroTime(checkRun.StartedAt)
+			checkRun.CompletedAt = utils.NilIfZeroTime(checkRun.CompletedAt)
 			paramsBytes, marshalError := json.Marshal(checkRun.Steps.Nodes)
 			err = errors.Convert(marshalError)
 			if err != nil {

--- a/backend/plugins/github_graphql/tasks/release_collector.go
+++ b/backend/plugins/github_graphql/tasks/release_collector.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/utils"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	githubTasks "github.com/apache/incubator-devlake/plugins/github/tasks"
 	"github.com/merico-dev/graphql"
@@ -66,7 +67,7 @@ type GraphqlQueryRelease struct {
 	IsLatest        bool                         `graphql:"isLatest"`
 	IsPrerelease    bool                         `graphql:"isPrerelease"`
 	Name            string                       `graphql:"name"`
-	PublishedAt     time.Time                    `graphql:"publishedAt"`
+	PublishedAt     *time.Time                   `graphql:"publishedAt"`
 	ResourcePath    string                       `graphql:"resourcePath"`
 	TagName         string                       `graphql:"tagName"`
 	TagCommit       GraphqlQueryReleaseTagCommit `graphql:"tagCommit"`
@@ -125,6 +126,7 @@ func CollectRelease(taskCtx plugin.SubTaskContext) errors.Error {
 			query := queryWrapper.(*GraphqlQueryReleaseWrapper)
 			releases := query.Repository.Releases.Releases
 			for _, rawL := range releases {
+				rawL.PublishedAt = utils.NilIfZeroTime(rawL.PublishedAt)
 				if since != nil && since.After(rawL.UpdatedAt) {
 					return messages, helper.ErrFinishCollect
 				}

--- a/backend/plugins/github_graphql/tasks/release_extractor.go
+++ b/backend/plugins/github_graphql/tasks/release_extractor.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/core/utils"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	githubModels "github.com/apache/incubator-devlake/plugins/github/models"
 	githubTasks "github.com/apache/incubator-devlake/plugins/github/tasks"
@@ -55,7 +56,7 @@ func ExtractReleases(taskCtx plugin.SubTaskContext) errors.Error {
 			if err != nil {
 				return nil, err
 			}
-
+			release.PublishedAt = utils.NilIfZeroTime(release.PublishedAt)
 			var results []interface{}
 			githubRelease, err := convertGitHubRelease(release, data.Options.ConnectionId, data.Options.GithubId)
 			if err != nil {

--- a/backend/plugins/q_dev/models/migrationscripts/20250320_modify_file_meta.go
+++ b/backend/plugins/q_dev/models/migrationscripts/20250320_modify_file_meta.go
@@ -51,7 +51,7 @@ func (*modifyFileMetaTable) Up(basicRes context.BasicRes) errors.Error {
 			return errors.Default.Wrap(err, "failed to load column metadata for _tool_q_dev_s3_file_meta.processed_time")
 		}
 		if len(cols) == 0 {
-			// If column is not visible in metadata, treat as no processing needed 
+			// If column is not visible in metadata, treat as no processing needed
 			return nil
 		}
 		if nullable, ok := cols[0].Nullable(); ok {


### PR DESCRIPTION
### Summary
GitHub GraphQL returns zero time (`&time.Time{}`) for `nullable` fields, this leads to GORM not properly handling this cases.
This PR:
- Introduces a new core helper util `NilIfZeroTime` in order to ensure that `*time.Time` fields are assigned the `nil` value.
- Fixes the relevant cases in both collectors and extractors (as existing entries in the DB should be properly handled as well).


### Does this close any open issues?
Closes #8538 

### Screenshots
⚠️  Screenshots pending, as this PR has not been tested yet.

⚠️  This PR has not been tested yet, I am looking for cases to properly test the fixes ⚠️ 
