### PR TITLE
fix(gh-copilot): skip empty report responses for dates without Copilot data

### DIFF
--- a/backend/plugins/gh-copilot/tasks/enterprise_metrics_collector.go
+++ b/backend/plugins/gh-copilot/tasks/enterprise_metrics_collector.go
@@ -95,11 +95,13 @@ func CollectEnterpriseMetrics(taskCtx plugin.SubTaskContext) errors.Error {
 		Concurrency:   1,
 		AfterResponse: ignore404,
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
-			// Parse metadata response to get download links
 			body, readErr := io.ReadAll(res.Body)
 			res.Body.Close()
 			if readErr != nil {
 				return nil, errors.Default.Wrap(readErr, "failed to read report metadata")
+			}
+			if isEmptyReport(body) {
+				return nil, nil
 			}
 
 			var meta reportMetadataResponse

--- a/backend/plugins/gh-copilot/tasks/metrics_collector_test.go
+++ b/backend/plugins/gh-copilot/tasks/metrics_collector_test.go
@@ -67,3 +67,24 @@ func TestComputeReportDateRangeClampsFutureSince(t *testing.T) {
 	require.Equal(t, time.Date(2025, 1, 9, 0, 0, 0, 0, time.UTC), until)
 	require.Equal(t, time.Date(2025, 1, 9, 0, 0, 0, 0, time.UTC), start)
 }
+
+func TestIsEmptyReport(t *testing.T) {
+	tests := []struct {
+		name string
+		body []byte
+		want bool
+	}{
+		{"empty JSON string", []byte(`""`), true},
+		{"null", []byte("null"), true},
+		{"empty body", []byte{}, true},
+		{"whitespace only", []byte("   "), true},
+		{"padded empty string", []byte(`  ""  `), true},
+		{"valid metadata", []byte(`{"download_links":["https://example.com/report.json"],"report_day":"2026-03-19"}`), false},
+		{"valid metadata empty links", []byte(`{"download_links":[],"report_day":"2026-03-19"}`), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isEmptyReport(tt.body))
+		})
+	}
+}

--- a/backend/plugins/gh-copilot/tasks/org_metrics_collector.go
+++ b/backend/plugins/gh-copilot/tasks/org_metrics_collector.go
@@ -94,6 +94,9 @@ func CollectOrgMetrics(taskCtx plugin.SubTaskContext) errors.Error {
 			if readErr != nil {
 				return nil, errors.Default.Wrap(readErr, "failed to read report metadata")
 			}
+			if isEmptyReport(body) {
+				return nil, nil
+			}
 
 			var meta reportMetadataResponse
 			if jsonErr := json.Unmarshal(body, &meta); jsonErr != nil {

--- a/backend/plugins/gh-copilot/tasks/report_download_helper.go
+++ b/backend/plugins/gh-copilot/tasks/report_download_helper.go
@@ -60,6 +60,14 @@ func ignore404(res *http.Response) errors.Error {
 	return nil
 }
 
+// isEmptyReport returns true when the GitHub API returned an HTTP 200 but the
+// body carries no usable report data.  For dates before Copilot usage data was
+// available the API responds with "" (empty JSON string) instead of a 404.
+func isEmptyReport(body []byte) bool {
+	b := bytes.TrimSpace(body)
+	return len(b) == 0 || string(b) == `""` || string(b) == "null"
+}
+
 // reportMetadataResponse represents the JSON returned by the report metadata endpoints.
 type reportMetadataResponse struct {
 	DownloadLinks []string `json:"download_links"`

--- a/backend/plugins/gh-copilot/tasks/user_metrics_collector.go
+++ b/backend/plugins/gh-copilot/tasks/user_metrics_collector.go
@@ -99,6 +99,9 @@ func CollectUserMetrics(taskCtx plugin.SubTaskContext) errors.Error {
 			if readErr != nil {
 				return nil, errors.Default.Wrap(readErr, "failed to read report metadata")
 			}
+			if isEmptyReport(body) {
+				return nil, nil
+			}
 
 			var meta reportMetadataResponse
 			if jsonErr := json.Unmarshal(body, &meta); jsonErr != nil {


### PR DESCRIPTION
## Summary

GitHub's Copilot Usage Metrics Reports API returns HTTP 200 with body `""` for dates before usage data was available, instead of returning a 404. The existing `ignore404` callback does not catch this, so the `ResponseParser` attempts `json.Unmarshal` on `""` which fails and crashes the collector pipeline.

**Changes:**
- Add an `isEmptyReport(body []byte) bool` helper in `report_download_helper.go` that detects empty, `""`, or `null` bodies
- Guard the `ResponseParser` in all three collectors (`enterprise_metrics_collector.go`, `org_metrics_collector.go`, `user_metrics_collector.go`) to return `nil, nil` when an empty report is detected, so the collector silently skips those days
- Add unit tests for `isEmptyReport` covering empty body, `""`, `null`, whitespace, and valid metadata cases

Fixes #8789

## Test Plan
- [x] Unit tests added for `isEmptyReport` covering edge cases (empty body, `""`, `null`, whitespace, valid JSON)
- [x] Manual verification: configure a Copilot connection with a `since` date predating available usage data and confirm the collector no longer crashes

Made with [Cursor](https://cursor.com)