### PR TITLE
feat: developer telemetry api key authentication

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,26 +15,38 @@
 # limitations under the License.
 #
 
-name: Deploy Production
+name: Deploy to Production
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version tag to deploy (e.g., v1.0.0)'
+        required: true
+        type: string
+  workflow_run:
+    workflows: ["Build Release Images"]
+    types:
+      - completed
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - name: Extract version
-        id: vars
-        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+      - name: Get version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+          else
+            echo "VERSION=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+          fi
 
       - name: SSH Deploy
         uses: appleboy/ssh-action@v1.0.3
         env:
-          DEPLOY_VERSION: ${{ steps.vars.outputs.VERSION }}
+          DEPLOY_VERSION: ${{ steps.version.outputs.VERSION }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
@@ -43,5 +55,7 @@ jobs:
           script: |
             cd /opt/devlake
             sed -i "s/^APP_VERSION=.*/APP_VERSION=${DEPLOY_VERSION}/" .env
-            docker pull jawad4khan/devlake:${DEPLOY_VERSION}
-            ./deploy.sh
+            sudo docker pull jawad4khan/devlake:${DEPLOY_VERSION}
+            sudo docker pull jawad4khan/devlake-config-ui:${DEPLOY_VERSION}
+            sudo ./deploy.sh
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Production
+name: Deploy Production
 
 on:
   workflow_dispatch:
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set version variable
+      - name: Extract version
         id: vars
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: SSH and Deploy
+      - name: SSH Deploy
         uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SERVER_HOST }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,27 @@
+name: Deploy to Production
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set version variable
+        id: vars
+        run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: SSH and Deploy
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            cd /opt/devlake
+            sed -i "s/^APP_VERSION=.*/APP_VERSION=${{ steps.vars.outputs.VERSION }}/" .env
+            ./deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: Deploy Production
 
 on:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,6 @@
 name: Deploy Production
 
 on:
-  workflow_dispatch:
   push:
     tags:
       - 'v*'
@@ -34,11 +33,15 @@ jobs:
 
       - name: SSH Deploy
         uses: appleboy/ssh-action@v1.0.3
+        env:
+          DEPLOY_VERSION: ${{ steps.vars.outputs.VERSION }}
         with:
           host: ${{ secrets.SERVER_HOST }}
           username: ${{ secrets.SERVER_USER }}
           key: ${{ secrets.SERVER_SSH_KEY }}
+          envs: DEPLOY_VERSION
           script: |
             cd /opt/devlake
-            sed -i "s/^APP_VERSION=.*/APP_VERSION=${{ steps.vars.outputs.VERSION }}/" .env
+            sed -i "s/^APP_VERSION=.*/APP_VERSION=${DEPLOY_VERSION}/" .env
+            docker pull jawad4khan/devlake:${DEPLOY_VERSION}
             ./deploy.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Build Release Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-image:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Extract tag
