### PR TITLE
feat: allow setting originalEnvironment in webhook deployments

### DIFF
--- a/backend/plugins/webhook/api/deployments.go
+++ b/backend/plugins/webhook/api/deployments.go
@@ -39,11 +39,12 @@ import (
 )
 
 type WebhookDeploymentReq struct {
-	Id           string `mapstructure:"id" validate:"required"`
-	DisplayTitle string `mapstructure:"displayTitle"`
-	Result       string `mapstructure:"result"`
-	Environment  string `validate:"omitempty,oneof=PRODUCTION STAGING TESTING DEVELOPMENT"`
-	Name         string `mapstructure:"name"`
+	Id                  string `mapstructure:"id" validate:"required"`
+	DisplayTitle        string `mapstructure:"displayTitle"`
+	Result              string `mapstructure:"result"`
+	Environment         string `validate:"omitempty,oneof=PRODUCTION STAGING TESTING DEVELOPMENT"`
+	OriginalEnvironment string `mapstructure:"originalEnvironment"`
+	Name                string `mapstructure:"name"`
 	// DeploymentCommits is used for multiple commits in one deployment
 	DeploymentCommits []WebhookDeploymentCommitReq `mapstructure:"deploymentCommits" validate:"omitempty,dive"`
 	CreatedDate       *time.Time                   `mapstructure:"createdDate"`
@@ -219,7 +220,7 @@ func CreateDeploymentAndDeploymentCommits(connection *models.WebhookConnection, 
 			DisplayTitle:        commit.DisplayTitle,
 			RepoUrl:             commit.RepoUrl,
 			Environment:         request.Environment,
-			OriginalEnvironment: request.Environment,
+			OriginalEnvironment: request.OriginalEnvironment,
 			RefName:             commit.RefName,
 			CommitSha:           commit.CommitSha,
 			CommitMsg:           commit.CommitMsg,


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

### Summary
Allows setting originalEnvironment when posting deployment to the webhook endpoint. 

### Does this close any open issues?
No

### Screenshots
Include any relevant screenshots here.

### Other Information
It is helpful when deploying applications to know the specific infrastructure the app is deployed to. Currently we work around this by parsing the Id or title but being able to set this in the `original_environment` column makes a lot more sense.


~~Also - the PR template suggest I add labels to this PR but I am unable to do so :(~~