### PR TITLE
fix: disable API client caching for GitHub App connections

### DIFF
--- a/backend/plugins/github/models/connection.go
+++ b/backend/plugins/github/models/connection.go
@@ -134,6 +134,16 @@ func (connection GithubConnection) TableName() string {
 	return "_tool_github_connections"
 }
 
+func (connection GithubConnection) GetHash() string {
+	if connection.AuthMethod == AppKey {
+		// GitHub App installation tokens expire after ~1 hour, disable API client caching
+		// to ensure fresh tokens are fetched for admin APIs (remote-scopes, test-connection)
+		return ""
+	}
+	// Use default caching for PAT connections (they don't expire)
+	return connection.BaseConnection.GetHash()
+}
+
 func (connection *GithubConnection) MergeFromRequest(target *GithubConnection, body map[string]interface{}) error {
 	modifiedConnection := GithubConnection{}
 	if err := helper.DecodeMapStruct(body, &modifiedConnection, true); err != nil {

--- a/backend/plugins/github/models/connection_test.go
+++ b/backend/plugins/github/models/connection_test.go
@@ -18,6 +18,7 @@ limitations under the License.
 package models
 
 import (
+	"github.com/apache/incubator-devlake/core/models/common"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"testing"
 
@@ -237,4 +238,45 @@ func TestTokenTypeClassification(t *testing.T) {
 	assert.Equal(t, GithubTokenTypeClassical, conn.typeIs("ghr_123"))
 	assert.Equal(t, GithubTokenTypeFineGrained, conn.typeIs("github_pat_123"))
 	assert.Equal(t, GithubTokenTypeUnknown, conn.typeIs("some_other_token"))
+}
+
+func TestGithubConnection_GetHash(t *testing.T) {
+	tests := []struct {
+		name       string
+		connection GithubConnection
+		want       string
+	}{
+		{
+			name: "GitHub App connection should return empty hash to disable caching",
+			connection: GithubConnection{
+				GithubConn: GithubConn{
+					MultiAuth: api.MultiAuth{
+						AuthMethod: AppKey,
+					},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "PAT connection should use default hash",
+			connection: GithubConnection{
+				BaseConnection: api.BaseConnection{
+					Model: common.Model{
+						ID: 123,
+					},
+				},
+				GithubConn: GithubConn{
+					MultiAuth: api.MultiAuth{
+						AuthMethod: AccessToken,
+					},
+				},
+			},
+			want: "1230001-01-01 00:00:00 +0000 UTC", // ID + zero UpdatedAt
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, tt.connection.GetHash(), "GetHash()")
+		})
+	}
 }


### PR DESCRIPTION
GitHub App installation tokens expire after ~1 hour, causing admin APIs (remote-scopes, test-connection) to fail silently after token expiry.

This fix overrides GetHash() to return empty string for GitHub App connections, disabling client caching and ensuring fresh tokens are fetched for each admin request.

PAT connections continue to use default caching behavior.

Fixes #8847

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

## Summary
Fixes GitHub App installation token expiration issue causing admin APIs to fail silently after 1 hour.

## Problem
GitHub App connections use installation tokens that expire after ~1 hour. Admin APIs (remote-scopes, test-connection) were reusing cached HTTP clients with expired tokens, causing silent failures.

## Root Cause
`DsRemoteApiProxyHelper.getApiClient()` caches HTTP clients using `connection.GetHash()`. Once cached, clients are reused indefinitely with their embedded tokens.

## Solution
Override `GetHash()` method in `GithubConnection` to return empty string for GitHub App connections, disabling client caching and ensuring fresh tokens are fetched for each admin request.

Follows the same pattern as Zentao plugin for connections with expiring credentials.

## Changes
- `backend/plugins/github/models/connection.go`: Added `GetHash()` method
- `backend/plugins/github/models/connection_test.go`: Added test for `GetHash()` logic

## Testing
- Unit tests pass for both GitHub App and PAT connections
- No impact on data collection (uses separate client creation path)

Fixes #8847