### PR TITLE
Fix/gh copilot apiversion

### DIFF
--- a/backend/plugins/gh-copilot/service/connection_test_helper.go
+++ b/backend/plugins/gh-copilot/service/connection_test_helper.go
@@ -73,7 +73,7 @@ func TestConnection(ctx stdctx.Context, br corectx.BasicRes, connection *models.
 	}
 	apiClient.SetHeaders(map[string]string{
 		"Accept":               "application/vnd.github+json",
-		"X-GitHub-Api-Version": "2022-11-28",
+		"X-GitHub-Api-Version": "2026-03-10",
 	})
 
 	result := &TestConnectionResult{

--- a/backend/plugins/gh-copilot/tasks/api_client.go
+++ b/backend/plugins/gh-copilot/tasks/api_client.go
@@ -28,6 +28,8 @@ import (
 	"github.com/apache/incubator-devlake/plugins/gh-copilot/models"
 )
 
+const gitHubApiVersion = "2026-03-10"
+
 type nowFunc func() time.Time
 type sleepFunc func(time.Duration)
 
@@ -65,7 +67,7 @@ func CreateApiClient(taskCtx plugin.TaskContext, connection *models.GhCopilotCon
 
 	apiClient.SetHeaders(map[string]string{
 		"Accept":               "application/vnd.github+json",
-		"X-GitHub-Api-Version": "2026-03-10",
+		"X-GitHub-Api-Version": gitHubApiVersion,
 	})
 
 	rateLimiter := &helper.ApiRateLimitCalculator{UserRateLimitPerHour: connection.RateLimitPerHour}

--- a/backend/plugins/gh-copilot/tasks/api_client.go
+++ b/backend/plugins/gh-copilot/tasks/api_client.go
@@ -65,7 +65,7 @@ func CreateApiClient(taskCtx plugin.TaskContext, connection *models.GhCopilotCon
 
 	apiClient.SetHeaders(map[string]string{
 		"Accept":               "application/vnd.github+json",
-		"X-GitHub-Api-Version": "2022-11-28",
+		"X-GitHub-Api-Version": "2026-03-10",
 	})
 
 	rateLimiter := &helper.ApiRateLimitCalculator{UserRateLimitPerHour: connection.RateLimitPerHour}

--- a/backend/plugins/gh-copilot/tasks/api_client_test.go
+++ b/backend/plugins/gh-copilot/tasks/api_client_test.go
@@ -75,3 +75,8 @@ func TestHandleGitHubRetryAfterNoopOnNon429(t *testing.T) {
 	require.Equal(t, time.Duration(0), slept)
 	require.Len(t, logger.warnings, 0)
 }
+
+func TestGitHubApiVersionHeaderValue(t *testing.T) {
+	require.Equal(t, "2026-03-10", gitHubApiVersion,
+		"GitHub API version header was changed; verify the new version is supported and update this test")
+}


### PR DESCRIPTION
### Summary
Updates the `X-GitHub-Api-Version` request header in the `gh-copilot` plugin from
`2022-11-28` to `2026-03-10` to target the latest stable GitHub REST API version.

Also extracts the version string into a named constant (`gitHubApiVersion`) to avoid
duplication, and aligns `connection_test_helper.go` which still referenced the old version.

### Does this close any open issues?
N/A

### Screenshots
N/A

### Other Information
- GitHub documents supported API versions here: https://docs.github.com/en/rest/copilot/copilot-usage-metrics?apiVersion=2026-03-10
- A regression test (`TestGitHubApiVersionHeaderValue`) is added to catch unintentional future version changes.