### PR TITLE
Fix/8787 cancel pipeline keeps running

### DIFF
--- a/backend/core/runner/run_task.go
+++ b/backend/core/runner/run_task.go
@@ -77,7 +77,12 @@ func RunTask(
 		}
 		finishedAt := time.Now()
 		spentSeconds := finishedAt.Unix() - beganAt.Unix()
+		isCancelled := errors.Is(err, gocontext.Canceled) || ctx.Err() == gocontext.Canceled
 		if err != nil {
+			taskStatus := models.TASK_FAILED
+			if isCancelled {
+				taskStatus = models.TASK_CANCELLED
+			}
 			lakeErr := errors.AsLakeErrorType(err)
 			subTaskName := "unknown"
 			if lakeErr = lakeErr.As(errors.SubtaskErr); lakeErr != nil {
@@ -87,16 +92,19 @@ func RunTask(
 			} else {
 				lakeErr = errors.Convert(err)
 			}
-			dbe := db.UpdateColumns(task, []dal.DalSet{
-				{ColumnName: "status", Value: models.TASK_FAILED},
+			columns := []dal.DalSet{
+				{ColumnName: "status", Value: taskStatus},
 				{ColumnName: "message", Value: lakeErr.Error()},
 				{ColumnName: "error_name", Value: lakeErr.Messages().Format()},
 				{ColumnName: "finished_at", Value: finishedAt},
 				{ColumnName: "spent_seconds", Value: spentSeconds},
-				{ColumnName: "failed_sub_task", Value: subTaskName},
-			})
+			}
+			if taskStatus == models.TASK_FAILED {
+				columns = append(columns, dal.DalSet{ColumnName: "failed_sub_task", Value: subTaskName})
+			}
+			dbe := db.UpdateColumns(task, columns)
 			if dbe != nil {
-				logger.Error(dbe, "failed to finalize task status into db (task failed)")
+				logger.Error(dbe, "failed to finalize task status into db (task %s)", taskStatus)
 			}
 		} else {
 			dbe := db.UpdateColumns(task, []dal.DalSet{
@@ -116,7 +124,7 @@ func RunTask(
 			dal.Where("id=?", task.PipelineId),
 		))
 		// not return err if the `SkipOnFail` is true and the error is not canceled
-		if dbPipeline.SkipOnFail && !errors.Is(err, gocontext.Canceled) {
+		if dbPipeline.SkipOnFail && !isCancelled {
 			err = nil
 		}
 	}()

--- a/backend/plugins/gitextractor/parser/repo_gogit.go
+++ b/backend/plugins/gitextractor/parser/repo_gogit.go
@@ -524,6 +524,11 @@ func (r *GogitRepoCollector) storeRepoSnapshot(subtaskCtx plugin.SubTaskContext,
 	ctx := subtaskCtx.GetContext()
 	snapshot := make(map[string][]string) // {"filePathAndName": ["line1 commit sha", "line2 commit sha"]}
 	for _, commit := range commitList {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
 		commitTree, firstParentTree, err := r.getCurrentAndParentTree(ctx, commit)
 		if err != nil {
 			return err
@@ -533,6 +538,11 @@ func (r *GogitRepoCollector) storeRepoSnapshot(subtaskCtx plugin.SubTaskContext,
 			return err
 		}
 		for _, p := range patch.Stats() {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			default:
+			}
 			fileName := p.Name
 			if _, ok := snapshot[fileName]; !ok {
 				snapshot[fileName] = []string{}

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -461,10 +461,39 @@ func CancelPipeline(pipelineId uint64) errors.Error {
 	if count == 0 {
 		return nil
 	}
+	// Separate running tasks (need context cancellation) from non-running tasks
+	// (non-running tasks have no context to cancel; update their status directly in DB)
+	var nonRunningTaskIds []uint64
+	var failedCancels int
 	for _, pendingTask := range pendingTasks {
-		_ = CancelTask(pendingTask.ID)
+		if pendingTask.Status == models.TASK_RUNNING {
+			if err := CancelTask(pendingTask.ID); err != nil {
+				if err.As(errors.NotFound) != nil {
+					// Task already finished between our DB read and cancel attempt
+					continue
+				}
+				globalPipelineLog.Error(err, "failed to cancel running task #%d", pendingTask.ID)
+				failedCancels++
+			}
+		} else {
+			nonRunningTaskIds = append(nonRunningTaskIds, pendingTask.ID)
+		}
 	}
-	return errors.Convert(err)
+	if len(nonRunningTaskIds) > 0 {
+		err = db.UpdateColumn(
+			&models.Task{},
+			"status", models.TASK_CANCELLED,
+			dal.Where("id IN ? AND status IN ?", nonRunningTaskIds, []string{models.TASK_CREATED, models.TASK_RERUN}),
+		)
+		if err != nil {
+			globalPipelineLog.Error(err, "failed to cancel %d pending tasks in DB", len(nonRunningTaskIds))
+			failedCancels += len(nonRunningTaskIds)
+		}
+	}
+	if failedCancels > 0 {
+		return errors.Default.New(fmt.Sprintf("failed to cancel %d task(s)", failedCancels))
+	}
+	return nil
 }
 
 // getPipelineLogsPath gets the logs directory of this pipeline

--- a/backend/server/services/pipeline.go
+++ b/backend/server/services/pipeline.go
@@ -461,39 +461,54 @@ func CancelPipeline(pipelineId uint64) errors.Error {
 	if count == 0 {
 		return nil
 	}
-	// Separate running tasks (need context cancellation) from non-running tasks
-	// (non-running tasks have no context to cancel; update their status directly in DB)
-	var nonRunningTaskIds []uint64
-	var failedCancels int
-	for _, pendingTask := range pendingTasks {
-		if pendingTask.Status == models.TASK_RUNNING {
-			if err := CancelTask(pendingTask.ID); err != nil {
-				if err.As(errors.NotFound) != nil {
-					// Task already finished between our DB read and cancel attempt
-					continue
-				}
-				globalPipelineLog.Error(err, "failed to cancel running task #%d", pendingTask.ID)
-				failedCancels++
-			}
+	var runningTaskIds []uint64
+	var pendingTaskIds []uint64
+	for _, task := range pendingTasks {
+		if task.Status == models.TASK_RUNNING {
+			runningTaskIds = append(runningTaskIds, task.ID)
 		} else {
-			nonRunningTaskIds = append(nonRunningTaskIds, pendingTask.ID)
+			pendingTaskIds = append(pendingTaskIds, task.ID)
 		}
 	}
-	if len(nonRunningTaskIds) > 0 {
-		err = db.UpdateColumn(
-			&models.Task{},
-			"status", models.TASK_CANCELLED,
-			dal.Where("id IN ? AND status IN ?", nonRunningTaskIds, []string{models.TASK_CREATED, models.TASK_RERUN}),
-		)
-		if err != nil {
-			globalPipelineLog.Error(err, "failed to cancel %d pending tasks in DB", len(nonRunningTaskIds))
-			failedCancels += len(nonRunningTaskIds)
-		}
-	}
+	failedCancels := cancelRunningTasks(runningTaskIds) + cancelPendingTasksInDB(pendingTaskIds)
 	if failedCancels > 0 {
-		return errors.Default.New(fmt.Sprintf("failed to cancel %d task(s)", failedCancels))
+		return errors.Default.New(fmt.Sprintf("failed to cancel %d task(s) for pipeline #%d", failedCancels, pipelineId))
 	}
 	return nil
+}
+
+// cancelRunningTasks cancels tasks that are actively running by triggering
+// their context cancellation. Returns the number of tasks that failed to cancel.
+func cancelRunningTasks(taskIds []uint64) int {
+	failCount := 0
+	for _, taskId := range taskIds {
+		if err := CancelTask(taskId); err != nil {
+			if err.GetType() == errors.NotFound {
+				continue // task no longer tracked in-memory (finished or context lost after restart)
+			}
+			globalPipelineLog.Error(err, "failed to cancel running task #%d", taskId)
+			failCount++
+		}
+	}
+	return failCount
+}
+
+// cancelPendingTasksInDB marks non-running pending tasks as cancelled directly
+// in the database. Returns the number of tasks that failed to update.
+func cancelPendingTasksInDB(taskIds []uint64) int {
+	if len(taskIds) == 0 {
+		return 0
+	}
+	err := db.UpdateColumn(
+		&models.Task{},
+		"status", models.TASK_CANCELLED,
+		dal.Where("id IN ? AND status IN ?", taskIds, []string{models.TASK_CREATED, models.TASK_RERUN, models.TASK_RESUME}),
+	)
+	if err != nil {
+		globalPipelineLog.Error(err, "failed to cancel %d pending tasks in DB", len(taskIds))
+		return len(taskIds)
+	}
+	return 0
 }
 
 // getPipelineLogsPath gets the logs directory of this pipeline

--- a/backend/server/services/pipeline_runner.go
+++ b/backend/server/services/pipeline_runner.go
@@ -107,9 +107,10 @@ func runPipeline(pipelineId uint64) errors.Error {
 }
 
 // ComputePipelineStatus determines pipeline status by its latest(rerun included) tasks statuses
-// 1. TASK_COMPLETED: all tasks were executed successfully
-// 2. TASK_FAILED: SkipOnFail=false with failed task(s)
-// 3. TASK_PARTIAL: SkipOnFail=true with failed task(s)
+// 1. TASK_CANCELLED: pipeline was cancelled by the user (takes priority)
+// 2. TASK_COMPLETED: all tasks were executed successfully
+// 3. TASK_FAILED: SkipOnFail=false with failed task(s)
+// 4. TASK_PARTIAL: SkipOnFail=true with failed task(s)
 func ComputePipelineStatus(pipeline *models.Pipeline, isCancelled bool) (string, errors.Error) {
 	tasks, err := GetLatestTasksOfPipeline(pipeline)
 	if err != nil {
@@ -134,6 +135,9 @@ func ComputePipelineStatus(pipeline *models.Pipeline, isCancelled bool) (string,
 		return "", errors.Default.New("unexpected status, did you call computePipelineStatus at a wrong timing?")
 	}
 
+	if isCancelled {
+		return models.TASK_CANCELLED, nil
+	}
 	if failed == 0 {
 		return models.TASK_COMPLETED, nil
 	}

--- a/backend/test/e2e/services/pipeline_runner_test.go
+++ b/backend/test/e2e/services/pipeline_runner_test.go
@@ -18,11 +18,14 @@ limitations under the License.
 package services
 
 import (
+	"testing"
+	"time"
+
+	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/models"
 	"github.com/apache/incubator-devlake/server/services"
 	"github.com/apache/incubator-devlake/test/helper"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestComputePipelineStatus(t *testing.T) {
@@ -180,4 +183,104 @@ func TestComputePipelineStatus(t *testing.T) {
 	status, err = services.ComputePipelineStatus(pipeline, true)
 	assert.Nil(t, err)
 	assert.Equal(t, models.TASK_CANCELLED, status)
+}
+
+func TestCancelPipeline(t *testing.T) {
+	client := helper.StartDevLakeServer(t, nil)
+	db := client.GetDal()
+
+	t.Run("cancels pending pipeline and all its tasks", func(t *testing.T) {
+		pipeline := &models.Pipeline{
+			TotalTasks: 2,
+			Status:     models.TASK_CREATED,
+		}
+		err := db.Create(pipeline)
+		assert.Nil(t, err)
+		assert.NotZero(t, pipeline.ID)
+
+		task1 := &models.Task{
+			PipelineId:  pipeline.ID,
+			PipelineRow: 1,
+			PipelineCol: 1,
+			Plugin:      "github",
+			Status:      models.TASK_CREATED,
+		}
+		task2 := &models.Task{
+			PipelineId:  pipeline.ID,
+			PipelineRow: 1,
+			PipelineCol: 2,
+			Plugin:      "gitextractor",
+			Status:      models.TASK_CREATED,
+		}
+		err = db.Create(task1)
+		assert.Nil(t, err)
+		assert.NotZero(t, task1.ID)
+		err = db.Create(task2)
+		assert.Nil(t, err)
+		assert.NotZero(t, task2.ID)
+
+		err = services.CancelPipeline(pipeline.ID)
+		assert.Nil(t, err)
+
+		cancelledPipeline := &models.Pipeline{}
+		err = db.First(cancelledPipeline, dal.Where("id = ?", pipeline.ID))
+		assert.Nil(t, err)
+		assert.Equal(t, models.TASK_CANCELLED, cancelledPipeline.Status)
+
+		cancelledTask1, err := services.GetTask(task1.ID)
+		assert.Nil(t, err)
+		assert.Equal(t, models.TASK_CANCELLED, cancelledTask1.Status)
+		cancelledTask2, err := services.GetTask(task2.ID)
+		assert.Nil(t, err)
+		assert.Equal(t, models.TASK_CANCELLED, cancelledTask2.Status)
+	})
+
+	t.Run("cancels pending tasks but leaves completed tasks unchanged", func(t *testing.T) {
+		pipeline := &models.Pipeline{
+			TotalTasks: 2,
+			Status:     models.TASK_RUNNING,
+		}
+		err := db.Create(pipeline)
+		assert.Nil(t, err)
+		assert.NotZero(t, pipeline.ID)
+
+		finishedAt := time.Now()
+		completedTask := &models.Task{
+			PipelineId:  pipeline.ID,
+			PipelineRow: 1,
+			PipelineCol: 1,
+			Plugin:      "github",
+			Status:      models.TASK_COMPLETED,
+			FinishedAt:  &finishedAt,
+		}
+		pendingTask := &models.Task{
+			PipelineId:  pipeline.ID,
+			PipelineRow: 2,
+			PipelineCol: 1,
+			Plugin:      "refdiff",
+			Status:      models.TASK_CREATED,
+		}
+		err = db.Create(completedTask)
+		assert.Nil(t, err)
+		assert.NotZero(t, completedTask.ID)
+		err = db.Create(pendingTask)
+		assert.Nil(t, err)
+		assert.NotZero(t, pendingTask.ID)
+
+		err = services.CancelPipeline(pipeline.ID)
+		assert.Nil(t, err)
+
+		reloadedCompleted, err := services.GetTask(completedTask.ID)
+		assert.Nil(t, err)
+		assert.Equal(t, models.TASK_COMPLETED, reloadedCompleted.Status)
+
+		reloadedPending, err := services.GetTask(pendingTask.ID)
+		assert.Nil(t, err)
+		assert.Equal(t, models.TASK_CANCELLED, reloadedPending.Status)
+	})
+
+	t.Run("returns error for non-existent pipeline", func(t *testing.T) {
+		err := services.CancelPipeline(999999)
+		assert.NotNil(t, err)
+	})
 }

--- a/backend/test/e2e/services/pipeline_runner_test.go
+++ b/backend/test/e2e/services/pipeline_runner_test.go
@@ -163,4 +163,21 @@ func TestComputePipelineStatus(t *testing.T) {
 	status, err = services.ComputePipelineStatus(pipeline, false)
 	assert.Nil(t, err)
 	assert.Equal(t, models.TASK_PARTIAL, status)
+
+	// pipeline.status == "cancelled" if the pipeline was cancelled by the user
+	// regardless of individual task statuses
+	task_row1_col1_rerun.Status = models.TASK_COMPLETED
+	err = db.Update(task_row1_col1_rerun)
+	assert.Nil(t, err)
+	status, err = services.ComputePipelineStatus(pipeline, true)
+	assert.Nil(t, err)
+	assert.Equal(t, models.TASK_CANCELLED, status)
+
+	// pipeline.status == "cancelled" even when some tasks failed
+	task_row1_col1_rerun.Status = models.TASK_FAILED
+	err = db.Update(task_row1_col1_rerun)
+	assert.Nil(t, err)
+	status, err = services.ComputePipelineStatus(pipeline, true)
+	assert.Nil(t, err)
+	assert.Equal(t, models.TASK_CANCELLED, status)
 }


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Clicking the cancel button in the UI (which fires DELETE /api/pipelines/:id) always returns "Operation successfully completed" (HTTP 200), but the pipeline continues running. Observable for 30+ minutes after the cancel request before it stops on its own.

Three independent bugs were causing this:

1. **`CancelPipeline` silently discarded errors from `CancelTask`** (`pipeline.go`). The cancel-func was never invoked for running tasks, and pending tasks were not batch-updated in the DB. Fixed by classifying tasks into running vs pending, then delegating to `cancelRunningTasks` (triggers context cancellation) and `cancelPendingTasksInDB` (batch DB update with status guard).

2. **`gitextractor` ignored context cancellation in `storeRepoSnapshot`** (`repo_gogit.go`). `gogit.Blame()` has no context parameter, so once a blame started it ran to completion. Added `select { case <-ctx.Done() }` checks at the top of the outer commit loop and inner `patch.Stats()` loop so cancellation is respected between iterations.

3. **Cancelled tasks were recorded as `TASK_FAILED`** (`run_task.go`, `pipeline_runner.go`). The deferred status-update block didn't distinguish cancellation from failure. Now detects cancellation via `errors.Is(err, context.Canceled) || ctx.Err() == context.Canceled`, sets status to `TASK_CANCELLED`, and skips writing `failed_sub_task`. `ComputePipelineStatus` also now returns `TASK_CANCELLED` when the pipeline was cancelled, taking priority over other statuses.

Additional correctness improvements:
- `cancelPendingTasksInDB` includes `TASK_RESUME` in the status filter so tasks awaiting restart recovery are also cancelled
- `cancelRunningTasks` uses `err.GetType() == errors.NotFound` instead of `.As(errors.NotFound)` to avoid walking the entire error chain
- `SkipOnFail` guard in `run_task.go` reuses the `isCancelled` variable instead of recomputing

### Does this close any open issues?
Closes #8787

### Screenshots
N/A

### Other Information
Additional improvements:
- `cancelPendingTasksInDB` includes `TASK_RESUME` in the status filter so tasks awaiting restart recovery are also cancelled
- `cancelRunningTasks` uses `err.GetType() == errors.NotFound` instead of `.As(errors.NotFound)` to avoid walking the entire error chain
- `SkipOnFail` guard in `run_task.go` reuses the `isCancelled` variable instead of recomputing

Tests:
- Added cancellation tests to `TestComputePipelineStatus` verifies `TASK_CANCELLED` is returned when `isCancelled=true`, regardless of individual task statuses
- Added `TestCancelPipeline` with 3 subtests: cancels all pending tasks, leaves completed tasks unchanged, returns error for non-existent pipeline