### PR TITLE
fix(grafana): update dashboard descriptions to list all supported data sources

### DIFF
--- a/grafana/dashboards/EngineeringOverview.json
+++ b/grafana/dashboards/EngineeringOverview.json
@@ -40,7 +40,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "- Use Cases: This dashboard is to overview the Git and project management metrics.\n- Data Source Required: Jira + GitHub, or Jira + GitLab.",
+        "content": "- Use Cases: This dashboard is to overview the Git and project management metrics.\n- Data Sources Required:\n   - One of the Git tools, e.g. [GitHub](https://devlake.apache.org/docs/Configuration/GitHub), [GitLab](https://devlake.apache.org/docs/Configuration/GitLab), [Bitbucket](https://devlake.apache.org/docs/Configuration/BitBucket) or [Azure DevOps](https://devlake.apache.org/docs/Configuration/AzureDevOps)\n   - One of the issue tracking tools, e.g. [Jira](https://devlake.apache.org/docs/Configuration/Jira)",
         "mode": "markdown"
       },
       "pluginVersion": "11.0.0",

--- a/grafana/dashboards/EngineeringThroughputAndCycleTime.json
+++ b/grafana/dashboards/EngineeringThroughputAndCycleTime.json
@@ -39,7 +39,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "- Use Cases: This dashboard shows the engineering throughput and and cycle time, which helps to identify productivity and bottlenecks of the development process.\n- Data Source Required: GitHub and Jira([transformation](https://devlake.apache.org/docs/UserManuals/ConfigUI/Jira#step-3---adding-transformation-rules-optional) required to tell DevLake what the story_points field is)",
+        "content": "- Use Cases: This dashboard shows the engineering throughput and and cycle time, which helps to identify productivity and bottlenecks of the development process.\n- Data Sources Required:\n   - One of the Git tools, e.g. [GitHub](https://devlake.apache.org/docs/Configuration/GitHub), [GitLab](https://devlake.apache.org/docs/Configuration/GitLab), [Bitbucket](https://devlake.apache.org/docs/Configuration/BitBucket) or [Azure DevOps](https://devlake.apache.org/docs/Configuration/AzureDevOps)\n   - One of the issue tracking tools, e.g. [Jira](https://devlake.apache.org/docs/Configuration/Jira) ([Scope Config](https://devlake.apache.org/docs/UserManuals/ConfigUI/Jira#step-3---adding-transformation-rules-optional) required to tell DevLake what the story_points field is)",
         "mode": "markdown"
       },
       "pluginVersion": "11.0.0",

--- a/grafana/dashboards/EngineeringThroughputAndCycleTimeTeamView.json
+++ b/grafana/dashboards/EngineeringThroughputAndCycleTimeTeamView.json
@@ -40,7 +40,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "- Use Cases: This dashboard shows the engineering throughput and and cycle time, which helps to identify productivity and bottlenecks of the development process.\n- Data Source Required: GitHub and Jira([transformation](https://devlake.apache.org/docs/UserManuals/ConfigUI/Jira#step-3---adding-transformation-rules-optional) required to tell DevLake what the story_points field is). You also need to do [team configuration](https://devlake.apache.org/docs/Configuration/TeamConfiguration) to use this dashboard.",
+        "content": "- Use Cases: This dashboard shows the engineering throughput and and cycle time, which helps to identify productivity and bottlenecks of the development process.\n- Data Sources Required:\n   - One of the Git tools, e.g. [GitHub](https://devlake.apache.org/docs/Configuration/GitHub), [GitLab](https://devlake.apache.org/docs/Configuration/GitLab), [Bitbucket](https://devlake.apache.org/docs/Configuration/BitBucket) or [Azure DevOps](https://devlake.apache.org/docs/Configuration/AzureDevOps)\n   - One of the issue tracking tools, e.g. [Jira](https://devlake.apache.org/docs/Configuration/Jira) ([Scope Config](https://devlake.apache.org/docs/UserManuals/ConfigUI/Jira#step-3---adding-transformation-rules-optional) required to tell DevLake what the story_points field is)\n- You also need to do [team configuration](https://devlake.apache.org/docs/Configuration/TeamConfiguration) to use this dashboard.",
         "mode": "markdown"
       },
       "pluginVersion": "11.0.0",

--- a/grafana/dashboards/WeeklyBugRetro.json
+++ b/grafana/dashboards/WeeklyBugRetro.json
@@ -40,7 +40,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "- Use Cases: This dashboard can be used to track bugs with metrics such as [Bug Age](https://devlake.apache.org/docs/Metrics/BugAge).\n- Data Source Required: GitHub ([Scope Config](https://devlake.apache.org/docs/UserManuals/ConfigUI/GitHub#step-3---adding-transformation-rules-optional) required) or Jira ([Scope Config](https://devlake.apache.org/docs/UserManuals/ConfigUI/Jira#step-3---adding-transformation-rules-optional) required). Scope config is the settings to define which issues are bugs.",
+        "content": "- Use Cases: This dashboard can be used to track bugs with metrics such as [Bug Age](https://devlake.apache.org/docs/Metrics/BugAge).\n- Data Source Required: One of the issue tracking tools, e.g. [GitHub](https://devlake.apache.org/docs/UserManuals/ConfigUI/GitHub#step-3---adding-transformation-rules-optional), [GitLab](https://devlake.apache.org/docs/Configuration/GitLab) or [Jira](https://devlake.apache.org/docs/UserManuals/ConfigUI/Jira#step-3---adding-transformation-rules-optional) (Scope Config required to define which issues are bugs).",
         "mode": "markdown"
       },
       "pluginVersion": "11.0.0",


### PR DESCRIPTION
## Summary
- Updated 4 Grafana dashboard introduction panels that hardcoded specific data sources ("GitHub and Jira") to list all supported sources
- Follows the pattern already used by DORA and WorkLogs dashboards (e.g. "One of the Git tools, e.g. GitHub, GitLab, Bitbucket or Azure DevOps")
- The underlying SQL queries in all affected dashboards use generic domain layer tables (`pull_requests`, `issues`, `boards`) that work with any supported data source

### Dashboards updated:
- **EngineeringThroughputAndCycleTime.json** - was "GitHub and Jira"
- **EngineeringThroughputAndCycleTimeTeamView.json** - was "GitHub and Jira"
- **WeeklyBugRetro.json** - was "GitHub or Jira"
- **EngineeringOverview.json** - was "Jira + GitHub, or Jira + GitLab" (incomplete)

Closes #8740

## Screenshots
N/A - text-only changes in dashboard description panels

## Other Information
All original context (Scope Config links, team configuration notes, story_points references) has been preserved. Only the data source listing was expanded.