### PR TITLE
fix(asana): use float8 instead of double for PostgreSQL compatibility

### DIFF
--- a/backend/plugins/asana/models/migrationscripts/20250212_add_task_transformation_fields.go
+++ b/backend/plugins/asana/models/migrationscripts/20250212_add_task_transformation_fields.go
@@ -32,7 +32,7 @@ type asanaTask20250212 struct {
 	StdType         string   `gorm:"type:varchar(255)"`
 	StdStatus       string   `gorm:"type:varchar(255)"`
 	Priority        string   `gorm:"type:varchar(255)"`
-	StoryPoint      *float64 `gorm:"type:double"`
+	StoryPoint      *float64 `gorm:"type:float8"`
 	Severity        string   `gorm:"type:varchar(255)"`
 	LeadTimeMinutes *uint    `gorm:"type:int unsigned"`
 }


### PR DESCRIPTION
## Summary

Closes #8835

The Asana plugin migration `20250212_add_task_transformation_fields` uses `gorm:"type:double"` on the `StoryPoint` field. PostgreSQL does not have a `double` type, causing the migration to fail:

```
ERROR: type "double" does not exist (SQLSTATE 42704)
```

## Change

Changed `gorm:"type:double"` to `gorm:"type:float8"` in the migration struct.

`float8` works on both databases:
- **PostgreSQL**: `float8` is a built-in alias for `double precision`
- **MySQL**: `float8` is accepted as a synonym for `double`

This is consistent with the GitLab plugin which already uses `float8` for the same purpose (see `backend/plugins/gitlab/models/job.go:37`).

## Test plan

- [x] `go build ./plugins/asana/...` compiles successfully
- [x] One-line change, no logic affected