### PR TITLE
fix(pipeline): fix priority

### DIFF
--- a/backend/core/models/migrationscripts/20251022_fix_null_priority.go
+++ b/backend/core/models/migrationscripts/20251022_fix_null_priority.go
@@ -1,0 +1,67 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var _ plugin.MigrationScript = (*fixNullPriority)(nil)
+
+type fixNullPriority struct{}
+
+type blueprint20251022 struct {
+	Priority int `json:"priority"`
+}
+
+func (blueprint20251022) TableName() string {
+	return "_devlake_blueprints"
+}
+
+type pipeline20251022 struct {
+	Priority int `json:"priority"`
+}
+
+func (pipeline20251022) TableName() string {
+	return "_devlake_pipelines"
+}
+
+func (*fixNullPriority) Up(basicRes context.BasicRes) errors.Error {
+	// Set default value 0 for NULL priority values in existing rows
+	db := basicRes.GetDal()
+	err := db.UpdateColumn(&blueprint20251022{}, "priority", 0, dal.Where("priority IS NULL"))
+	if err != nil {
+		return err
+	}
+	err = db.UpdateColumn(&pipeline20251022{}, "priority", 0, dal.Where("priority IS NULL"))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (*fixNullPriority) Version() uint64 {
+	return 20251022195645
+}
+
+func (*fixNullPriority) Name() string {
+	return "fix null priority values in blueprints and pipelines"
+}

--- a/backend/core/models/migrationscripts/register.go
+++ b/backend/core/models/migrationscripts/register.go
@@ -140,5 +140,6 @@ func All() []plugin.MigrationScript {
 		new(extendFieldSizeForCq),
 		new(addIssueFixVerion),
 		new(addPipelinePriority),
+		new(fixNullPriority),
 	}
 }


### PR DESCRIPTION
### Summary
After upgrading from `v1.0.2-beta8` to `v1.0.3-beta7`, DevLake instances crash on startup with the following error:
```
│ [GIN-debug] Listening and serving HTTP on :8080                                                      │
│ panic: sql: Scan error on column index 0, name "priority": converting NULL to int is unsupported (50 │
│ Wraps: (2) sql: Scan error on column index 0, name "priority"                                        │
│ Wraps: (3) converting NULL to int is unsupported                                                     │
│ Error types: (1) *hintdetail.withDetail (2) *fmt.wrapError (3) *errors.errorString                   │
│                                                                                                      │
│ goroutine 116 [running]:                                                                             │
│ github.com/apache/incubator-devlake/server/services.dequeuePipeline({0x2c8cb78, 0x0, 0x0})           │
│     /app/server/services/pipeline.go:270 +0x10d3                                                     │
│ github.com/apache/incubator-devlake/server/services.RunPipelineInQueue(0x1)                          │
│     /app/server/services/pipeline.go:335 +0x42c                                                      │
│ created by github.com/apache/incubator-devlake/server/services.pipelineServiceInit                   │
│     /app/server/services/pipeline.go:112 +0x23d
```
This occurs in `dequeuePipeline()` when attempting to query the priority column.
The migration script `20250813_add_pipeline_priority.go` adds the priority column to existing tables but doesn't set default values for existing rows, leaving them as `NULL`. 
When the pipeline service queries these `NULL` values into Go's int type (which is not nullable), it causes a panic.

### Does this close any open issues?
Closes #8621 
