### PR TITLE
fix(plugins): fix raw table schemas and cleanup legacy table structures in testmo

### DIFF
--- a/backend/plugins/testmo/models/migrationscripts/20250905_fix_raw_table_names_and_schemas.go
+++ b/backend/plugins/testmo/models/migrationscripts/20250905_fix_raw_table_names_and_schemas.go
@@ -1,0 +1,69 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+type fixRawTableNamesAndSchemas struct{}
+
+func (*fixRawTableNamesAndSchemas) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+
+	legacy := []string{
+		"testmo_projects",
+		"testmo_milestones",
+		"testmo_automation_runs",
+		"testmo_runs",
+	}
+	for _, tbl := range legacy {
+		if db.HasTable(tbl) {
+			if err := db.DropTables(tbl); err != nil {
+				return err
+			}
+		}
+	}
+
+	current := []string{
+		"_raw_testmo_projects",
+		"_raw_testmo_milestones",
+		"_raw_testmo_automation_runs",
+		"_raw_testmo_runs",
+	}
+	for _, tbl := range current {
+		if db.HasTable(tbl) {
+			err := db.All(&[]struct{}{}, dal.From(tbl), dal.Where("_raw_data_table = '' AND 1 = 0"))
+			if err != nil {
+				if dropErr := db.DropTables(tbl); dropErr != nil {
+					return dropErr
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (*fixRawTableNamesAndSchemas) Version() uint64 { return 20250905000001 }
+func (*fixRawTableNamesAndSchemas) Name() string    { return "Fix raw table names and schemas" }
+
+var _ plugin.MigrationScript = (*fixRawTableNamesAndSchemas)(nil)

--- a/backend/plugins/testmo/models/migrationscripts/archived/run.go
+++ b/backend/plugins/testmo/models/migrationscripts/archived/run.go
@@ -19,6 +19,8 @@ package archived
 
 import (
 	"time"
+
+	corearchived "github.com/apache/incubator-devlake/core/models/migrationscripts/archived"
 )
 
 type TestmoRun struct {
@@ -40,9 +42,8 @@ type TestmoRun struct {
 	TestmoCreatedAt *time.Time `json:"created_at"`
 	TestmoUpdatedAt *time.Time `json:"updated_at"`
 
-	// Inline definition of NoPKModel
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	// Include standard NoPKModel with RawDataOrigin columns
+	corearchived.NoPKModel
 }
 
 func (TestmoRun) TableName() string {

--- a/backend/plugins/testmo/models/migrationscripts/register.go
+++ b/backend/plugins/testmo/models/migrationscripts/register.go
@@ -24,5 +24,6 @@ func All() []plugin.MigrationScript {
 		new(addInitTables),
 		new(addScopeConfigIdToProjects),
 		new(replaceTestsWithRuns),
+		new(fixRawTableNamesAndSchemas),
 	}
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
The PR fixes this error in the pipeline for the testmo plugin, when using a new database:
```
subtask extractRuns ended unexpectedly Wraps: (2) error getting batch from result (500) Wraps: (3) Error 1054 (42S22): Unknown column '_raw_data_table' in 'where clause' (500) Wraps: (4) Error 1054 (42S22): Unknown column '_raw_data_table' in 'where clause' Error types: (1) *hintdetail.withDetail (2) *hintdetail.withDetail (3) *hintdetail.withDetail (4) *mysql.MySQLError
```

I had performed tests on my previous PR with an existing mysql database, which contained more tables than it should have. This cleans up the old tables and makes sure everything is proper.

### Does this close any open issues?
n/a

### Screenshots
n/a

### Other Information
Validated with both an existing mySQL db and a fresh new one.