### PR TITLE
Fix/bitbucket microsecond timestamp

### DIFF
--- a/backend/core/models/common/iso8601time.go
+++ b/backend/core/models/common/iso8601time.go
@@ -57,6 +57,10 @@ func init() {
 			Format:  "2006-01-02T15:04:05-0700",
 		},
 		{
+			Matcher: regexp.MustCompile(`[\d]{6}[+-][\d]{2}:[\d]{2}$`),
+			Format:  "2006-01-02T15:04:05.000000-07:00",
+		},
+		{
 			Matcher: regexp.MustCompile(`[\d]{3}[+-][\d]{2}:[\d]{2}$`),
 			Format:  "2006-01-02T15:04:05.000-07:00",
 		},

--- a/backend/core/models/common/iso8601time_test.go
+++ b/backend/core/models/common/iso8601time_test.go
@@ -146,6 +146,18 @@ func TestConvertStringToTime(t *testing.T) {
 			err:    nil,
 		},
 		{
+			name:   "Valid time string with milliseconds",
+			input:  "2025-09-15T08:53:36.337+00:00",
+			output: time.Date(2025, 9, 15, 8, 53, 36, 337000000, time.UTC),
+			err:    nil,
+		},
+		{
+			name:   "Valid time string with microseconds (Bitbucket Cloud format)",
+			input:  "2025-09-15T08:53:36.337932+00:00",
+			output: time.Date(2025, 9, 15, 8, 53, 36, 337932000, time.UTC),
+			err:    nil,
+		},
+		{
 			name:   "Invalid time string",
 			input:  "invalid",
 			output: time.Time{},

--- a/backend/plugins/bitbucket/tasks/pr_extractor.go
+++ b/backend/plugins/bitbucket/tasks/pr_extractor.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"time"
 
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/common"
@@ -57,8 +56,8 @@ type BitbucketApiPullRequest struct {
 	} `json:"links"`
 	ClosedBy           *BitbucketAccountResponse `json:"closed_by"`
 	Author             *BitbucketAccountResponse `json:"author"`
-	BitbucketCreatedAt time.Time                 `json:"created_on"`
-	BitbucketUpdatedAt time.Time                 `json:"updated_on"`
+	BitbucketCreatedAt *common.Iso8601Time        `json:"created_on"`
+	BitbucketUpdatedAt *common.Iso8601Time        `json:"updated_on"`
 	BaseRef            *struct {
 		Branch struct {
 			Name string `json:"name"`
@@ -174,8 +173,8 @@ func convertBitbucketPullRequest(pull *BitbucketApiPullRequest, connId uint64, r
 		Url:                pull.Links.Html.Href,
 		Type:               pull.Type,
 		CommentCount:       pull.CommentCount,
-		BitbucketCreatedAt: pull.BitbucketCreatedAt,
-		BitbucketUpdatedAt: pull.BitbucketUpdatedAt,
+		BitbucketCreatedAt: pull.BitbucketCreatedAt.ToTime(),
+		BitbucketUpdatedAt: pull.BitbucketUpdatedAt.ToTime(),
 	}
 	if pull.BaseRef != nil {
 		if pull.BaseRef.Repo != nil {


### PR DESCRIPTION
Bitbucket Cloud returns timestamps with 6-digit fractional seconds (e.g. 2025-09-15T08:53:36.337932+00:00). The PR extractor used time.Time directly for created_on/updated_on fields, causing a time.ParseError since Go's json.Unmarshal uses RFC3339 which does not accept microseconds.

Fix:
- Change BitbucketCreatedAt/BitbucketUpdatedAt in BitbucketApiPullRequest struct from time.Time to *common.Iso8601Time
- Add microsecond format (6-digit fractional seconds) to DateTimeFormats in Iso8601Time, before the existing 3-digit format, so that ConvertStringToTime correctly parses these timestamps

Fixes #8708

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [ x ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x ] I have added relevant tests.
- [ x] I have added relevant documentation.
- [ x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
  Bitbucket Cloud returns timestamps with 6-digit microsecond precision   (e.g. `2025-09-15T08:53:36.337932+00:00`).  The PR extractor stored   `created_on` and `updated_on` directly as `time.Time`, which caused   a `time.ParseError` during extraction because Go's `json.Unmarshal`    uses RFC3339 — a format that does not accept microseconds.

### Does this close any open issues?
  Closes #8708
  
### Screenshots
-

### Other Information
  Developed with the assistance of an AI coding agent. While I am not proficient in Go,   I have a general software  engineering background and verified that the fix is minimal, targeted, and does not introduce regressions.
