### PR TITLE
fix(github): made token expiration fields nullable

### DIFF
--- a/backend/plugins/github/models/connection.go
+++ b/backend/plugins/github/models/connection.go
@@ -56,13 +56,13 @@ type GithubConn struct {
 	helper.MultiAuth      `mapstructure:",squash"`
 	GithubAccessToken     `mapstructure:",squash" authMethod:"AccessToken"`
 	GithubAppKey          `mapstructure:",squash" authMethod:"AppKey"`
-	RefreshToken          string    `mapstructure:"refreshToken" json:"refreshToken" gorm:"type:text;serializer:encdec"`
-	TokenExpiresAt        time.Time `mapstructure:"tokenExpiresAt" json:"tokenExpiresAt"`
-	RefreshTokenExpiresAt time.Time `mapstructure:"refreshTokenExpiresAt" json:"refreshTokenExpiresAt"`
+	RefreshToken          string     `mapstructure:"refreshToken" json:"refreshToken" gorm:"type:text;serializer:encdec"`
+	TokenExpiresAt        *time.Time `mapstructure:"tokenExpiresAt" json:"tokenExpiresAt"`
+	RefreshTokenExpiresAt *time.Time `mapstructure:"refreshTokenExpiresAt" json:"refreshTokenExpiresAt"`
 }
 
 // UpdateToken updates the token and refresh token information
-func (conn *GithubConn) UpdateToken(newToken, newRefreshToken string, expiry, refreshExpiry time.Time) {
+func (conn *GithubConn) UpdateToken(newToken, newRefreshToken string, expiry, refreshExpiry *time.Time) {
 	conn.Token = newToken
 	conn.RefreshToken = newRefreshToken
 	conn.TokenExpiresAt = expiry

--- a/backend/plugins/github/models/migrationscripts/20260211_modify_connection_token_expires_at_to_nullable.go
+++ b/backend/plugins/github/models/migrationscripts/20260211_modify_connection_token_expires_at_to_nullable.go
@@ -1,0 +1,52 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"time"
+
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+)
+
+type githubConnection20260211 struct {
+	TokenExpiresAt        *time.Time
+	RefreshTokenExpiresAt *time.Time
+}
+
+func (githubConnection20260211) TableName() string {
+	return "_tool_github_connections"
+}
+
+type modifyTokenExpiresAtToNullable struct{}
+
+func (*modifyTokenExpiresAtToNullable) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(
+		basicRes,
+		&githubConnection20260211{},
+	)
+}
+
+func (*modifyTokenExpiresAtToNullable) Version() uint64 {
+	return 20260211000001
+}
+
+func (*modifyTokenExpiresAtToNullable) Name() string {
+	return "modify token_expires_at and refresh_token_expires_at to nullable"
+}

--- a/backend/plugins/github/models/migrationscripts/register.go
+++ b/backend/plugins/github/models/migrationscripts/register.go
@@ -56,5 +56,6 @@ func All() []plugin.MigrationScript {
 		new(changeIssueComponentType),
 		new(addIndexToGithubJobs),
 		new(addRefreshTokenFields),
+		new(modifyTokenExpiresAtToNullable),
 	}
 }

--- a/backend/plugins/github/token/round_tripper_test.go
+++ b/backend/plugins/github/token/round_tripper_test.go
@@ -36,6 +36,7 @@ func TestRoundTripper401Refresh(t *testing.T) {
 	mockRT := new(MockRoundTripper)
 	client := &http.Client{Transport: mockRT}
 
+	expiry := time.Now().Add(10 * time.Minute) // Not expired
 	conn := &models.GithubConnection{
 		GithubConn: models.GithubConn{
 			RefreshToken: "refresh_token",
@@ -44,7 +45,7 @@ func TestRoundTripper401Refresh(t *testing.T) {
 					Token: "old_token",
 				},
 			},
-			TokenExpiresAt: time.Now().Add(10 * time.Minute), // Not expired
+			TokenExpiresAt: &expiry,
 			GithubAppKey: models.GithubAppKey{
 				AppKey: api.AppKey{
 					AppId:     "123",

--- a/backend/plugins/github/token/token_provider_test.go
+++ b/backend/plugins/github/token/token_provider_test.go
@@ -55,15 +55,18 @@ func TestNeedsRefresh(t *testing.T) {
 	}
 
 	// Not expired, outside buffer
-	tp.conn.TokenExpiresAt = time.Now().Add(10 * time.Minute)
+	expiry1 := time.Now().Add(10 * time.Minute)
+	tp.conn.TokenExpiresAt = &expiry1
 	assert.False(t, tp.needsRefresh())
 
 	// Inside buffer
-	tp.conn.TokenExpiresAt = time.Now().Add(1 * time.Minute)
+	expiry2 := time.Now().Add(1 * time.Minute)
+	tp.conn.TokenExpiresAt = &expiry2
 	assert.True(t, tp.needsRefresh())
 
 	// Expired
-	tp.conn.TokenExpiresAt = time.Now().Add(-1 * time.Minute)
+	expiry3 := time.Now().Add(-1 * time.Minute)
+	tp.conn.TokenExpiresAt = &expiry3
 	assert.True(t, tp.needsRefresh())
 
 	// No refresh token
@@ -75,10 +78,11 @@ func TestTokenProviderConcurrency(t *testing.T) {
 	mockRT := new(MockRoundTripper)
 	client := &http.Client{Transport: mockRT}
 
+	expired := time.Now().Add(-1 * time.Minute) // Expired
 	conn := &models.GithubConnection{
 		GithubConn: models.GithubConn{
 			RefreshToken:   "refresh_token",
-			TokenExpiresAt: time.Now().Add(-1 * time.Minute), // Expired
+			TokenExpiresAt: &expired,
 			GithubAppKey: models.GithubAppKey{
 				AppKey: api.AppKey{
 					AppId:     "123",
@@ -129,11 +133,13 @@ func TestConfigurableBuffer(t *testing.T) {
 	}
 
 	// 9 minutes remaining (inside 10m buffer)
-	tp.conn.TokenExpiresAt = time.Now().Add(9 * time.Minute)
+	expiry9 := time.Now().Add(9 * time.Minute)
+	tp.conn.TokenExpiresAt = &expiry9
 	assert.True(t, tp.needsRefresh())
 
 	// 11 minutes remaining (outside 10m buffer)
-	tp.conn.TokenExpiresAt = time.Now().Add(11 * time.Minute)
+	expiry11 := time.Now().Add(11 * time.Minute)
+	tp.conn.TokenExpiresAt = &expiry11
 	assert.False(t, tp.needsRefresh())
 }
 


### PR DESCRIPTION
### Summary
What does this PR do?

This PR fixes a MySQL datetime error that occurs when creating GitHub connections with Personal Access Tokens (PATs). The fix modifies the `token_expires_at` and `refresh_token_expires_at` columns in the `_tool_github_connections` table to be nullable.

**The Problem:**
- MySQL rejects `'0000-00-00'` datetime values with error: `Error 1292 (22007): Incorrect datetime value: '0000-00-00' for column 'token_expires_at'`
- PAT-based GitHub connections don't have OAuth-style token expiration, so these fields should be NULL
- The database columns were not nullable, causing connection creation to fail

**The Solution:**
- Added a database migration script to alter `token_expires_at` and `refresh_token_expires_at` columns to be nullable (`*time.Time`)
- This allows PAT connections to store NULL values while OAuth connections can still store actual expiration timestamps

### Does this close any open issues?
Closes #8693

### Screenshots

### Other Information