### PR TITLE
feat(circleci): add server version requirement and endpoint help text

### DIFF
--- a/config-ui/src/plugins/register/circleci/config.tsx
+++ b/config-ui/src/plugins/register/circleci/config.tsx
@@ -34,8 +34,10 @@ export const CircleCIConfig: IPluginConfig = {
         key: 'endpoint',
         multipleVersions: {
           cloud: 'https://circleci.com/api/',
-          server: '',
+          server: '(v4.x+)',
         },
+        subLabel:
+          'If you are using CircleCI Server, please enter the endpoint URL. E.g. https://circleci.your-company.com/api/',
       },
       'token',
       'proxy',


### PR DESCRIPTION
### Summary
Enables CircleCI Server support in the connection configuration UI by adding version requirements and endpoint configuration guidance.

### Does this close any open issues?
NA

### Screenshots

<img width="824" height="712" alt="CircleCI_Server" src="https://github.com/user-attachments/assets/93916bfb-aeee-4010-8de2-dadb6647c1bd" />

### Other Information
- This is a frontend-only change in `config-ui/src/plugins/register/circleci/config.tsx`
- No backend changes required
- Tested by running the config-ui dev server and verifying the connection form renders correctly
- Follows the same pattern used by other plugins with `multipleVersions` endpoint configurations

