### PR TITLE
fix(jenkins): scope multi-branch build collector query by job full_name

### DIFF
--- a/backend/plugins/jenkins/tasks/build_collector.go
+++ b/backend/plugins/jenkins/tasks/build_collector.go
@@ -150,8 +150,8 @@ func collectMultiBranchJobApiBuilds(taskCtx plugin.SubTaskContext) errors.Error 
 	clauses := []dal.Clause{
 		dal.Select("j.full_name,j.name,j.path,j.class,j.url"),
 		dal.From("_tool_jenkins_jobs as j"),
-		dal.Where(`j.connection_id = ? and j.class = ? and j._raw_data_table = ?`,
-			data.Options.ConnectionId, WORKFLOW_JOB, fmt.Sprintf("_raw_%s", RAW_JOB_TABLE)),
+		dal.Where(`j.connection_id = ? and j.class = ? and j._raw_data_table = ? and j.full_name like ?`,
+			data.Options.ConnectionId, WORKFLOW_JOB, fmt.Sprintf("_raw_%s", RAW_JOB_TABLE), fmt.Sprintf("%s%%", data.Options.JobFullName)),
 	}
 	cursor, err := db.Cursor(clauses...)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Fix data corruption in `_raw_jenkins_api_builds` table where records have mismatched `params` and `url` fields when multiple multi-branch Jenkins pipelines are configured
- Add `full_name LIKE ?` filter to `collectMultiBranchJobApiBuilds()` query, matching the existing pattern in `stage_collector.go:145`

## Root Cause

`collectMultiBranchJobApiBuilds()` in `build_collector.go` queries child jobs for a multi-branch pipeline filtering only by `connection_id`, `class`, and `_raw_data_table` — but **not by the parent pipeline's `full_name`**.

When multiple multi-branch pipelines exist (e.g., `FE/frontend` and `BE/backend`), the query returns child jobs from ALL pipelines. All those builds are then stored with `params` set to the current pipeline's identity, but `url` and `input` fields point to jobs from other pipelines.

The `stage_collector.go` already correctly uses `full_name LIKE ?` filtering (line 145). The build collector was simply missing this same filter.

## Changes

One-line change in `backend/plugins/jenkins/tasks/build_collector.go:153`:

```diff
- dal.Where(`j.connection_id = ? and j.class = ? and j._raw_data_table = ?`,
-     data.Options.ConnectionId, WORKFLOW_JOB, fmt.Sprintf("_raw_%s", RAW_JOB_TABLE)),
+ dal.Where(`j.connection_id = ? and j.class = ? and j._raw_data_table = ? and j.full_name like ?`,
+     data.Options.ConnectionId, WORKFLOW_JOB, fmt.Sprintf("_raw_%s", RAW_JOB_TABLE),
+     fmt.Sprintf("%s%%", data.Options.JobFullName)),
```

## Test Plan

- [ ] Configure 2+ multi-branch Jenkins pipelines pointing to different repos/folders
- [ ] Run data collection for both pipelines
- [ ] Verify `_raw_jenkins_api_builds` records have matching `params` and `url` fields
- [ ] Verify no cross-contamination between pipeline records
- [ ] Verify existing single-pipeline setups still work correctly