### PR TITLE
fix(azuredevops): default empty entities and add CROSS to repo scope in makeScopeV200

### DIFF
--- a/backend/plugins/azuredevops_go/api/blueprint_v200.go
+++ b/backend/plugins/azuredevops_go/api/blueprint_v200.go
@@ -77,8 +77,14 @@ func makeScopeV200(
 		}
 		id := didgen.NewDomainIdGenerator(&models.AzuredevopsRepo{}).Generate(connectionId, azuredevopsRepo.Id)
 
+		// if no entities specified, use all entities enabled by default
+		if len(scopeConfig.Entities) == 0 {
+			scopeConfig.Entities = plugin.DOMAIN_TYPES
+		}
+
 		if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE_REVIEW) ||
-			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE) {
+			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE) ||
+			utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CROSS) {
 			// if we don't need to collect gitex, we need to add repo to scopes here
 			scopeRepo := code.NewRepo(id, azuredevopsRepo.Name)
 			sc = append(sc, scopeRepo)

--- a/backend/plugins/azuredevops_go/api/blueprint_v200_test.go
+++ b/backend/plugins/azuredevops_go/api/blueprint_v200_test.go
@@ -78,6 +78,64 @@ func TestMakeScopes(t *testing.T) {
 	assert.Equal(t, actualScopes[2].ScopeId(), expectDomainScopeId)
 }
 
+func TestMakeScopesWithEmptyEntities(t *testing.T) {
+	mockAzuredevopsPlugin(t)
+
+	actualScopes, err := makeScopeV200(
+		connectionID,
+		[]*srvhelper.ScopeDetail[models.AzuredevopsRepo, models.AzuredevopsScopeConfig]{
+			{
+				Scope: models.AzuredevopsRepo{
+					Scope: common.Scope{
+						ConnectionId: connectionID,
+					},
+					Id:   azuredevopsRepoId,
+					Type: models.RepositoryTypeADO,
+				},
+				ScopeConfig: &models.AzuredevopsScopeConfig{
+					ScopeConfig: common.ScopeConfig{
+						Entities: []string{},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err)
+	// empty entities should default to all domain types, producing repo + cicd + board scopes
+	assert.Equal(t, 3, len(actualScopes))
+	assert.Equal(t, actualScopes[0].ScopeId(), expectDomainScopeId)
+}
+
+func TestMakeScopesWithCrossEntity(t *testing.T) {
+	mockAzuredevopsPlugin(t)
+
+	actualScopes, err := makeScopeV200(
+		connectionID,
+		[]*srvhelper.ScopeDetail[models.AzuredevopsRepo, models.AzuredevopsScopeConfig]{
+			{
+				Scope: models.AzuredevopsRepo{
+					Scope: common.Scope{
+						ConnectionId: connectionID,
+					},
+					Id:   azuredevopsRepoId,
+					Type: models.RepositoryTypeADO,
+				},
+				ScopeConfig: &models.AzuredevopsScopeConfig{
+					ScopeConfig: common.ScopeConfig{
+						Entities: []string{plugin.DOMAIN_TYPE_CROSS, plugin.DOMAIN_TYPE_TICKET},
+					},
+				},
+			},
+		},
+	)
+	assert.Nil(t, err)
+	// CROSS entity should trigger repo scope creation, plus ticket = board scope
+	assert.Equal(t, 2, len(actualScopes))
+	assert.Equal(t, actualScopes[0].ScopeId(), expectDomainScopeId)
+	assert.Equal(t, "repos", actualScopes[0].TableName())
+	assert.Equal(t, "boards", actualScopes[1].TableName())
+}
+
 func TestMakeDataSourcePipelinePlanV200(t *testing.T) {
 	mockAzuredevopsPlugin(t)
 


### PR DESCRIPTION
## Summary

- When `scopeConfig.Entities` is empty (common when no entities are explicitly selected in the UI), `makeScopeV200` produced zero scopes, leaving `project_mapping` with no rows
- The repo scope condition did not check for `DOMAIN_TYPE_CROSS`, so selecting only CROSS would not create a repo scope, breaking DORA metrics
- Adds the same fixes applied to GitLab in #8743
- Adds unit tests for empty entities and CROSS entity scenarios

## How has this been tested?

```bash
docker run --rm -v $(pwd):/app -w /app/backend mericodev/lake-builder:latest \
  bash -c "go test ./plugins/azuredevops_go/api/ -v -run TestMakeScopes"
```

All tests pass (new + existing):
- `TestMakeScopes` - CODE + TICKET + CICD = 3 scopes
- `TestMakeScopesWithEmptyEntities` - empty entities defaults to all domain types = 3 scopes
- `TestMakeScopesWithCrossEntity` - CROSS + TICKET = 2 scopes (repos + boards)
- `TestMakeDataSourcePipelinePlanV200` - existing test still passes
- `TestMakeRemoteRepoScopes` - existing test still passes

## What is the fix?

1. After generating the domain ID, default empty entities to `plugin.DOMAIN_TYPES`:

```go
if len(scopeConfig.Entities) == 0 {
    scopeConfig.Entities = plugin.DOMAIN_TYPES
}
```

2. Add `DOMAIN_TYPE_CROSS` to the repo scope condition:

```go
if utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE_REVIEW) ||
    utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CODE) ||
    utils.StringsContains(scopeConfig.Entities, plugin.DOMAIN_TYPE_CROSS) {
```

Closes #8749