### PR TITLE
fix: replace panics with error returns in helper packages

### DIFF
--- a/backend/helpers/dbhelper/txhelper.go
+++ b/backend/helpers/dbhelper/txhelper.go
@@ -57,7 +57,7 @@ func (l *TxHelper[E]) LockTablesTimeout(timeout time.Duration, lockTables dal.Lo
 	select {
 	case err := <-c:
 		if err != nil {
-			panic(err)
+			return err
 		}
 	case <-time.After(timeout):
 		return errors.Timeout.New("lock tables timeout: " + fmt.Sprintf("%v", lockTables))

--- a/backend/helpers/srvhelper/scope_service_helper.go
+++ b/backend/helpers/srvhelper/scope_service_helper.go
@@ -270,7 +270,7 @@ func (scopeSrv *ScopeSrvHelper[C, S, SC]) getAffectedTables() ([]string, errors.
 	}
 	pluginModel, ok := meta.(plugin.PluginModel)
 	if !ok {
-		panic(errors.Default.New(fmt.Sprintf("plugin \"%s\" does not implement listing its tables", scopeSrv.pluginName)))
+		return nil, errors.Default.New(fmt.Sprintf("plugin \"%s\" does not implement listing its tables", scopeSrv.pluginName))
 	}
 	// Unfortunately, can't cache the tables because Python creates some tables on a per-demand basis, so such a cache would possibly get outdated.
 	// It's a rare scenario in practice, but might as well play it safe and sacrifice some performance here


### PR DESCRIPTION
## Summary
- In `TxHelper.LockTablesTimeout`, return the lock error instead of panicking so callers can handle it gracefully
- In `ScopeSrvHelper.getAffectedTables`, return an error instead of panicking when a plugin doesn't implement the `PluginModel` interface

## Test plan
- [ ] Verify table locking timeout is properly returned as an error
- [ ] Verify scope deletion still works correctly when plugin implements PluginModel
- [ ] Verify proper error message when plugin does not implement PluginModel