### PR TITLE
unify JIRA epic collector to v3 API; build: add CONTAINER_CMD/PLATFORM vars for cross-arch builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,15 +21,17 @@ SHA ?= $(shell if [ -d .git ]; then git show -s --format=%h; else echo "unknown_
 TAG ?= $(shell if [ -d .git ]; then git tag --points-at HEAD; else echo "local_build"; fi)
 IMAGE_REPO ?= "apache"
 VERSION = $(TAG)@$(SHA)
+CONTAINER_CMD ?= docker
+PLATFORM ?= linux/amd64
 
 build-server-image:
 	make build-server-image -C backend
 
 build-config-ui-image:
-	cd config-ui; docker build -t $(IMAGE_REPO)/devlake-config-ui:$(TAG) --file ./Dockerfile .
+	cd config-ui; $(CONTAINER_CMD) build --platform=$(PLATFORM) -t $(IMAGE_REPO)/devlake-config-ui:$(TAG) --file ./Dockerfile .
 
 build-grafana-image:
-	cd grafana; docker build -t $(IMAGE_REPO)/devlake-dashboard:$(TAG) --file ./backend/Dockerfile .
+	cd grafana; $(CONTAINER_CMD) build --platform=$(PLATFORM) -t $(IMAGE_REPO)/devlake-dashboard:$(TAG) --file ./Dockerfile .
 
 build-images: build-server-image build-config-ui-image build-grafana-image
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -69,13 +69,17 @@ RUN for arch in aarch64 x86_64 ; do \
         if [ "$arch" = "aarch64" ] ; then \
             cmake .. -DCMAKE_C_COMPILER=aarch64-linux-gnu-gcc \
                 -DBUILD_SHARED_LIBS=ON -DCMAKE_SYSROOT=/rootfs-arm64 \
-                -DCMAKE_INSTALL_PREFIX=/usr/local/deps/${arch} ; \
+                -DCMAKE_INSTALL_PREFIX=/usr/local/deps/${arch} \
+                -DCMAKE_C_FLAGS="-Wno-incompatible-pointer-types" \
+                -DUSE_BUNDLED_ZLIB=ON ; \
         elif [ "$arch" = "x86_64" ] ; then \
             cmake .. -DCMAKE_C_COMPILER=x86_64-linux-gnu-gcc \
                 -DBUILD_SHARED_LIBS=ON -DCMAKE_SYSROOT=/rootfs-amd64 \
-                -DCMAKE_INSTALL_PREFIX=/usr/local/deps/${arch} ; \
+                -DCMAKE_INSTALL_PREFIX=/usr/local/deps/${arch} \
+                -DCMAKE_C_FLAGS="-Wno-incompatible-pointer-types" \
+                -DUSE_BUNDLED_ZLIB=ON ; \
         fi && \
-        make -j install ; \
+        make install -j ; \
     done
 
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -22,6 +22,8 @@ TAG ?= $(shell if [ -d .git ]; then git tag --points-at HEAD; else echo "local_b
 IMAGE_REPO ?= "apache"
 VERSION = $(TAG)@$(SHA)
 PYTHON_DIR ?= "./python"
+CONTAINER_CMD ?= docker
+PLATFORM ?= linux/amd64
 
 
 all: build
@@ -106,7 +108,7 @@ clean:
 	@rm -rf bin
 
 build-server-image:
-	docker build -t $(IMAGE_REPO)/devlake:$(TAG) --build-arg TAG=$(TAG) --build-arg SHA=$(SHA) --file ./Dockerfile .
+	$(CONTAINER_CMD) build --platform=$(PLATFORM) -t $(IMAGE_REPO)/devlake:$(TAG) --build-arg TAG=$(TAG) --build-arg SHA=$(SHA) --file ./Dockerfile .
 
 migration-script-lint:
 	go run core/migration/linter/main.go -- $$(find . -path '**/migrationscripts/**.go')


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [X] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [X] I have added relevant documentation.
- [X] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

---

### Summary
This PR improves container build flexibility and unifies the JIRA epic collector to use the v3 `/search/jql` endpoint exclusively.

**Key changes:**
- **Makefiles**
  - Introduces `CONTAINER_CMD` (defaults to `docker`) and `PLATFORM` (defaults to `linux/amd64`) for flexible builds across environments.
  - Updates all `docker build` commands to respect `$(CONTAINER_CMD)` and `--platform=$(PLATFORM)`.
- **Backend Dockerfile**
  - Adds `-Wno-incompatible-pointer-types` and `USE_BUNDLED_ZLIB=ON` to CMake flags for stable cross-compile of `libgit2`.
  - Simplifies `make install -j` invocation.
- **JIRA Epic Collector**
  - Removes `api/2/search` (Server/DC) collector path.
  - Always uses the `api/3/search/jql` endpoint.
  - Inlines next-page handling via `nextPageToken` and removes redundant v2/v3 helper functions.

---

### Does this close any open issues?
- #8563 still broken for people according to the comments.

---

### Screenshots
N/A

---

### Other Information
#### Motivation
- Jira Collection broken against atlassian.net