### PR TITLE
fix(github_graphql): keep requestedIssues out of GraphQL query in Collect Issues

### DIFF
--- a/backend/plugins/github_graphql/tasks/issue_collector.go
+++ b/backend/plugins/github_graphql/tasks/issue_collector.go
@@ -22,6 +22,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/apache/incubator-devlake/core/dal"
@@ -52,8 +53,7 @@ type GraphqlQueryIssueWrapper struct {
 }
 
 type GraphqlQueryIssueDetailWrapper struct {
-	requestedIssues map[int]missingGithubIssueRef
-	RateLimit       struct {
+	RateLimit struct {
 		Cost int
 	}
 	Repository struct {
@@ -182,6 +182,7 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 		return err
 	}
 	issueUpdatedAt := make(map[int]time.Time)
+	requestedIssuesByQuery := sync.Map{}
 	err = apiCollector.InitGraphQLCollector(api.GraphqlCollectorArgs{
 		GraphqlClient: data.GraphqlClient,
 		Input:         iterator,
@@ -195,14 +196,14 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			ownerName := strings.Split(data.Options.Name, "/")
 			inputIssues := reqData.Input.([]interface{})
 			outputIssues := []map[string]interface{}{}
-			query.requestedIssues = make(map[int]missingGithubIssueRef, len(inputIssues))
+			requestedIssues := make(map[int]missingGithubIssueRef, len(inputIssues))
 			for _, i := range inputIssues {
 				inputIssue := i.(*models.GithubIssue)
 				outputIssues = append(outputIssues, map[string]interface{}{
 					`number`: graphql.Int(inputIssue.Number),
 				})
 				issueUpdatedAt[inputIssue.Number] = inputIssue.GithubUpdatedAt
-				query.requestedIssues[inputIssue.Number] = missingGithubIssueRef{
+				requestedIssues[inputIssue.Number] = missingGithubIssueRef{
 					ConnectionId:  inputIssue.ConnectionId,
 					RepoId:        inputIssue.RepoId,
 					GithubId:      inputIssue.GithubId,
@@ -210,6 +211,7 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 					RawDataOrigin: inputIssue.RawDataOrigin,
 				}
 			}
+			requestedIssuesByQuery.Store(query, requestedIssues)
 			variables := map[string]interface{}{
 				"issue": outputIssues,
 				"owner": graphql.String(ownerName[0]),
@@ -219,6 +221,11 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 		},
 		ResponseParser: func(queryWrapper any) (messages []json.RawMessage, err errors.Error) {
 			query := queryWrapper.(*GraphqlQueryIssueDetailWrapper)
+			v, ok := requestedIssuesByQuery.LoadAndDelete(query)
+			var requestedIssues map[int]missingGithubIssueRef
+			if ok {
+				requestedIssues = v.(map[int]missingGithubIssueRef)
+			}
 			issues := query.Repository.Issues
 			for _, rawL := range issues {
 				if rawL.DatabaseId == 0 || rawL.Number == 0 {
@@ -228,7 +235,7 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 					messages = append(messages, errors.Must1(json.Marshal(rawL)))
 				}
 			}
-			missingIssues := findMissingGithubIssues(query.requestedIssues, issues)
+			missingIssues := findMissingGithubIssues(requestedIssues, issues)
 			if len(missingIssues) > 0 {
 				err = cleanupMissingGithubIssues(db, taskCtx.GetLogger(), missingIssues)
 			}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

Putting the per-batch metadata on the wrapper struct caused merico-ai/graphql to emit it as a top-level GraphQL field. Moved it off the wrapper into a `sync.Map` kept in the surrounding closure.

### Does this close any open issues?
Closes #8853 

### Screenshots
N/A

### Other Information

