### PR TITLE
docs: add gh-devlake CLI to Getting Started installation options

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ You can set up Apache DevLake by following our step-by-step instructions for eit
 
 - [Install via Docker Compose](https://devlake.apache.org/docs/GettingStarted/DockerComposeSetup)
 - [Install via Helm](https://devlake.apache.org/docs/GettingStarted/HelmSetup)
+- [Install via gh-devlake CLI](https://github.com/DevExpGBB/gh-devlake) — A GitHub CLI extension that deploys, configures, and monitors DevLake entirely from the terminal. Supports local Docker and Azure deployments.
 
 ## 🤓 Usage
 


### PR DESCRIPTION
### Summary

Adds [gh-devlake](https://github.com/DevExpGBB/gh-devlake) as a third installation option under **Getting Started > Installation**, alongside Docker Compose and Helm.

### What is gh-devlake?

`gh-devlake` is a GitHub CLI extension that automates Apache DevLake deployment, configuration, and monitoring entirely from the terminal. It supports both local Docker and Azure deployments, handles connections to GitHub and GitHub Copilot, and enables DORA metrics computation without requiring the web UI. Support for additional plugins is coming soon.

### Change

Single line addition to `README.md`:

```markdown
- [Install via gh-devlake CLI](https://github.com/DevExpGBB/gh-devlake) — A GitHub CLI extension that deploys, configures, and monitors DevLake entirely from the terminal. Supports local Docker and Azure deployments.
```

Closes #8732