### PR TITLE
fix(plugins): add missed repoURL in ArgoCD plugin

### DIFF
--- a/backend/plugins/argocd/api/remote_api.go
+++ b/backend/plugins/argocd/api/remote_api.go
@@ -63,6 +63,9 @@ func listArgocdRemoteScopes(
 				} `json:"metadata"`
 				Spec struct {
 					Project string `json:"project"`
+					Source  struct {
+						RepoURL string `json:"repoURL"`
+					} `json:"source"`
 				} `json:"spec"`
 			} `json:"items"`
 		}
@@ -107,6 +110,9 @@ func listArgocdRemoteScopes(
 			} `json:"metadata"`
 			Spec struct {
 				Project string `json:"project"`
+				Source  struct {
+					RepoURL string `json:"repoURL"`
+				} `json:"source"`
 			} `json:"spec"`
 		} `json:"items"`
 	}
@@ -126,6 +132,7 @@ func listArgocdRemoteScopes(
 				Name:      item.Metadata.Name,
 				Namespace: item.Metadata.Namespace,
 				Project:   item.Spec.Project,
+				RepoURL:   item.Spec.Source.RepoURL,
 			}
 			app.ConnectionId = connection.ID
 

--- a/backend/plugins/argocd/models/application.go
+++ b/backend/plugins/argocd/models/application.go
@@ -31,7 +31,7 @@ type ArgocdApplication struct {
 	Name           string     `gorm:"type:varchar(255);primaryKey" json:"name" mapstructure:"name" validate:"required"`
 	Namespace      string     `gorm:"type:varchar(255)" json:"namespace" mapstructure:"namespace"`
 	Project        string     `gorm:"type:varchar(255)" json:"project" mapstructure:"project"`
-	RepoURL        string     `gorm:"type:varchar(500)" json:"repoUrl" mapstructure:"repoUrl"`
+	RepoURL        string     `gorm:"type:varchar(500)" json:"repoURL" mapstructure:"repoURL"`
 	Path           string     `gorm:"type:varchar(255)" json:"path" mapstructure:"path"`
 	TargetRevision string     `gorm:"type:varchar(255)" json:"targetRevision" mapstructure:"targetRevision"`
 	DestServer     string     `gorm:"type:varchar(255)" json:"destServer" mapstructure:"destServer"`


### PR DESCRIPTION
### Summary

Testing ArgoCD plugin (https://github.com/apache/incubator-devlake/issues/5207), after:
- https://github.com/apache/incubator-devlake/pull/8706

I noticed that the Median Lead Time for Changes metric in DORA wasn't being reflected.

I saw that in `cicd_deployment_commits`, the `repo_url` field contained the ArgoCD app name name instead of the repository URL... And then I saw that the `repo_url` field in `_tool_argocd_applications` was null.
