### PR TITLE
fix(gitlab): fix remote project api page

### DIFF
--- a/backend/plugins/gitlab/api/remote_api.go
+++ b/backend/plugins/gitlab/api/remote_api.go
@@ -78,7 +78,7 @@ func listGitlabRemoteScopes(
 	// no more groups, start to load projects under the group
 	var moreChild []dsmodels.DsRemoteApiScopeListEntry[models.GitlabProject]
 	moreChild, nextPage, err = listGitlabRemoteProjects(connection, apiClient, groupId, GitlabRemotePagination{
-		Page:    1,
+		Page:    page.Page,
 		PerPage: page.PerPage,
 		Step:    "project",
 	})


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
This PR fixes a hardcoded page value in the GitLab remote API pagination logic. The code was previously hardcoded to start pagination from page 1, which could cause issues with proper pagination handling when users specify different starting pages or when resuming from a specific page.

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
