### PR TITLE
[fix][SonarQube]: allow project list with non-admin (Browse) token (fixes #8710)

### DIFF
--- a/backend/plugins/sonarqube/api/blueprint_v200.go
+++ b/backend/plugins/sonarqube/api/blueprint_v200.go
@@ -131,7 +131,8 @@ func GetApiProject(
 	}
 	query := url.Values{}
 	query.Set("q", projectKey)
-	res, err := apiClient.Get("projects/search", query, nil)
+	// Use components/search_projects for consistency and normal-token (Browse) support.
+	res, err := apiClient.Get("components/search_projects", query, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/plugins/sonarqube/api/remote_api.go
+++ b/backend/plugins/sonarqube/api/remote_api.go
@@ -48,7 +48,8 @@ func querySonarqubeProjects(
 	if page.Page == 0 {
 		page.Page = 1
 	}
-	res, err := apiClient.Get("projects/search", url.Values{
+	// Use components/search_projects so non-admin (Browse) tokens can list projects.
+	res, err := apiClient.Get("components/search_projects", url.Values{
 		"p":  {fmt.Sprintf("%v", page.Page)},
 		"ps": {fmt.Sprintf("%v", page.PageSize)},
 		"q":  {keyword},

--- a/config-ui/src/plugins/register/sonarqube/config.tsx
+++ b/config-ui/src/plugins/register/sonarqube/config.tsx
@@ -55,7 +55,11 @@ export const SonarQubeConfig: IPluginConfig = {
           setErrors={setErrors}
         />
       ),
-      'token',
+      {
+        key: 'token',
+        subLabel:
+          'A token with Browse permission on the projects you want is sufficient for listing projects and collecting issues, hotspots, and file metrics. Listing Accounts (users) may require a system admin token on some SonarQube instances.',
+      },
       'proxy',
       {
         key: 'rateLimitPerHour',


### PR DESCRIPTION

### Summary
When adding a SonarQube data scope, the project list was empty even though "Test Connection" succeeded when using a non-admin token. The plugin was calling the projects/search API, which requires admin (or equivalent) permissions. This PR switches to components/search_projects, which works with a token that has Browse permission, so users can list projects and add scopes without an admin token.

Backend: use `components/search_projects` instead of `projects/search` in `api/blueprint_v200.go` (GetApiProject) and `api/remote_api.go` (querySonarqubeProjects). 

Config UI: add a subLabel on the token field stating that a token with Browse permission is sufficient for listing projects and collecting issues, hotspots, and file metrics; listing Accounts may still require a system admin token on some instances.

### Does this close any open issues?
Closes #8710 

### Screenshots
Include any relevant screenshots here.

### Other Information
No change to connection validation; "Test Connection" behavior is unchanged.
