### PR TITLE
fix(jenkins): scope multi-branch build collection to current project

### DIFF
--- a/backend/plugins/jenkins/tasks/build_collector.go
+++ b/backend/plugins/jenkins/tasks/build_collector.go
@@ -146,12 +146,17 @@ func collectMultiBranchJobApiBuilds(taskCtx plugin.SubTaskContext) errors.Error 
 	logger := taskCtx.GetLogger()
 
 	// Jobs added through the multi-branch workflow have _raw_data_table set to "jenkins_api_jobs".
-	// This check works, but it's not very robust. It would be better to use a more explicit check like a "source" column.
+	// Filter by _raw_data_params to scope to only this multi-branch project's branch jobs,
+	// preventing cross-project data mixing when multiple multi-branch pipelines exist.
+	jobParams := plugin.MarshalScopeParams(JenkinsApiParams{
+		ConnectionId: data.Options.ConnectionId,
+		FullName:     data.Options.JobFullName,
+	})
 	clauses := []dal.Clause{
 		dal.Select("j.full_name,j.name,j.path,j.class,j.url"),
 		dal.From("_tool_jenkins_jobs as j"),
-		dal.Where(`j.connection_id = ? and j.class = ? and j._raw_data_table = ?`,
-			data.Options.ConnectionId, WORKFLOW_JOB, fmt.Sprintf("_raw_%s", RAW_JOB_TABLE)),
+		dal.Where(`j.connection_id = ? and j.class = ? and j._raw_data_table = ? and j._raw_data_params = ?`,
+			data.Options.ConnectionId, WORKFLOW_JOB, fmt.Sprintf("_raw_%s", RAW_JOB_TABLE), jobParams),
 	}
 	cursor, err := db.Cursor(clauses...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes #8430 — `_raw_jenkins_api_builds` table becomes bloated with faulty records when using multiple multi-branch pipelines
- The branch jobs query in `collectMultiBranchJobApiBuilds` selected all `WorkflowJob` entries across **all** multi-branch pipelines for a connection, causing builds to be duplicated and misattributed between projects
- Added `_raw_data_params` filter to scope the query to only the current multi-branch project's branch jobs

## Test plan
- [ ] Configure two or more multi-branch pipelines on the same Jenkins connection
- [ ] Run a full sync and verify `_raw_jenkins_api_builds` only contains records for the correct project per params value
- [ ] Verify no cross-project data mixing in `_tool_jenkins_builds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)