### PR TITLE
fix(doc): update expired Slack invite links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ limitations under the License.
 [![Dockerhub pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhub.docker.com%2Fv2%2Frepositories%2Fapache%2Fdevlake&query=%24.pull_count&label=Dockerhub%20pulls)](https://hub.docker.com/r/apache/devlake)
 [![unit-test](https://github.com/apache/incubator-devlake/actions/workflows/test.yml/badge.svg)](https://github.com/apache/incubator-devlake/actions/workflows/test.yml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/apache/incubator-devlake)](https://goreportcard.com/report/github.com/apache/incubator-devlake)
-[![Slack](https://img.shields.io/badge/slack-join_chat-success.svg?logo=slack)](https://join.slack.com/t/devlake-io/shared_invite/zt-18uayb6ut-cHOjiYcBwERQ8VVPZ9cQQw)
+[![Slack](https://img.shields.io/badge/slack-join_chat-success.svg?logo=slack)](https://join.slack.com/t/devlake-io/shared_invite/zt-1lkgbdmys-AU2azidzO1u~mtjlg9my7A)
 [![Twitter](https://badgen.net/badge/icon/twitter?icon=twitter&label)](https://twitter.com/ApacheDevLake)
 
 </div>
@@ -121,7 +121,7 @@ One of the best ways to get started contributing is by improving DevLake's docum
 
 ## 💙 Community
 
-Message us on <a href="https://join.slack.com/t/devlake-io/shared_invite/zt-18uayb6ut-cHOjiYcBwERQ8VVPZ9cQQw" target="_blank">Slack</a>
+Message us on <a href="https://join.slack.com/t/devlake-io/shared_invite/zt-1lkgbdmys-AU2azidzO1u~mtjlg9my7A" target="_blank">Slack</a>
 
 ## 📄 License<a id="license"></a>
 


### PR DESCRIPTION
## Summary
- Updated two expired Slack invite links in README.md to match the current link on the official DevLake website
- The badge link (line 28) and community section link (line 124) both pointed to an expired invite URL

Closes #8738

## Screenshots
N/A - text-only change

## Other Information
The website repo was already updated via incubator-devlake-website#818, but the main repo README still had the old links.