### PR TITLE
fix(devcontainer): make Config UI and Grafana accessible from host when using devcontainers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,6 @@
  * limitations under the License.
  *
  */
-
 {
   "name": "Go",
   "dockerComposeFile": "docker-compose.yml",
@@ -36,6 +35,10 @@
     4000,
     8080
   ],
+  "containerEnv": {
+    "VITE_GRAFANA_URL": "http://grafana:3000",
+    "VITE_GRAFANA_CHANGE_ORIGIN": "false"
+  },
   "postCreateCommand": "npm install commitizen -g",
   "customizations": {
     "vscode": {

--- a/config-ui/package.json
+++ b/config-ui/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "packageManager": "yarn@3.4.1",
   "scripts": {
-    "start": "vite",
+    "start": "vite --host --strictPort",
     "build": "vite build",
     "preview": "vite preview",
     "lint": "tsc && eslint . --fix",

--- a/config-ui/vite.config.ts
+++ b/config-ui/vite.config.ts
@@ -21,6 +21,10 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import svgr from 'vite-plugin-svgr';
 
+// Allow Grafana access from the dev server when using dev container 
+const grafanaOrigin = process.env.VITE_GRAFANA_URL || 'http://localhost:3002';
+const grafanaChangeOrigin = envBool('VITE_GRAFANA_CHANGE_ORIGIN', true);
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), svgr()],
@@ -36,8 +40,9 @@ export default defineConfig({
         rewrite: (path) => path.replace(/^\/api\//, ''),
       },
       '/grafana': {
-        target: 'http://localhost:3002/',
-        changeOrigin: true,
+        target: grafanaOrigin,
+        changeOrigin: grafanaChangeOrigin,
+        ws: true // Proxying websockets to allow features like query auto-complete
       },
     },
   },
@@ -48,3 +53,9 @@ export default defineConfig({
     },
   },
 });
+
+function envBool(name: string, defaultValue = false): boolean {
+  const v = process.env[name];
+  if (v == null) return defaultValue;
+  return /^(1|true|yes|on)$/i.test(v);
+}


### PR DESCRIPTION

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Make config-ui dev server accessible outside the container when started by listening on 0.0.0.0 with the `--host` flag.
Also ensure it uses port 4000 or fails to start with `--strictPort` to prevent silent port change that will mismatch with the exported dev container port.

In addition, it makes Grafana accessible from dev container' config-ui by making the Grafana origin and origin change configurable and injected via the dev container environment variables.

web socket proxying (ws) is enabled regardless of dev container or not as it allows for features like grafana query auto-complete to work via the dev server proxy.

### Does this close any open issues?
Closes [#8638](https://github.com/apache/incubator-devlake/issues/8638)
