### PR TITLE
fix(docker): pin Poetry to 2.2.1 for Python 3.9 compatibility

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -149,7 +149,7 @@ RUN python3 -m pip install --no-cache --upgrade pip setuptools && \
     python3 -m pip install --upgrade pip
 
 # Setup Python Poetry package manager
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1
 ENV PATH="$PATH:/app/.local/bin"
 
 # Build Python plugins, make sure the scripts has execute permission


### PR DESCRIPTION
**Title:** fix(docker): pin Poetry to 2.2.1 for Python 3.9 compatibility

**Base:** `main` (apache/incubator-devlake)

---

### Summary

The `backend/Dockerfile` installs Poetry without pinning a version:

```dockerfile
RUN curl -sSL https://install.python-poetry.org | python3 -
```

Poetry 2.3.0 dropped support for Python 3.9. Since the base image uses `python:3.9-slim-bookworm`, the unpinned installer now fetches an incompatible version (currently 2.3.2), causing the build to fail when there is no Docker layer cache available.

Reference: https://python-poetry.org/blog/announcing-poetry-2.3.0/

Current CI builds succeed only because the cached `devlake:base` image still contains a Poetry layer from a previous compatible version. Any cache invalidation (base image security update, forced rebuild, new registry) will break the build with:

```
Installing Poetry (2.3.2): An error occurred. Removing partial environment.
Poetry installation failed.
```

This PR pins Poetry to 2.2.1, the last release compatible with Python 3.9.

### Does this close any open issues?

Closes #8734

### Screenshots

N/A

### Other Information

An alternative approach would be to upgrade the base image to Python 3.10+ to support Poetry 2.3+, but that has a larger blast radius.