### PR TITLE
fix(argoCD): avoid duplication of latest  deployments

### DIFF
--- a/backend/plugins/argocd/tasks/sync_operation_extractor.go
+++ b/backend/plugins/argocd/tasks/sync_operation_extractor.go
@@ -188,6 +188,13 @@ func ExtractSyncOperations(taskCtx plugin.SubTaskContext) errors.Error {
 
 			isOperationState := apiOp.Phase != ""
 
+			// *** THE FIX ***
+			// operationState always represents the same sync as the latest history entry
+			// (when phase=Succeeded). Skip it to avoid the duplicate DeploymentId.
+			if isOperationState && apiOp.Phase == "Succeeded" {
+				return nil, nil
+			}
+
 			// For multi-source apps ArgoCD sets revisions[] instead of revision. Resolve
 			// the single commit SHA we care about before deciding whether to skip this entry.
 			if apiOp.Revision == "" {

--- a/backend/plugins/argocd/tasks/sync_operation_extractor.go
+++ b/backend/plugins/argocd/tasks/sync_operation_extractor.go
@@ -191,7 +191,7 @@ func ExtractSyncOperations(taskCtx plugin.SubTaskContext) errors.Error {
 			// *** THE FIX ***
 			// operationState always represents the same sync as the latest history entry
 			// (when phase=Succeeded). Skip it to avoid the duplicate DeploymentId.
-			if isOperationState && apiOp.Phase == "Succeeded" {
+			if isOperationState && isRedundantOperationState(apiOp.Phase) {
 				return nil, nil
 			}
 
@@ -540,4 +540,22 @@ func isCommitSHA(s string) bool {
 		}
 	}
 	return true
+}
+
+// isRedundantOperationState reports whether an operationState entry should be
+// skipped because it duplicates the most recent history entry.
+//
+// ArgoCD exposes a completed sync in two places:
+//   - status.history[]     — authoritative log, one entry per sync
+//   - status.operationState — mirrors the last sync while it is current
+//
+// When phase is Succeeded the operationState is always already present in
+// history[]. Emitting it would produce a second ArgocdSyncOperation whose
+// DeploymentId differs by one second (startedAt vs deployedAt), creating a
+// duplicate deployment in DORA metrics.
+//
+// In-flight (Running, Terminating) and terminal-failure (Failed, Error) states
+// are not yet — or may never be — written to history, so they must be kept.
+func isRedundantOperationState(phase string) bool {
+	return phase == "Succeeded"
 }

--- a/backend/plugins/argocd/tasks/sync_operation_extractor_test.go
+++ b/backend/plugins/argocd/tasks/sync_operation_extractor_test.go
@@ -143,7 +143,7 @@ func TestIsCommitSHA(t *testing.T) {
 	assert.True(t, isCommitSHA("AABBCCDD11223344AABBCCDD11223344AABBCCDD"))
 	assert.False(t, isCommitSHA("2.6.2"))
 	assert.False(t, isCommitSHA(""))
-	assert.False(t, isCommitSHA("5dd95b4efd7e9b668c361bbddb8d7f1e56c32ac")) // 39 chars
+	assert.False(t, isCommitSHA("5dd95b4efd7e9b668c361bbddb8d7f1e56c32ac"))   // 39 chars
 	assert.False(t, isCommitSHA("5dd95b4efd7e9b668c361bbddb8d7f1e56c32ac12")) // 41 chars
 }
 
@@ -215,4 +215,32 @@ func TestIsGitHostedURL(t *testing.T) {
 	assert.False(t, isGitHostedURL("oci://registry.example.com/charts"))
 	assert.False(t, isGitHostedURL("s3://my-bucket/charts"))
 	assert.False(t, isGitHostedURL(""))
+}
+
+// ── isRedundantOperationState ─────────────────────────────────────────────────
+
+func TestIsRedundantOperationState_SucceededIsSkipped(t *testing.T) {
+	assert.True(t, isRedundantOperationState("Succeeded"),
+		"Succeeded operationState always duplicates the latest history entry")
+}
+
+func TestIsRedundantOperationState_NonTerminalPhasesAreKept(t *testing.T) {
+	for _, phase := range []string{"Running", "Terminating"} {
+		assert.False(t, isRedundantOperationState(phase),
+			"in-flight phase %q is not yet in history and must be kept", phase)
+	}
+}
+
+func TestIsRedundantOperationState_FailurePhasesAreKept(t *testing.T) {
+	for _, phase := range []string{"Failed", "Error"} {
+		assert.False(t, isRedundantOperationState(phase),
+			"failure phase %q may never reach history and must be kept", phase)
+	}
+}
+
+func TestIsRedundantOperationState_HistoryEntryHasNoPhase(t *testing.T) {
+	// History entries have phase="" — isOperationState is false before this
+	// function is called, but double-check the function itself is safe with
+	// an empty string so the guard can never accidentally suppress history rows.
+	assert.False(t, isRedundantOperationState(""))
 }


### PR DESCRIPTION
## Summary

Fix duplicate `ArgocdSyncOperation` records caused by ArgoCD exposing the same completed sync in two places in its API response: `status.history[]` and `status.operationState`.

## Problem

ArgoCD includes the most recent completed sync in both:
- `status.history[]` — the authoritative log of all past syncs, each with `deployedAt`
- `status.operationState` — a mirror of the last operation, with `startedAt`

The DevLake collector feeds both into the raw table. The extractor then processes each independently, using different timestamp fields as `DeploymentId`:

| Source | Field used | Example value | DeploymentId |
|---|---|---|---|
| `history[id=30]` | `deployedAt` | `2026-04-16T09:02:16Z` | `1776330136` |
| `operationState` | `startedAt` | `2026-04-16T09:02:15Z` | `1776330135` |

Because `startedAt` and `deployedAt` differ by one second (the sync duration), the two records get different primary keys and both are persisted — resulting in duplicate deployment entries in DORA metrics and deployment frequency charts.

## Fix

Extract the skip logic into a dedicated `isRedundantOperationState(phase string) bool` function and call it from inside `Extract` before processing any `operationState` row.

A `Succeeded` `operationState` is always already present in `status.history[]` so it is skipped. In-flight (`Running`, `Terminating`) and failure (`Failed`, `Error`) states are not yet — or may never be — written to history, so they continue to be processed normally.

```go
// isRedundantOperationState reports whether an operationState entry should be
// skipped because it duplicates the most recent history entry.
func isRedundantOperationState(phase string) bool {
    return phase == "Succeeded"
}
```

```go
// inside Extract:
isOperationState := apiOp.Phase != ""

if isOperationState && isRedundantOperationState(apiOp.Phase) {
    return nil, nil
}
```

## Behaviour by phase

| `operationState` phase | Already in `history[]`? | Action |
|---|---|---|
| `Succeeded` | yes | skip — history entry is authoritative |
| `Running` / `Terminating` | no | keep — only source for in-flight sync |
| `Failed` / `Error` | no | keep — failure may never reach history |
| ` ` (empty) | n/a — history entry, not operationState | keep — guard never fires |

## Testing

Added unit tests for `isRedundantOperationState` covering all phase variants. Verified against production ArgoCD API responses for multiple applications where `operationState.phase = Succeeded` — duplicate `ArgocdSyncOperation` records are eliminated after the fix.

## Related

- Affects: `backend/plugins/argocd/tasks/sync_operation_extractor.go`
- Reproduces with: any ArgoCD application whose last sync completed successfully (i.e. the vast majority of applications in a healthy cluster)