### PR TITLE
fix: add timeout to HTTP client in StarRocks stream load

### DIFF
--- a/backend/plugins/starrocks/tasks/tasks.go
+++ b/backend/plugins/starrocks/tasks/tasks.go
@@ -394,6 +394,7 @@ func putBatchData(c plugin.SubTaskContext, starrocksTmpTable, table string, data
 		return err
 	}
 	client := http.Client{
+		Timeout: 60 * time.Second,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},


### PR DESCRIPTION
## Summary
- Add a 60-second timeout to the `http.Client` used in StarRocks stream load
- Without a timeout, requests could hang indefinitely if the StarRocks server becomes unresponsive

## Test plan
- [ ] Verify StarRocks stream load still works correctly
- [ ] Verify timeout triggers appropriately for unresponsive servers