### PR TITLE
fix(q_dev): replace MariaDB-specific IF NOT EXISTS syntax with DAL methods for MySQL 8.x compatibility

### DIFF
--- a/backend/plugins/q_dev/models/migrationscripts/20251209_add_scope_id_fields.go
+++ b/backend/plugins/q_dev/models/migrationscripts/20251209_add_scope_id_fields.go
@@ -19,6 +19,7 @@ package migrationscripts
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 )
@@ -32,29 +33,24 @@ func (*addScopeIdFields) Up(basicRes context.BasicRes) errors.Error {
 
 	// Add scope_id column to _tool_q_dev_user_data table
 	// This field links user data to QDevS3Slice scope, which can then be mapped to projects via project_mapping
-	err := db.Exec(`
-		ALTER TABLE _tool_q_dev_user_data
-		ADD COLUMN IF NOT EXISTS scope_id VARCHAR(255) DEFAULT NULL
-	`)
-	if err != nil {
-		// Try alternative syntax for databases that don't support IF NOT EXISTS
-		_ = db.Exec(`ALTER TABLE _tool_q_dev_user_data ADD COLUMN scope_id VARCHAR(255) DEFAULT NULL`)
+	if !db.HasColumn("_tool_q_dev_user_data", "scope_id") {
+		if err := db.AddColumn("_tool_q_dev_user_data", "scope_id", dal.Varchar); err != nil {
+			return errors.Default.Wrap(err, "failed to add scope_id to _tool_q_dev_user_data")
+		}
 	}
 
 	// Add index on scope_id for better query performance
-	_ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_q_dev_user_data_scope_id ON _tool_q_dev_user_data(scope_id)`)
+	_ = db.Exec(`CREATE INDEX idx_q_dev_user_data_scope_id ON _tool_q_dev_user_data(scope_id)`)
 
 	// Add scope_id column to _tool_q_dev_s3_file_meta table
-	err = db.Exec(`
-		ALTER TABLE _tool_q_dev_s3_file_meta
-		ADD COLUMN IF NOT EXISTS scope_id VARCHAR(255) DEFAULT NULL
-	`)
-	if err != nil {
-		_ = db.Exec(`ALTER TABLE _tool_q_dev_s3_file_meta ADD COLUMN scope_id VARCHAR(255) DEFAULT NULL`)
+	if !db.HasColumn("_tool_q_dev_s3_file_meta", "scope_id") {
+		if err := db.AddColumn("_tool_q_dev_s3_file_meta", "scope_id", dal.Varchar); err != nil {
+			return errors.Default.Wrap(err, "failed to add scope_id to _tool_q_dev_s3_file_meta")
+		}
 	}
 
 	// Add index on scope_id
-	_ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_q_dev_s3_file_meta_scope_id ON _tool_q_dev_s3_file_meta(scope_id)`)
+	_ = db.Exec(`CREATE INDEX idx_q_dev_s3_file_meta_scope_id ON _tool_q_dev_s3_file_meta(scope_id)`)
 
 	return nil
 }

--- a/backend/plugins/q_dev/models/migrationscripts/20260220_add_account_id_to_s3_slice.go
+++ b/backend/plugins/q_dev/models/migrationscripts/20260220_add_account_id_to_s3_slice.go
@@ -19,6 +19,7 @@ package migrationscripts
 
 import (
 	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 )
@@ -30,13 +31,10 @@ type addAccountIdToS3Slice struct{}
 func (*addAccountIdToS3Slice) Up(basicRes context.BasicRes) errors.Error {
 	db := basicRes.GetDal()
 
-	err := db.Exec(`
-		ALTER TABLE _tool_q_dev_s3_slices
-		ADD COLUMN IF NOT EXISTS account_id VARCHAR(255) DEFAULT NULL
-	`)
-	if err != nil {
-		// Try alternative syntax for databases that don't support IF NOT EXISTS
-		_ = db.Exec(`ALTER TABLE _tool_q_dev_s3_slices ADD COLUMN account_id VARCHAR(255) DEFAULT NULL`)
+	if !db.HasColumn("_tool_q_dev_s3_slices", "account_id") {
+		if err := db.AddColumn("_tool_q_dev_s3_slices", "account_id", dal.Varchar); err != nil {
+			return errors.Default.Wrap(err, "failed to add account_id to _tool_q_dev_s3_slices")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Replace MariaDB-specific `ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS` syntax with database-agnostic DAL methods (`db.HasColumn()` + `db.AddColumn()`) in q_dev migration scripts. This fixes MySQL 8.x compatibility where these syntaxes cause Error 1064 (syntax error).

### Does this close any open issues?
Closes #8744

### Screenshots
N/A
