### PR TITLE
fix(sonarqube): increase cq_issues and cq_file_metrics project_key length to 500

### DIFF
--- a/backend/core/models/domainlayer/codequality/cq_file_metrics.go
+++ b/backend/core/models/domainlayer/codequality/cq_file_metrics.go
@@ -23,7 +23,7 @@ import (
 
 type CqFileMetrics struct {
 	domainlayer.DomainEntity
-	ProjectKey                          string `gorm:"index;type:varchar(255)"` //domain project key
+	ProjectKey                          string `gorm:"index;type:varchar(500)"` //domain project key
 	FileName                            string `gorm:"type:varchar(2000)"`
 	FilePath                            string
 	FileLanguage                        string `gorm:"type:varchar(20)"`

--- a/backend/core/models/domainlayer/codequality/cq_issues.go
+++ b/backend/core/models/domainlayer/codequality/cq_issues.go
@@ -27,7 +27,7 @@ type CqIssue struct {
 	Rule                     string `gorm:"type:varchar(255)"`
 	Severity                 string `gorm:"type:varchar(100)"`
 	Component                string
-	ProjectKey               string `gorm:"index;type:varchar(100)"` //domain project key
+	ProjectKey               string `gorm:"index;type:varchar(500)"` //domain project key
 	Line                     int
 	Status                   string `gorm:"type:varchar(20)"`
 	Message                  string

--- a/backend/core/models/migrationscripts/20260317_increase_cq_issues_project_key_length.go
+++ b/backend/core/models/migrationscripts/20260317_increase_cq_issues_project_key_length.go
@@ -1,0 +1,44 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var _ plugin.MigrationScript = (*increaseCqIssuesProjectKeyLength)(nil)
+
+type increaseCqIssuesProjectKeyLength struct{}
+
+func (script *increaseCqIssuesProjectKeyLength) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	if err := db.ModifyColumnType("cq_issues", "project_key", "varchar(500)"); err != nil {
+		return err
+	}
+	return db.ModifyColumnType("cq_file_metrics", "project_key", "varchar(500)")
+}
+
+func (*increaseCqIssuesProjectKeyLength) Version() uint64 {
+	return 20260317000000
+}
+
+func (*increaseCqIssuesProjectKeyLength) Name() string {
+	return "increase cq_issues and cq_file_metrics project_key length to 500"
+}

--- a/backend/core/models/migrationscripts/register.go
+++ b/backend/core/models/migrationscripts/register.go
@@ -143,5 +143,6 @@ func All() []plugin.MigrationScript {
 		new(addPipelinePriority),
 		new(fixNullPriority),
 		new(modifyCicdDeploymentsToText),
+		new(increaseCqIssuesProjectKeyLength),
 	}
 }


### PR DESCRIPTION


### Summary

The project_key column in cq_issues and cq_file_metrics were too short to hold the domain-layer project ID generated by didgen (format: sonarqube:SonarqubeProject:<connectionId>:<projectKey>). Since SonarQube allows project keys up to 400 characters, the generated domain ID can be around ~450 characters, which will cause the "Data too long for column" error. This changes the columns cq_issues and cq_file_metrics to varchar(500) which allows for the long names and is consistent with DomainEntityExtended.Id

### Does this close any open issues?
Closes #8331

### Screenshots
N/A

### Other Information
Added migration script (20260317_increase_cq_issues_project_key_length) to alter both columns on the next startup.