### PR TITLE
fix(server): use interface{} for store handler swag annotations

### DIFF
--- a/backend/server/api/store/store.go
+++ b/backend/server/api/store/store.go
@@ -33,7 +33,7 @@ import (
 // @Description Get the value by given key
 // @Tags framework/projects
 // @Param storeKey path string true "storeKey"
-// @Success 200  {object} json.RawMessage
+// @Success 200  {object} interface{}
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /store/{storeKey} [get]
@@ -53,8 +53,8 @@ func GetStore(c *gin.Context) {
 // @Tags framework/projects
 // @Accept application/json
 // @Param storeKey path string true "storeKey"
-// @Param project body json.RawMessage false "json"
-// @Success 200  {object} json.RawMessage
+// @Param project body interface{} false "json"
+// @Success 200  {object} interface{}
 // @Failure 400  {string} errcode.Error "Bad Request"
 // @Failure 500  {string} errcode.Error "Internal Error"
 // @Router /store/{storeKey} [PUT]


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary

`Build-Images-Push-Docker` on `main` fails at `make swag` since #8854:

https://github.com/apache/incubator-devlake/actions/runs/24995058459
```
ParseComment error in file /app/server/api/store/store.go :cannot find type definition: json.RawMessage
```

`json.RawMessage` is `encoding/json`'s `[]byte`, so swag treats it as a byte array and emits a schema for an integer array — not what this API actually returns. The correct way to express "any JSON value" in an OpenAPI annotation is `interface{}`, which swag emits as an empty schema (`{}`). This PR replaces the three `json.RawMessage` references in `store.go`'s annotations with `interface{}`. Annotation-only; runtime is unchanged.

### Does this close any open issues?
N/A

### Screenshots
N/A

### Other Information

