### PR TITLE
fix: handle silently ignored errors in migration helper and pipeline cancel

### DIFF
--- a/backend/helpers/migrationhelper/migrationhelper.go
+++ b/backend/helpers/migrationhelper/migrationhelper.go
@@ -40,7 +40,11 @@ func AutoMigrateTables(basicRes context.BasicRes, dst ...interface{}) errors.Err
 		if err != nil {
 			return err
 		}
-		_ = db.First(entity)
+		// Load one record to verify the table is readable after migration.
+		// NotFound is expected for empty tables and can be safely ignored.
+		if err = db.First(entity); err != nil && !db.IsErrorNotFound(err) {
+			return errors.Default.Wrap(err, "failed to verify table after migration")
+		}
 	}
 	return nil
 }

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -462,9 +462,11 @@ func CancelPipeline(pipelineId uint64) errors.Error {
 		return nil
 	}
 	for _, pendingTask := range pendingTasks {
-		_ = CancelTask(pendingTask.ID)
+		if cancelErr := CancelTask(pendingTask.ID); cancelErr != nil {
+			globalPipelineLog.Error(cancelErr, "failed to cancel task #%d of pipeline #%d", pendingTask.ID, pipelineId)
+		}
 	}
-	return errors.Convert(err)
+	return nil
 }
 
 // getPipelineLogsPath gets the logs directory of this pipeline


### PR DESCRIPTION
## Summary
- In `AutoMigrateTables`, properly handle `db.First` errors instead of silently discarding them — `NotFound` is expected for empty tables but other errors (e.g. connection issues) should be surfaced
- In `CancelPipeline`, log task cancellation failures instead of silently ignoring them with `_ = CancelTask()`

## Test plan
- [ ] Verify AutoMigrateTables works correctly for both empty and populated tables
- [ ] Verify pipeline cancellation logs errors for individual task cancel failures
- [ ] Verify existing migration scripts still pass