### PR TITLE
fix(ci): lock Poetry to version 2.2.1 for Python 3.9 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,11 @@ on:
       - main
       - release-*
       - fix-clear-docker-images-before-build
+  pull_request:
+    paths:
+      - 'backend/Dockerfile'
+      - 'config-ui/Dockerfile'
+      - 'grafana/Dockerfile'
 
 jobs:
   build-and-push-builder:
@@ -186,12 +191,13 @@ jobs:
         id: get_push_tags
         run: |
           image_name=${{ secrets.DOCKERHUB_OWNER }}/devlake
+          ref_name=$(echo "${{ github.ref_name }}" | tr '/' '-')
           if printf ${{ github.ref }} |grep -Pq '^refs/tags/' && printf ${{ github.ref_name }} | grep -Pq '^v(\d+).(\d+).(\d+)$'; then
               echo "TAGS=${image_name}:latest,${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
           elif printf ${{ github.ref }} |grep -Pq '^refs/tags/'; then
               echo "TAGS=${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
-              echo "TAGS=${image_name}:${{ github.ref_name }}_${{ needs.get-timestamp.outputs.timestamp }}_${{ steps.get_short_sha.outputs.SHORT_SHA }}" >> $GITHUB_OUTPUT
+              echo "TAGS=${image_name}:${ref_name}_${{ needs.get-timestamp.outputs.timestamp }}_${{ steps.get_short_sha.outputs.SHORT_SHA }}" >> $GITHUB_OUTPUT
           fi
       - name: Build and push lake image
         uses: docker/build-push-action@v3
@@ -265,12 +271,13 @@ jobs:
         id: get_push_tags
         run: |
           image_name=${{ secrets.DOCKERHUB_OWNER }}/${{ matrix.build.image }}
+          ref_name=$(echo "${{ github.ref_name }}" | tr '/' '-')
           if printf ${{ github.ref }} |grep -Pq '^refs/tags/' && printf ${{ github.ref_name }} | grep -Pq '^v(\d+).(\d+).(\d+)$'; then
               echo "TAGS=${image_name}:latest,${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
           elif printf ${{ github.ref }} |grep -Pq '^refs/tags/'; then
               echo "TAGS=${image_name}:${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
-              echo "TAGS=${image_name}:${{ github.ref_name }}_${{ needs.get-timestamp.outputs.timestamp }}_${{ steps.get_short_sha.outputs.SHORT_SHA }}" >> $GITHUB_OUTPUT
+              echo "TAGS=${image_name}:${ref_name}_${{ needs.get-timestamp.outputs.timestamp }}_${{ steps.get_short_sha.outputs.SHORT_SHA }}" >> $GITHUB_OUTPUT
           fi
       - name: Build and push ${{ matrix.build.name }} image
         uses: docker/build-push-action@v3

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -149,7 +149,8 @@ RUN python3 -m pip install --no-cache --upgrade pip setuptools && \
     python3 -m pip install --upgrade pip
 
 # Setup Python Poetry package manager
-RUN curl -sSL https://install.python-poetry.org | python3 -
+# Install Poetry 2.2.1 (last version compatible with Python 3.9)
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1
 ENV PATH="$PATH:/app/.local/bin"
 
 # Build Python plugins, make sure the scripts has execute permission


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Poetry 2.3.x requires Python >= 3.10, but this project uses Python 3.9. Lock Poetry to version 2.2.1 (last version compatible with Python 3.9).

Also add PR trigger for Docker builds and fix Docker tag slash issues by replacing slashes with dashes in ref_name.

### Does this close any open issues?
Closes xx

### Screenshots
Include any relevant screenshots here.

### Other Information
Any other information that is important to this PR.
