### PR TITLE
fix(github): fix token handling to use the first token from a comma-separated list

### DIFF
--- a/backend/plugins/github/impl/impl.go
+++ b/backend/plugins/github/impl/impl.go
@@ -267,7 +267,7 @@ func (p Github) GetDynamicGitUrl(taskCtx plugin.TaskContext, connectionId uint64
 		return "", err
 	}
 
-	newUrl, err := replaceAcessTokenInUrl(repoUrl, connection.Token)
+	newUrl, err := replaceAcessTokenInUrl(repoUrl, strings.Split(connection.Token, ",")[0])
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Fixed the handling of cases where multiple access tokens are registered.

### Does this close any open issues?
Closes #8424 (already closed)

### Screenshots
![pipeline_log_v103beta4](https://github.com/user-attachments/assets/e0556fa4-9164-4f32-b857-f43401051de8)
A screenshot of v1.0.3-beta4 with four access tokens, showing that the password portion of the URL is too long.


### Other Information
It would be better to use tokens in order or randomly, but this time I prioritized the fix.