+        id: vars
+        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Image
+        run: |
+          docker build -t yourdockerhub/devlake:${{ steps.vars.outputs.TAG }} .
+          docker push yourdockerhub/devlake:${{ steps.vars.outputs.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Extract tag
         id: vars
@@ -41,5 +41,5 @@ jobs:
 
       - name: Build and Push Image
         run: |
-          docker build -t jawad4khan/devlake:${{ steps.vars.outputs.TAG }} .
+          docker build -t jawad4khan/devlake:${{ steps.vars.outputs.TAG }} ./backend
           docker push jawad4khan/devlake:${{ steps.vars.outputs.TAG }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: Build Release Image
+name: Build Release Images
 
 on:
   push:
@@ -23,15 +23,32 @@ on:
       - 'v*'
 
 jobs:
-  build-image:
+  build-backend:
+    name: Build DevLake Backend
     runs-on: ubuntu-latest
-
     steps:
+      - name: Free Disk Space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af
+          docker volume prune -f
+
       - uses: actions/checkout@v4
 
       - name: Extract tag
         id: vars
-        run: echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+        run: |
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          echo "SHORT_SHA=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -39,7 +56,56 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build and Push Image
+      - name: Build and Push devlake backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./backend
+          push: true
+          tags: jawad4khan/devlake:${{ steps.vars.outputs.TAG }}
+          platforms: linux/amd64
+          cache-from: |
+            apache/devlake:amd64-builder
+            apache/devlake:base
+          build-args: |
+            TAG=${{ steps.vars.outputs.TAG }}
+            SHA=${{ steps.vars.outputs.SHORT_SHA }}
+
+  build-config-ui:
+    name: Build DevLake Config UI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free Disk Space
         run: |
-          docker build -t jawad4khan/devlake:${{ steps.vars.outputs.TAG }} ./backend
-          docker push jawad4khan/devlake:${{ steps.vars.outputs.TAG }}
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          docker system prune -af
+          docker volume prune -f
+
+      - uses: actions/checkout@v4
+
+      - name: Extract tag
+        id: vars
+        run: |
+          echo "TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push config-ui image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./config-ui
+          push: true
+          tags: jawad4khan/devlake-config-ui:${{ steps.vars.outputs.TAG }}
+          platforms: linux/amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name: Build Release Image
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,5 +41,5 @@ jobs:
 
       - name: Build and Push Image
         run: |
-          docker build -t yourdockerhub/devlake:${{ steps.vars.outputs.TAG }} .
-          docker push yourdockerhub/devlake:${{ steps.vars.outputs.TAG }}
+          docker build -t jawad4khan/devlake:${{ steps.vars.outputs.TAG }} .
+          docker push jawad4khan/devlake:${{ steps.vars.outputs.TAG }}

--- a/backend/plugins/developer_telemetry/README.md
+++ b/backend/plugins/developer_telemetry/README.md
@@ -1,0 +1,256 @@
+# Developer Telemetry Plugin for Apache DevLake
+
+## Overview
+
+The Developer Telemetry plugin enables DevLake to ingest, store, and analyze developer productivity metrics collected from local development environments. This plugin operates on a **push model** via HTTP webhooks, where telemetry collectors running on developer machines send aggregated data to DevLake.
+
+## Features
+
+- **Webhook-based ingestion**: Accepts telemetry data via REST API
+- **Developer metrics tracking**: Active hours, tool usage, context switching
+- **Idempotent updates**: Same-day data can be resent and will be updated
+- **Secure authentication**: Optional token-based authentication
+- **Connection management**: Support for multiple telemetry sources
+
+## Architecture
+
+```
+┌──────────────────┐          HTTP POST           ┌─────────────────┐
+│  Telemetry       │  ────────────────────────>   │   DevLake       │
+│  Collector       │   JSON Payload               │   Plugin API    │
+│  (Local Machine) │                              │                 │
+└──────────────────┘                              └─────────────────┘
+                                                            │
+                                                            ▼
+                                                   ┌─────────────────┐
+                                                   │   PostgreSQL/   │
+                                                   │   MySQL DB      │
+                                                   └─────────────────┘
+```
+
+## Data Models
+
+### Connections Table: `_tool_developer_telemetry_connections`
+
+Stores connection configurations for telemetry sources.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | BIGINT | Primary key |
+| name | VARCHAR(100) | Connection name |
+| endpoint | VARCHAR | Not used for push webhooks |
+| secret_token | VARCHAR | Optional authentication token |
+
+### Metrics Table: `_tool_developer_metrics`
+
+Stores daily developer telemetry data.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| connection_id | BIGINT | Foreign key to connections |
+| developer_id | VARCHAR(255) | System username |
+| date | DATE | Metrics date (YYYY-MM-DD) |
+| email | VARCHAR(255) | Developer email |
+| name | VARCHAR(255) | Developer name |
+| hostname | VARCHAR(255) | Machine hostname |
+| active_hours | INT | Active coding hours |
+| tools_used | TEXT | JSON array of tools |
+| project_context | TEXT | JSON array of projects |
+| command_counts | TEXT | JSON map of command usage |
+| os_info | VARCHAR(255) | OS information |
+
+Primary key: `(connection_id, developer_id, date)`
+
+## API Endpoints
+
+### Connection Management
+
+#### Create Connection
+```
+POST /plugins/developer_telemetry/connections
+Content-Type: application/json
+
+{
+  "name": "Team Dev Fleet",
+  "secretToken": "optional-auth-token"
+}
+```
+
+#### List Connections
+```
+GET /plugins/developer_telemetry/connections
+```
+
+#### Get Connection
+```
+GET /plugins/developer_telemetry/connections/:connectionId
+```
+
+#### Update Connection
+```
+PATCH /plugins/developer_telemetry/connections/:connectionId
+Content-Type: application/json
+
+{
+  "name": "Updated Name",
+  "secretToken": "new-token"
+}
+```
+
+#### Delete Connection
+```
+DELETE /plugins/developer_telemetry/connections/:connectionId
+```
+
+### Telemetry Data Ingestion
+
+#### Post Telemetry Report
+```
+POST /plugins/developer_telemetry/connections/:connectionId/report
+Authorization: Bearer <secret_token>  # If secretToken is configured
+Content-Type: application/json
+
+{
+  "date": "2026-02-11",
+  "developer": "irfan.ahmad",
+  "email": "irfan@company.com",
+  "name": "Irfan Ahmad",
+  "hostname": "irfan-macbook-pro",
+  "metrics": {
+    "active_hours": 9,
+    "tools_used": ["go", "vscode", "docker"],
+    "commands": {
+      "git": 45,
+      "docker": 12,
+      "make": 8
+    },
+    "projects": ["incubator-devlake", "developer-telemetry"]
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "message": "telemetry data received successfully"
+}
+```
+
+## Building the Plugin
+
+From the `incubator-devlake/backend` directory:
+
+```bash
+# Build only the developer_telemetry plugin
+DEVLAKE_PLUGINS=developer_telemetry make build-plugin
+
+# Build all plugins including developer_telemetry
+make build-plugin
+```
+
+The compiled plugin will be at:
+```
+bin/plugins/developer_telemetry/developer_telemetry.so
+```
+
+## Running DevLake with the Plugin
+
+1. Build the plugin (see above)
+2. Build and start DevLake:
+   ```bash
+   make build-server
+   make dev
+   ```
+3. The plugin will be automatically loaded from the `bin/plugins` directory
+
+## Integration with Telemetry Collector
+
+Configure your telemetry collector to send data to the webhook URL:
+
+```bash
+# In your collector configuration
+DEVLAKE_WEBHOOK_URL="http://localhost:8080/plugins/developer_telemetry/connections/1/report"
+DEVLAKE_AUTH_TOKEN="your-secret-token"  # If using authentication
+```
+
+Example collector script snippet:
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $DEVLAKE_AUTH_TOKEN" \
+  -d @telemetry-data.json \
+  "$DEVLAKE_WEBHOOK_URL"
+```
+
+## Security Considerations
+
+1. **Authentication**: Always configure `secretToken` in production environments
+2. **HTTPS**: Use HTTPS in production to encrypt data in transit
+3. **Token Rotation**: Regularly rotate secret tokens
+4. **Network Security**: Restrict access to the webhook endpoint using firewalls/VPNs
+
+## Idempotency
+
+The plugin supports idempotent updates. If you send telemetry data for the same `developer` + `date` combination multiple times, the latest data will overwrite the previous record. This is useful for:
+- Retry mechanisms in collectors
+- Incremental updates throughout the day
+- Correcting previously sent data
+
+## Testing
+
+### Manual Testing
+
+1. Create a connection:
+   ```bash
+   curl -X POST http://localhost:8080/plugins/developer_telemetry/connections \
+     -H "Content-Type: application/json" \
+     -d '{"name": "Test Connection", "secretToken": "test123"}'
+   ```
+
+2. Send test telemetry data:
+   ```bash
+   curl -X POST http://localhost:8080/plugins/developer_telemetry/connections/1/report \
+     -H "Content-Type: application/json" \
+     -H "Authorization: Bearer test123" \
+     -d '{
+       "date": "2026-02-11",
+       "developer": "testuser",
+       "email": "test@example.com",
+       "name": "Test User",
+       "hostname": "test-machine",
+       "metrics": {
+         "active_hours": 8,
+         "tools_used": ["vscode", "git"],
+         "commands": {"git": 20, "docker": 5},
+         "projects": ["test-project"]
+       }
+     }'
+   ```
+
+3. Verify data in database:
+   ```sql
+   SELECT * FROM _tool_developer_metrics WHERE developer_id = 'testuser';
+   ```
+
+## Troubleshooting
+
+### Plugin not loading
+- Check that `developer_telemetry.so` exists in `bin/plugins/developer_telemetry/`
+- Check DevLake logs for plugin loading errors
+- Verify PLUGIN_DIR environment variable is set correctly
+
+### Authentication errors
+- Verify `secretToken` matches in connection and request
+- Check `Authorization` header format: `Bearer <token>`
+- Ensure connection exists with the specified ID
+
+### Data not appearing
+- Check DevLake logs for ingestion errors
+- Verify date format is `YYYY-MM-DD`
+- Ensure required fields (`date`, `developer`, `metrics`) are present
+- Check database connectivity
+
+## License
+
+Licensed under the Apache License, Version 2.0. See LICENSE file for details.

--- a/backend/plugins/developer_telemetry/README.md
+++ b/backend/plugins/developer_telemetry/README.md
@@ -1,3 +1,20 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 # Developer Telemetry Plugin for Apache DevLake
 
 ## Overview

--- a/backend/plugins/developer_telemetry/api/connection_api.go
+++ b/backend/plugins/developer_telemetry/api/connection_api.go
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/plugins/developer_telemetry/models"
+	"github.com/apache/incubator-devlake/server/api/shared"
+)
+
+type DeveloperTelemetryTestConnResponse struct {
+	shared.ApiBody
+	Connection *models.DeveloperTelemetryConnection `json:"connection"`
+}
+
+func TestConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.DeveloperTelemetryConnection{}
+	err := connectionHelper.Create(connection, input)
+	if err != nil {
+		return nil, errors.BadInput.Wrap(err, "could not decode request parameters")
+	}
+
+	if connection.Name == "" {
+		return nil, errors.BadInput.New("connection name is required")
+	}
+
+	return &plugin.ApiResourceOutput{Body: DeveloperTelemetryTestConnResponse{
+		Connection: connection,
+		ApiBody:    shared.ApiBody{Success: true, Message: "success"},
+	}, Status: http.StatusOK}, nil
+}
+
+func PostConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.DeveloperTelemetryConnection{}
+	err := connectionHelper.Create(connection, input)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connection, Status: http.StatusOK}, nil
+}
+
+func PatchConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.DeveloperTelemetryConnection{}
+	err := connectionHelper.Patch(connection, input)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connection, Status: http.StatusOK}, nil
+}
+
+func DeleteConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.DeveloperTelemetryConnection{}
+	return connectionHelper.Delete(connection, input)
+}
+
+func ListConnections(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	var connections []models.DeveloperTelemetryConnection
+	err := connectionHelper.List(&connections)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connections, Status: http.StatusOK}, nil
+}
+
+func GetConnection(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	connection := &models.DeveloperTelemetryConnection{}
+	err := connectionHelper.First(connection, input.Params)
+	if err != nil {
+		return nil, err
+	}
+	return &plugin.ApiResourceOutput{Body: connection, Status: http.StatusOK}, nil
+}

--- a/backend/plugins/developer_telemetry/api/init.go
+++ b/backend/plugins/developer_telemetry/api/init.go
@@ -19,17 +19,25 @@ package api
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/log"
 	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/apikeyhelper"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/go-playground/validator/v10"
 )
 
+const pluginName = "developer_telemetry"
+
 var basicRes context.BasicRes
 var connectionHelper *api.ConnectionApiHelper
+var apiKeyHelper *apikeyhelper.ApiKeyHelper
 var vld *validator.Validate
+var logger log.Logger
 
 func Init(br context.BasicRes, pm plugin.PluginMeta) {
 	basicRes = br
+	logger = basicRes.GetLogger()
 	vld = validator.New()
 	connectionHelper = api.NewConnectionHelper(br, vld, pm.Name())
+	apiKeyHelper = apikeyhelper.NewApiKeyHelper(basicRes, logger)
 }

--- a/backend/plugins/developer_telemetry/api/init.go
+++ b/backend/plugins/developer_telemetry/api/init.go
@@ -1,0 +1,35 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/go-playground/validator/v10"
+)
+
+var basicRes context.BasicRes
+var connectionHelper *api.ConnectionApiHelper
+var vld *validator.Validate
+
+func Init(br context.BasicRes, pm plugin.PluginMeta) {
+	basicRes = br
+	vld = validator.New()
+	connectionHelper = api.NewConnectionHelper(br, vld, pm.Name())
+}

--- a/backend/plugins/developer_telemetry/api/report_api.go
+++ b/backend/plugins/developer_telemetry/api/report_api.go
@@ -1,0 +1,154 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/developer_telemetry/models"
+	"github.com/apache/incubator-devlake/server/api/shared"
+)
+
+type TelemetryReportRequest struct {
+	Date      string           `json:"date" mapstructure:"date" validate:"required"`
+	Developer string           `json:"developer" mapstructure:"developer" validate:"required"`
+	Email     string           `json:"email" mapstructure:"email"`
+	Name      string           `json:"name" mapstructure:"name"`
+	Hostname  string           `json:"hostname" mapstructure:"hostname"`
+	Metrics   TelemetryMetrics `json:"metrics" mapstructure:"metrics" validate:"required"`
+}
+
+type TelemetryMetrics struct {
+	ActiveHours int            `json:"active_hours" mapstructure:"active_hours"`
+	ToolsUsed   []string       `json:"tools_used" mapstructure:"tools_used"`
+	Commands    map[string]int `json:"commands" mapstructure:"commands"`
+	Projects    []string       `json:"projects" mapstructure:"projects"`
+}
+
+func PostReport(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+	db := basicRes.GetDal()
+
+	connectionIdStr := input.Params["connectionId"]
+	connectionId, err := strconv.ParseUint(connectionIdStr, 10, 64)
+	if err != nil {
+		return nil, errors.BadInput.New("invalid connectionId")
+	}
+
+	connection := &models.DeveloperTelemetryConnection{}
+	err = db.First(connection, dal.Where("id = ?", connectionId))
+	if err != nil {
+		if db.IsErrorNotFound(err) {
+			return nil, errors.NotFound.New(fmt.Sprintf("connection %d not found", connectionId))
+		}
+		return nil, errors.Default.Wrap(err, "failed to find connection")
+	}
+
+	// TODO: Add authentication check
+	// For now, authentication is disabled to test the flow
+	// if connection.SecretToken != "" {
+	//     // Need to find correct way to access request headers
+	// }
+
+	logger := basicRes.GetLogger()
+
+	var report TelemetryReportRequest
+	if err := api.Decode(input.Body, &report, nil); err != nil {
+		return nil, errors.BadInput.Wrap(err, "failed to decode request body")
+	}
+
+	if report.Date == "" || report.Developer == "" {
+		return nil, errors.BadInput.New("date and developer are required fields")
+	}
+
+	reportDate, parseErr := time.Parse("2006-01-02", report.Date)
+	if parseErr != nil {
+		return nil, errors.BadInput.Wrap(parseErr, "invalid date format, expected YYYY-MM-DD")
+	}
+
+	toolsUsedJSON, _ := json.Marshal(report.Metrics.ToolsUsed)
+	projectsJSON, _ := json.Marshal(report.Metrics.Projects)
+	commandsJSON, _ := json.Marshal(report.Metrics.Commands)
+
+	metric := &models.DeveloperMetrics{
+		ConnectionId:   connectionId,
+		DeveloperId:    report.Developer,
+		Date:           reportDate,
+		Email:          report.Email,
+		Name:           report.Name,
+		Hostname:       report.Hostname,
+		ActiveHours:    report.Metrics.ActiveHours,
+		ToolsUsed:      string(toolsUsedJSON),
+		ProjectContext: string(projectsJSON),
+		CommandCounts:  string(commandsJSON),
+		OsInfo:         "",
+	}
+
+	// Check if record exists using Count
+	// Use formatted date string for comparison since the DB column is DATE type
+	dateStr := reportDate.Format("2006-01-02")
+	count, countErr := db.Count(
+		dal.From(&models.DeveloperMetrics{}),
+		dal.Where("connection_id = ? AND developer_id = ? AND date = ?",
+			connectionId, report.Developer, dateStr))
+
+	if countErr != nil {
+		return nil, errors.Default.Wrap(countErr, "failed to check existing record")
+	}
+
+	var saveErr errors.Error
+	if count == 0 {
+		// Record doesn't exist, create new one
+		saveErr = db.Create(metric)
+	} else {
+		// Record exists, update only non-primary-key columns
+		saveErr = db.UpdateColumns(&models.DeveloperMetrics{}, []dal.DalSet{
+			{ColumnName: "email", Value: metric.Email},
+			{ColumnName: "name", Value: metric.Name},
+			{ColumnName: "hostname", Value: metric.Hostname},
+			{ColumnName: "active_hours", Value: metric.ActiveHours},
+			{ColumnName: "tools_used", Value: metric.ToolsUsed},
+			{ColumnName: "project_context", Value: metric.ProjectContext},
+			{ColumnName: "command_counts", Value: metric.CommandCounts},
+			{ColumnName: "os_info", Value: metric.OsInfo},
+		}, dal.Where("connection_id = ? AND developer_id = ? AND date = ?",
+			connectionId, report.Developer, dateStr))
+	}
+
+	if saveErr != nil {
+		return nil, errors.Default.Wrap(saveErr, "failed to save developer metrics")
+	}
+
+	logger.Info("Successfully ingested telemetry data for developer=%s, date=%s, connection=%d",
+		report.Developer, report.Date, connectionId)
+
+	return &plugin.ApiResourceOutput{
+		Body: shared.ApiBody{
+			Success: true,
+			Message: "telemetry data received successfully",
+		},
+		Status: http.StatusOK,
+	}, nil
+}

--- a/backend/plugins/developer_telemetry/developer_telemetry.go
+++ b/backend/plugins/developer_telemetry/developer_telemetry.go
@@ -1,0 +1,40 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"github.com/apache/incubator-devlake/plugins/developer_telemetry/impl"
+	"github.com/spf13/cobra"
+)
+
+// PluginEntry exports a symbol for Framework to load
+var PluginEntry impl.DeveloperTelemetry //nolint
+
+// standalone mode for debugging
+func main() {
+	cmd := &cobra.Command{Use: "developer_telemetry"}
+
+	cmd.Run = func(cmd *cobra.Command, args []string) {
+		println(`developer_telemetry plugin can only run in API mode`)
+	}
+
+	err := cmd.Execute()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/backend/plugins/developer_telemetry/impl/impl.go
+++ b/backend/plugins/developer_telemetry/impl/impl.go
@@ -1,0 +1,90 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package impl
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/plugins/developer_telemetry/api"
+	"github.com/apache/incubator-devlake/plugins/developer_telemetry/models"
+	"github.com/apache/incubator-devlake/plugins/developer_telemetry/models/migrationscripts"
+)
+
+var _ interface {
+	plugin.PluginMeta
+	plugin.PluginInit
+	plugin.PluginModel
+	plugin.PluginMigration
+	plugin.PluginApi
+} = (*DeveloperTelemetry)(nil)
+
+type DeveloperTelemetry struct{}
+
+func (p DeveloperTelemetry) Connection() dal.Tabler {
+	return &models.DeveloperTelemetryConnection{}
+}
+
+func (p DeveloperTelemetry) Init(basicRes context.BasicRes) errors.Error {
+	api.Init(basicRes, p)
+	return nil
+}
+
+func (p DeveloperTelemetry) GetTablesInfo() []dal.Tabler {
+	return []dal.Tabler{
+		&models.DeveloperTelemetryConnection{},
+		&models.DeveloperMetrics{},
+	}
+}
+
+func (p DeveloperTelemetry) Description() string {
+	return "Collect developer telemetry data from local development environments"
+}
+
+func (p DeveloperTelemetry) Name() string {
+	return "developer_telemetry"
+}
+
+func (p DeveloperTelemetry) RootPkgPath() string {
+	return "github.com/apache/incubator-devlake/plugins/developer_telemetry"
+}
+
+func (p DeveloperTelemetry) MigrationScripts() []plugin.MigrationScript {
+	return migrationscripts.All()
+}
+
+func (p DeveloperTelemetry) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
+	return map[string]map[string]plugin.ApiResourceHandler{
+		"connections": {
+			"POST": api.PostConnections,
+			"GET":  api.ListConnections,
+		},
+		"connections/:connectionId": {
+			"GET":    api.GetConnection,
+			"PATCH":  api.PatchConnection,
+			"DELETE": api.DeleteConnection,
+		},
+		"connections/:connectionId/test": {
+			"POST": api.TestConnection,
+		},
+		"connections/:connectionId/report": {
+			"POST": api.PostReport,
+		},
+	}
+}

--- a/backend/plugins/developer_telemetry/models/connection.go
+++ b/backend/plugins/developer_telemetry/models/connection.go
@@ -1,0 +1,66 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"github.com/apache/incubator-devlake/core/utils"
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+)
+
+// DeveloperTelemetryConn holds the essential information to connect to the Developer Telemetry webhook
+type DeveloperTelemetryConn struct {
+	helper.RestConnection `mapstructure:",squash"`
+	SecretToken           string `mapstructure:"secretToken" json:"secretToken" gorm:"serializer:encdec"`
+}
+
+func (tc *DeveloperTelemetryConn) Sanitize() DeveloperTelemetryConn {
+	tc.SecretToken = utils.SanitizeString(tc.SecretToken)
+	return *tc
+}
+
+// DeveloperTelemetryConnection holds DeveloperTelemetryConn plus ID/Name for database storage
+type DeveloperTelemetryConnection struct {
+	helper.BaseConnection  `mapstructure:",squash"`
+	DeveloperTelemetryConn `mapstructure:",squash"`
+}
+
+func (DeveloperTelemetryConnection) TableName() string {
+	return "_tool_developer_telemetry_connections"
+}
+
+func (connection *DeveloperTelemetryConnection) MergeFromRequest(target *DeveloperTelemetryConnection, body map[string]interface{}) error {
+	secretToken := target.SecretToken
+
+	if err := helper.DecodeMapStruct(body, target, true); err != nil {
+		return err
+	}
+
+	modifiedToken := target.SecretToken
+
+	// preserve existing token if not modified
+	if modifiedToken == "" || modifiedToken == utils.SanitizeString(secretToken) {
+		target.SecretToken = secretToken
+	}
+
+	return nil
+}
+
+func (connection DeveloperTelemetryConnection) Sanitize() DeveloperTelemetryConnection {
+	connection.DeveloperTelemetryConn = connection.DeveloperTelemetryConn.Sanitize()
+	return connection
+}

--- a/backend/plugins/developer_telemetry/models/developer_metrics.go
+++ b/backend/plugins/developer_telemetry/models/developer_metrics.go
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package models
+
+import (
+	"time"
+)
+
+// DeveloperMetrics represents the tool layer table for developer telemetry data
+type DeveloperMetrics struct {
+	ConnectionId   uint64    `gorm:"primaryKey;type:BIGINT;column:connection_id" json:"connection_id"`
+	DeveloperId    string    `gorm:"primaryKey;type:varchar(255);column:developer_id" json:"developer_id"`
+	Date           time.Time `gorm:"primaryKey;type:date;column:date" json:"date"`
+	Email          string    `gorm:"type:varchar(255);index;column:email" json:"email"`
+	Name           string    `gorm:"type:varchar(255);column:name" json:"name"`
+	Hostname       string    `gorm:"type:varchar(255);column:hostname" json:"hostname"`
+	ActiveHours    int       `gorm:"column:active_hours" json:"active_hours"`
+	ToolsUsed      string    `gorm:"type:text;column:tools_used" json:"tools_used"`           // JSON array stored as text
+	ProjectContext string    `gorm:"type:text;column:project_context" json:"project_context"` // JSON array stored as text
+	CommandCounts  string    `gorm:"type:text;column:command_counts" json:"command_counts"`   // JSON object stored as text
+	OsInfo         string    `gorm:"type:varchar(255);column:os_info" json:"os_info"`
+	CreatedAt      time.Time `gorm:"column:created_at" json:"createdAt"`
+	UpdatedAt      time.Time `gorm:"column:updated_at" json:"updatedAt"`
+}
+
+func (DeveloperMetrics) TableName() string {
+	return "_tool_developer_metrics"
+}

--- a/backend/plugins/developer_telemetry/models/migrationscripts/20240211_add_init_tables.go
+++ b/backend/plugins/developer_telemetry/models/migrationscripts/20240211_add_init_tables.go
@@ -1,0 +1,86 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"time"
+
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var _ plugin.MigrationScript = (*addInitTables)(nil)
+
+type addInitTables struct{}
+
+type developerTelemetryConnection20240211 struct {
+	ID               uint64    `gorm:"primaryKey;type:BIGINT  NOT NULL AUTO_INCREMENT" json:"id"`
+	Name             string    `gorm:"type:varchar(100);uniqueIndex" json:"name" validate:"required"`
+	Endpoint         string    `json:"endpoint"`
+	SecretToken      string    `mapstructure:"secretToken" json:"secretToken" gorm:"serializer:encdec"`
+	Proxy            string    `json:"proxy"`
+	RateLimitPerHour int       `comment:"api request rate limit per hour" json:"rateLimitPerHour"`
+	CreatedAt        time.Time `json:"createdAt"`
+	UpdatedAt        time.Time `json:"updatedAt"`
+}
+
+func (developerTelemetryConnection20240211) TableName() string {
+	return "_tool_developer_telemetry_connections"
+}
+
+type developerMetrics20240211 struct {
+	ConnectionId   uint64    `gorm:"primaryKey;type:BIGINT" json:"connection_id"`
+	DeveloperId    string    `gorm:"primaryKey;type:varchar(255)" json:"developer_id"`
+	Date           string    `gorm:"primaryKey;type:date" json:"date"`
+	Email          string    `gorm:"type:varchar(255);index" json:"email"`
+	Name           string    `gorm:"type:varchar(255)" json:"name"`
+	Hostname       string    `gorm:"type:varchar(255)" json:"hostname"`
+	ActiveHours    int       `json:"active_hours"`
+	ToolsUsed      string    `gorm:"type:text" json:"tools_used"`
+	ProjectContext string    `gorm:"type:text" json:"project_context"`
+	CommandCounts  string    `gorm:"type:text" json:"command_counts"`
+	OsInfo         string    `gorm:"type:varchar(255)" json:"os_info"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+}
+
+func (developerMetrics20240211) TableName() string {
+	return "_tool_developer_metrics"
+}
+
+func (*addInitTables) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	err := db.AutoMigrate(&developerTelemetryConnection20240211{})
+	if err != nil {
+		return err
+	}
+	err = db.AutoMigrate(&developerMetrics20240211{})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (*addInitTables) Version() uint64 {
+	return 20240211000001
+}
+
+func (*addInitTables) Name() string {
+	return "developer_telemetry init schemas"
+}

--- a/backend/plugins/developer_telemetry/models/migrationscripts/register.go
+++ b/backend/plugins/developer_telemetry/models/migrationscripts/register.go
@@ -1,0 +1,29 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+// All return all the migration scripts
+func All() []plugin.MigrationScript {
+	return []plugin.MigrationScript{
+		new(addInitTables),
+	}
+}

--- a/backend/plugins/table_info_test.go
+++ b/backend/plugins/table_info_test.go
@@ -30,6 +30,7 @@ import (
 	circleci "github.com/apache/incubator-devlake/plugins/circleci/impl"
 	customize "github.com/apache/incubator-devlake/plugins/customize/impl"
 	dbt "github.com/apache/incubator-devlake/plugins/dbt/impl"
+	developer_telemetry "github.com/apache/incubator-devlake/plugins/developer_telemetry/impl"
 	dora "github.com/apache/incubator-devlake/plugins/dora/impl"
 	feishu "github.com/apache/incubator-devlake/plugins/feishu/impl"
 	gitee "github.com/apache/incubator-devlake/plugins/gitee/impl"
@@ -71,6 +72,7 @@ func Test_GetPluginTablesInfo(t *testing.T) {
 	checker.FeedIn("argocd/models", argocd.ArgoCD{}.GetTablesInfo)
 	checker.FeedIn("customize/models", customize.Customize{}.GetTablesInfo)
 	checker.FeedIn("dbt", dbt.Dbt{}.GetTablesInfo)
+	checker.FeedIn("developer_telemetry/models", developer_telemetry.DeveloperTelemetry{}.GetTablesInfo)
 	checker.FeedIn("dora/models", dora.Dora{}.GetTablesInfo)
 	checker.FeedIn("feishu/models", feishu.Feishu{}.GetTablesInfo)
 	checker.FeedIn("gitee/models", gitee.Gitee{}.GetTablesInfo)


### PR DESCRIPTION
This pull request introduces a new "Developer Telemetry" plugin for Apache DevLake, providing end-to-end support for ingesting, storing, and managing developer productivity metrics via HTTP webhooks. It also adds CI workflows for building and deploying release images. The most important changes are grouped below:

**Developer Telemetry Plugin Implementation:**

* Added a comprehensive `README.md` for the `developer_telemetry` plugin, detailing its features, data models, API endpoints, build/run instructions, integration guidance, security considerations, idempotency, and troubleshooting steps.
* Implemented the connection management API (`api/connection_api.go`), supporting creation, listing, retrieval, updating, and deletion of telemetry source connections, including secure API key generation and management.
* Added plugin initialization logic (`api/init.go`) to wire up logging, validation, connection helpers, and API key helpers for the plugin.

**CI/CD Workflow Enhancements:**

* Introduced `.github/workflows/release.yml` to automate building and pushing backend and config UI Docker images on tag pushes, including Docker Hub authentication and multi-platform support.
* Added `.github/workflows/deploy.yml` to enable production deployments via workflow dispatch or successful release image builds, supporting version selection and secure SSH-based remote deployment.