### PR TITLE
fix(gitlab): add missing repos scope in project_mapping

### DIFF
--- a/backend/plugins/gitlab/api/blueprint_V200_test.go
+++ b/backend/plugins/gitlab/api/blueprint_V200_test.go
@@ -72,6 +72,70 @@ func TestMakeScopes(t *testing.T) {
 	assert.Equal(t, actualScopes[2].ScopeId(), expectDomainScopeId)
 }
 
+func TestMakeScopesWithEmptyEntities(t *testing.T) {
+	mockGitlabPlugin(t)
+
+	const connectionId = 1
+	const gitlabProjectId = 37
+	const expectDomainScopeId = "gitlab:GitlabProject:1:37"
+
+	actualScopes, err := makeScopeV200(
+		connectionId,
+		[]*srvhelper.ScopeDetail[models.GitlabProject, models.GitlabScopeConfig]{
+			{
+				Scope: models.GitlabProject{
+					Scope: common.Scope{
+						ConnectionId: connectionId,
+					},
+					GitlabId: gitlabProjectId,
+				},
+				ScopeConfig: &models.GitlabScopeConfig{
+					ScopeConfig: common.ScopeConfig{
+						Entities: []string{},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err)
+	// empty entities should default to all domain types, producing repo + cicd + board scopes
+	assert.Equal(t, 3, len(actualScopes))
+	assert.Equal(t, actualScopes[0].ScopeId(), expectDomainScopeId)
+}
+
+func TestMakeScopesWithCrossEntity(t *testing.T) {
+	mockGitlabPlugin(t)
+
+	const connectionId = 1
+	const gitlabProjectId = 37
+	const expectDomainScopeId = "gitlab:GitlabProject:1:37"
+
+	actualScopes, err := makeScopeV200(
+		connectionId,
+		[]*srvhelper.ScopeDetail[models.GitlabProject, models.GitlabScopeConfig]{
+			{
+				Scope: models.GitlabProject{
+					Scope: common.Scope{
+						ConnectionId: connectionId,
+					},
+					GitlabId: gitlabProjectId,
+				},
+				ScopeConfig: &models.GitlabScopeConfig{
+					ScopeConfig: common.ScopeConfig{
+						Entities: []string{plugin.DOMAIN_TYPE_CROSS, plugin.DOMAIN_TYPE_TICKET},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err)
+	// CROSS entity should trigger repo scope creation, plus ticket = board scope
+	assert.Equal(t, 2, len(actualScopes))
+	assert.Equal(t, actualScopes[0].ScopeId(), expectDomainScopeId)
+	assert.Equal(t, "repos", actualScopes[0].TableName())
+	assert.Equal(t, "boards", actualScopes[1].TableName())
+}
+
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockGitlabPlugin(t)
 

--- a/backend/plugins/gitlab/api/blueprint_v200.go
+++ b/backend/plugins/gitlab/api/blueprint_v200.go
@@ -78,8 +78,14 @@ func makeScopeV200(
 		gitlabProject, scopeConfig := scope.Scope, scope.ScopeConfig
 		id := didgen.NewDomainIdGenerator(&models.GitlabProject{}).Generate(connectionId, gitlabProject.GitlabId)
 
+		// if no entities specified, use all entities enabled by default
+		if len(scopeConfig.Entities) == 0 {
+			scopeConfig.Entities = plugin.DOMAIN_TYPES
+		}
+
 		if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE_REVIEW) ||
-			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE) {
+			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE) ||
+			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CROSS) {
 			// if we don't need to collect gitex, we need to add repo to scopes here
 			scopeRepo := code.NewRepo(id, gitlabProject.PathWithNamespace)
 


### PR DESCRIPTION
## Summary
- GitLab's `makeScopeV200` did not create a `repos` scope when `scopeConfig.Entities` was empty or only contained `CROSS`, causing `project_mapping` to have no `table='repos'` row
- This broke downstream DORA metrics, PR-issue linking, and all Grafana PR dashboard panels that join on `project_mapping` with `table='repos'`
- The fix aligns GitLab with the GitHub plugin's `makeScopesV200` (lines 155-160) by:
  1. Defaulting empty entities to `plugin.DOMAIN_TYPES`
  2. Adding `DOMAIN_TYPE_CROSS` to the repo scope condition

Closes #8742

## Changes
- `backend/plugins/gitlab/api/blueprint_v200.go` - two-line fix in `makeScopeV200`
- `backend/plugins/gitlab/api/blueprint_V200_test.go` - two new test cases:
  - `TestMakeScopesWithEmptyEntities` - verifies empty entities default to all domain types
  - `TestMakeScopesWithCrossEntity` - verifies CROSS entity triggers repo scope creation

## Test plan
- [x] All existing tests pass (`TestMakeScopes`, `TestMakeDataSourcePipelinePlanV200`)
- [x] New tests pass for both empty entities and CROSS entity scenarios
- [x] Tests verified in `mericodev/lake-builder:latest` Docker container (same as CI)

## Note
The same issue also affects Bitbucket (missing empty default) and Azure DevOps (missing both). If this fix is accepted, I am happy to submit follow-up PRs for those plugins.