### PR TITLE
fix: add nil check for PublishedAt in release converter to prevent panic

### DIFF
--- a/backend/plugins/github/tasks/release_convertor.go
+++ b/backend/plugins/github/tasks/release_convertor.go
@@ -72,6 +72,10 @@ func ConvertRelease(taskCtx plugin.SubTaskContext) errors.Error {
 		RawDataSubTaskArgs: *rawDataSubTaskArgs,
 		Convert: func(inputRow interface{}) ([]interface{}, errors.Error) {
 			githubRelease := inputRow.(*models.GithubRelease)
+			// Skip releases with nil PublishedAt (draft releases or data inconsistency)
+			if githubRelease.PublishedAt == nil {
+				return nil, nil
+			}
 			release := &devops.CicdRelease{
 				DomainEntity: domainlayer.DomainEntity{
 					Id: releaseIdGen.Generate(githubRelease.ConnectionId, githubRelease.Id),


### PR DESCRIPTION
## Summary

This PR fixes a nil pointer dereference panic in the GitHub plugin's release converter that was introduced in commit 794f8efcd.

**Fixes:** #8629

## Problem

The recent commit [794f8efcd](https://github.com/apache/incubator-devlake/commit/794f8efcd7f8dbb7f0ddc7da9929f436f33f1e56) added a SQL filter to exclude draft releases (`published_at IS NOT NULL`) but failed to add a defensive nil check before dereferencing the `PublishedAt` pointer in the converter function.

This caused runtime panics when processing certain releases where the `PublishedAt` field was unexpectedly nil, despite the SQL filter. This affected all repositories with releases, with a 100% failure rate at step 30/30 ("Convert Releases").

**Error:**
```
runtime error: invalid memory address or nil pointer dereference
at github.com/apache/incubator-devlake/plugins/github/tasks.ConvertRelease.func1:79
```

## Solution

Add a nil check that safely skips releases with nil `PublishedAt`, maintaining the original intent of excluding draft releases while preventing the panic.

**Change:**
```go
// Skip releases with nil PublishedAt (draft releases or data inconsistency)
if githubRelease.PublishedAt == nil {
    return nil, nil
}
```

## Impact

- **Affected tasks:** All GitHub GraphQL plugin tasks processing repositories with releases
- **Severity:** Critical - causes 100% failure for affected pipelines
- **Fix type:** Defensive programming - adds nil check before pointer dereference
- **Data loss:** None - fix is backwards compatible

## Testing

Verified locally by:
1. Analyzing 10 failed pipeline tasks (all with same error)
2. Applying the fix
3. Confirming no syntax errors

Recommended verification:
- Rerun affected pipeline tasks after merge
- Monitor logs for successful completion of "Convert Releases" subtask

## Related

- Fixes: #8629
- Related to: 794f8efcd (fix: drafting releases should not be converted to domain layer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)