### PR TITLE
fix(docker): Add BUILDPLATFORM to config-ui builder stage and update node version

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -23,7 +23,7 @@
 #While incubation status is not necessarily a reflection of the completeness or stability of the code,
 #it does indicate that the project has yet to be fully endorsed by the ASF.
 
-FROM node:18-bookworm-slim as builder
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS builder
 
 WORKDIR /home/node/code
 COPY . .
@@ -47,4 +47,4 @@ RUN chmod +x /usr/bin/nginx.sh
 RUN chgrp -R 0 /etc/nginx /var/log/nginx /usr/share/nginx /run && \
     chmod -R g=u /etc/nginx /var/log/nginx /usr/share/nginx /run
 USER 101
-CMD /usr/bin/nginx.sh
+CMD ["/usr/bin/nginx.sh"]


### PR DESCRIPTION


<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [ ] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

### Summary
- Adds `--platform=$BUILDPLATFORM` to the config-ui Dockerfile base image specifier so that the Node builder runs natively on the build host (e.g. arm64 on Apple Silicon) rather than under x64 emulation. This avoids the esbuild Go runtime crash (lfstack.push invalid packing) that occurs when Go binaries compiled for x64 run under Rosetta 2 / QEMU in Rancher Desktop. Only the compiled static assets are copied to the final nginx image, so the builder platform has no effect on the runtime image architecture.
- Updates the builder base image Node version from v18 (which reached EOL in April 2025) to the current LTS version (v22)

### Does this close any open issues?
No

### Screenshots
N/a

### Other Information
N/a
