### PR TITLE
fix: replace panics with error handling in pipeline and locking services

### DIFF
--- a/backend/server/services/locking.go
+++ b/backend/server/services/locking.go
@@ -18,7 +18,6 @@ limitations under the License.
 package services
 
 import (
-	"fmt"
 	"os"
 	"time"
 
@@ -61,6 +60,6 @@ func lockDatabase() {
 	select {
 	case <-c:
 	case <-time.After(10 * time.Second):
-		panic(fmt.Errorf("locking _devlake_locking_stub timeout, the database might be locked by another devlake instance"))
+		errors.Must(errors.Default.New("locking _devlake_locking_stub timeout, the database might be locked by another devlake instance"))
 	}
 }

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -267,7 +267,7 @@ func dequeuePipeline(runningParallelLabels []string) (pipeline *models.Pipeline,
 	where_status := dal.Where("status IN ?", []string{models.TASK_CREATED, models.TASK_RERUN, models.TASK_RESUME})
 	err = tx.Pluck("priority", &top_priorities, dal.From(pipeline), where_status, dal.Orderby("priority DESC"), dal.Limit(1))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 	if len(top_priorities) > 0 {
 		top_priority = top_priorities[0]
@@ -303,7 +303,7 @@ func dequeuePipeline(runningParallelLabels []string) (pipeline *models.Pipeline,
 			{ColumnName: "began_at", Value: pipeline.BeganAt},
 		}, dal.Where("id = ?", pipeline.ID))
 		if err != nil {
-			panic(err)
+			return nil, err
 		}
 
 		return
@@ -341,7 +341,9 @@ func RunPipelineInQueue(pipelineMaxParallel int64) {
 
 		err = fillPipelineDetail(dbPipeline)
 		if err != nil {
-			panic(err)
+			globalPipelineLog.Error(err, "failed to fill pipeline detail for pipeline #%d", dbPipeline.ID)
+			sema.Release(1)
+			continue
 		}
 		// add pipelineParallelLabels to runningParallelLabels
 		var pipelineParallelLabels []string


### PR DESCRIPTION
## Summary
- In `RunPipelineInQueue`, replace `panic(err)` with logging + continue when `fillPipelineDetail` fails, so the pipeline queue doesn't crash
- In `lockDatabase`, use `errors.Must` instead of raw `panic(fmt.Errorf(...))` for consistent error handling
- Remove unused `fmt` import in `locking.go`

## Test plan
- [ ] Verify pipeline queue continues processing after a failed pipeline detail fill
- [ ] Verify database locking still works and produces clear error messages on timeout