### PR TITLE
feat(ui): implement dark theme and refactor color usage

### DIFF
--- a/backend/server/api/auth/auth_test.go
+++ b/backend/server/api/auth/auth_test.go
@@ -39,7 +39,7 @@ func TestSafeReturnURL(t *testing.T) {
 		{"missing leading slash", "projects", "/"},
 		{"javascript scheme", "javascript:alert(1)", "/"},
 		{"data scheme", "data:text/html,x", "/"},
-		{"unparseable", "://", "/"},
+		{"unparsable", "://", "/"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/config-ui/src/app/store.ts
+++ b/config-ui/src/app/store.ts
@@ -18,11 +18,12 @@
 
 import { configureStore, ThunkAction, Action } from '@reduxjs/toolkit';
 
-import { connectionsSlice } from '@/features';
+import { connectionsSlice, themeSlice } from '@/features';
 
 export const store = configureStore({
   reducer: {
     connections: connectionsSlice.reducer,
+    theme: themeSlice.reducer,
   },
 });
 

--- a/config-ui/src/components/block/styled.ts
+++ b/config-ui/src/components/block/styled.ts
@@ -24,7 +24,7 @@ export const Label = styled.label`
 `;
 
 export const LabelInfo = styled.i`
-  color: #ff8b8b;
+  color: ${({ theme }) => theme.colors.secondary};
 `;
 
 export const subLabel = styled.p`

--- a/config-ui/src/components/inspector/styled.ts
+++ b/config-ui/src/components/inspector/styled.ts
@@ -20,7 +20,7 @@ import styled from 'styled-components';
 
 export const Wrapper = styled.div`
   padding: 16px 24px;
-  background-color: #f3f3f3;
+  background-color: ${({ theme }) => theme.colors.bgElevated};
 
   .title {
     display: flex;
@@ -34,7 +34,7 @@ export const Wrapper = styled.div`
 
     span {
       font-size: 10px;
-      color: #aaaaaa;
+      color: ${({ theme }) => theme.colors.textFaint};
     }
   }
 
@@ -46,7 +46,7 @@ export const Wrapper = styled.div`
   .content {
     padding: 10px;
     max-height: 600;
-    background-color: #ffff;
+    background-color: ${({ theme }) => theme.colors.bgContainer};
     border-radius: 4px;
     box-shadow: 1px 1px 3px 0px rgb(0 0 0 / 20%) inset;
     overflow-y: auto;

--- a/config-ui/src/components/loading/styled.ts
+++ b/config-ui/src/components/loading/styled.ts
@@ -37,7 +37,7 @@ export const Wrapper = styled.div`
 export const Spin = styled.div<{ size: number }>`
   width: ${({ size }) => size}px;
   height: ${({ size }) => size}px;
-  border: 2px solid #7497f7;
+  border: 2px solid ${({ theme }) => theme.colors.primary};
   border-radius: 50%;
   border-right-color: transparent;
   box-sizing: border-box;

--- a/config-ui/src/components/message/index.tsx
+++ b/config-ui/src/components/message/index.tsx
@@ -35,7 +35,7 @@ export const Message = ({ style, size = 20, content }: Props) => {
   return (
     <Wrapper style={style}>
       <Space>
-        <WarningOutlined style={{ fontSize: size, color: '#f4be55' }} />
+        <WarningOutlined style={{ fontSize: size, color: 'var(--devlake-color-warning-soft)' }} />
         <span>{content}</span>
       </Space>
     </Wrapper>

--- a/config-ui/src/components/page-header/styled.ts
+++ b/config-ui/src/components/page-header/styled.ts
@@ -47,7 +47,7 @@ export const Breadcrumb = styled.li`
   a {
     display: flex;
     align-items: center;
-    color: #292b3f;
+    color: ${({ theme }) => theme.colors.text};
   }
 `;
 export const Extra = styled.div``;

--- a/config-ui/src/components/tip-layout/styled.ts
+++ b/config-ui/src/components/tip-layout/styled.ts
@@ -24,7 +24,7 @@ export const Wrapper = styled.div`
   align-items: center;
   padding-top: 100px;
   height: 100vh;
-  background-color: #f9f9fa;
+  background-color: ${({ theme }) => theme.colors.bgLayout};
   box-sizing: border-box;
 `;
 
@@ -42,7 +42,7 @@ export const Inner = styled.div`
     margin: 16px 0;
 
     &.warning {
-      color: #faad14;
+      color: ${({ theme }) => theme.colors.warningAlt};
     }
   }
 `;

--- a/config-ui/src/features/index.ts
+++ b/config-ui/src/features/index.ts
@@ -17,3 +17,4 @@
  */
 
 export * from './connections';
+export * from './theme';

--- a/config-ui/src/features/theme/index.ts
+++ b/config-ui/src/features/theme/index.ts
@@ -16,30 +16,4 @@
  *
  */
 
-import styled from 'styled-components';
-
-export const Label = styled.label`
-  font-size: 16px;
-  font-weight: 600;
-`;
-
-export const LabelInfo = styled.i`
-  color: ${({ theme }) => theme.colors.secondary};
-`;
-
-export const LabelDescription = styled.p`
-  margin: 0;
-`;
-
-export const RateLimit = styled.div`
-  display: flex;
-  align-items: center;
-
-  & > span {
-    margin-left: 8px;
-  }
-`;
-
-export const RateLimitInfo = styled.p`
-  white-space: pre-line;
-`;
+export * from './slice';

--- a/config-ui/src/features/theme/slice.ts
+++ b/config-ui/src/features/theme/slice.ts
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+
+import { RootState } from '@/app/store';
+import type { ThemeMode, ResolvedTheme } from '@/theme/tokens';
+
+export const THEME_STORAGE_KEY = 'devlake.theme';
+
+const NEXT_MODE: Record<ThemeMode, ThemeMode> = {
+  light: 'dark',
+  dark: 'system',
+  system: 'light',
+};
+
+const isThemeMode = (value: unknown): value is ThemeMode => value === 'light' || value === 'dark' || value === 'system';
+
+const loadInitialMode = (): ThemeMode => {
+  if (typeof window === 'undefined') return 'system';
+  try {
+    const stored = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (isThemeMode(stored)) return stored;
+  } catch {
+    // localStorage may be unavailable (e.g., SSR / privacy mode)
+  }
+  return 'system';
+};
+
+const persistMode = (mode: ThemeMode): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, mode);
+  } catch {
+    // localStorage may be unavailable (e.g., SSR / privacy mode)
+  }
+};
+
+interface ThemeState {
+  mode: ThemeMode;
+}
+
+const initialState: ThemeState = {
+  mode: loadInitialMode(),
+};
+
+export const themeSlice = createSlice({
+  name: 'theme',
+  initialState,
+  reducers: {
+    setMode(state, action: PayloadAction<ThemeMode>) {
+      state.mode = action.payload;
+      persistMode(action.payload);
+    },
+    cycleMode(state) {
+      state.mode = NEXT_MODE[state.mode];
+      persistMode(state.mode);
+    },
+  },
+});
+
+export const { setMode, cycleMode } = themeSlice.actions;
+
+export default themeSlice.reducer;
+
+export const selectThemeMode = (state: RootState): ThemeMode => state.theme.mode;
+
+export const resolveThemeMode = (mode: ThemeMode): ResolvedTheme => {
+  if (mode !== 'system') return mode;
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+};

--- a/config-ui/src/index.css
+++ b/config-ui/src/index.css
@@ -16,8 +16,16 @@
  *
  */
 
+/* Initial-paint fallbacks; ThemeProvider overrides these from theme tokens. */
+:root {
+  --devlake-color-text: #292b3f;
+  --devlake-color-text-muted: #94959f;
+  --devlake-color-bg: #ffffff;
+}
+
 body {
-  color: #292b3f;
+  color: var(--devlake-color-text);
+  background-color: var(--devlake-color-bg);
   margin: 0;
 }
 
@@ -64,7 +72,7 @@ ul {
 p {
   margin: 8px 0;
   font-size: 12px;
-  color: #94959f;
+  color: var(--devlake-color-text-muted);
 }
 
 #root {

--- a/config-ui/src/main.tsx
+++ b/config-ui/src/main.tsx
@@ -19,25 +19,19 @@
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { RouterProvider } from 'react-router-dom';
-import { ConfigProvider } from 'antd';
 
 import { PageLoading } from '@/components';
+import { ThemeProvider } from '@/theme';
 
 import { store } from './app/store';
 import { router } from './app/router';
 import './index.css';
 
 ReactDOM.render(
-  <ConfigProvider
-    theme={{
-      token: {
-        colorPrimary: import.meta.env.DEVLAKE_COLOR_CUSTOM ?? '#7497F7',
-      },
-    }}
-  >
-    <Provider store={store}>
+  <Provider store={store}>
+    <ThemeProvider>
       <RouterProvider router={router} fallbackElement={<PageLoading />} />
-    </Provider>
-  </ConfigProvider>,
+    </ThemeProvider>
+  </Provider>,
   document.getElementById('root'),
 );

--- a/config-ui/src/plugins/components/data-scope-remote/search-local.tsx
+++ b/config-ui/src/plugins/components/data-scope-remote/search-local.tsx
@@ -219,7 +219,7 @@ export const SearchLocal = ({ mode, plugin, connectionId, config, disabledScope,
 
         {status === 'loaded' && (
           <S.JobLoad>
-            <CheckCircleFilled style={{ color: '#4DB764' }} />
+            <CheckCircleFilled style={{ color: 'var(--devlake-color-success)' }} />
             <span className="count">{miller.items.length}</span> scopes found
           </S.JobLoad>
         )}

--- a/config-ui/src/plugins/components/data-scope-remote/styled.ts
+++ b/config-ui/src/plugins/components/data-scope-remote/styled.ts
@@ -31,6 +31,6 @@ export const JobLoad = styled.div`
 
   & > span.count {
     margin: 0 8px;
-    color: #7497f7;
+    color: ${({ theme }) => theme.colors.primary};
   }
 `;

--- a/config-ui/src/plugins/register/argocd/transformation.tsx
+++ b/config-ui/src/plugins/register/argocd/transformation.tsx
@@ -99,7 +99,7 @@ const renderCollapseItems = ({
                 })
               }
             />
-            <i style={{ color: '#E34040' }}>*</i>
+            <i style={{ color: 'var(--devlake-color-error-alt)' }}>*</i>
             <HelpTooltip content="Use regex to match application names. Default pattern matches any name containing 'prod' (case-insensitive)." />
           </div>
           <div style={{ marginTop: 16, marginBottom: 8 }}>

--- a/config-ui/src/plugins/register/azure/connection-fields/styled.ts
+++ b/config-ui/src/plugins/register/azure/connection-fields/styled.ts
@@ -24,7 +24,7 @@ export const Label = styled.label`
 `;
 
 export const LabelInfo = styled.i`
-  color: #ff8b8b;
+  color: ${({ theme }) => theme.colors.secondary};
 `;
 
 export const LabelDescription = styled.p`

--- a/config-ui/src/plugins/register/azure/transformation.tsx
+++ b/config-ui/src/plugins/register/azure/transformation.tsx
@@ -100,7 +100,7 @@ const renderCollapseItems = ({
                 })
               }
             />
-            <i style={{ color: '#E34040' }}>*</i>
+            <i style={{ color: 'var(--devlake-color-error-alt)' }}>*</i>
             <HelpTooltip content="Azure Pipelines: https://learn.microsoft.com/en-us/azure/devops/pipelines/get-started/what-is-azure-pipelines?view=azure-devops#continuous-testing" />
           </div>
           <div style={{ margin: '8px 0', paddingLeft: 28 }}>

--- a/config-ui/src/plugins/register/circleci/transformation.tsx
+++ b/config-ui/src/plugins/register/circleci/transformation.tsx
@@ -100,7 +100,7 @@ const renderCollapseItems = ({
                 })
               }
             />
-            <i style={{ color: '#E34040' }}>*</i>
+            <i style={{ color: 'var(--devlake-color-error-alt)' }}>*</i>
             <HelpTooltip content="CircleCI Workflows: https://circleci.com/docs/workflows/" />
           </div>
           <div style={{ margin: '8px 0', paddingLeft: 28 }}>

--- a/config-ui/src/plugins/register/gh-copilot/connection-fields/styled.ts
+++ b/config-ui/src/plugins/register/gh-copilot/connection-fields/styled.ts
@@ -20,6 +20,6 @@ import styled from 'styled-components';
 
 export const ErrorText = styled.div`
   margin-top: 4px;
-  color: #f5222d;
+  color: ${({ theme }) => theme.colors.error};
   font-size: 12px;
 `;

--- a/config-ui/src/plugins/register/github/connection-fields/styled.ts
+++ b/config-ui/src/plugins/register/github/connection-fields/styled.ts
@@ -24,7 +24,7 @@ export const Label = styled.label`
 `;
 
 export const LabelInfo = styled.i`
-  color: #ff8b8b;
+  color: ${({ theme }) => theme.colors.secondary};
 `;
 
 export const LabelDescription = styled.p`
@@ -48,11 +48,11 @@ export const Input = styled.div`
       margin-left: 4px;
 
       span.error {
-        color: #f5222d;
+        color: ${({ theme }) => theme.colors.error};
       }
 
       span.success {
-        color: #4db764;
+        color: ${({ theme }) => theme.colors.success};
       }
     }
   }
@@ -65,7 +65,7 @@ export const Input = styled.div`
 export const Alert = styled.div`
   margin-top: 8px;
   padding: 12px 20px;
-  background: #f9f9fa;
-  border: 1px solid #dbdcdf;
+  background: ${({ theme }) => theme.colors.bgLayout};
+  border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: 4px;
 `;

--- a/config-ui/src/plugins/register/github/connection-fields/token.tsx
+++ b/config-ui/src/plugins/register/github/connection-fields/token.tsx
@@ -171,9 +171,9 @@ export const Token = ({
             {status && (
               <S.Alert>
                 <h4>
-                  {status === 'success' && <CheckCircleFilled style={{ color: '#4DB764' }} />}
-                  {status === 'warning' && <WarningFilled style={{ color: '#F4BE55' }} />}
-                  {status === 'error' && <CloseCircleFilled style={{ color: '#E34040' }} />}
+                  {status === 'success' && <CheckCircleFilled style={{ color: 'var(--devlake-color-success)' }} />}
+                  {status === 'warning' && <WarningFilled style={{ color: 'var(--devlake-color-warning-soft)' }} />}
+                  {status === 'error' && <CloseCircleFilled style={{ color: 'var(--devlake-color-error-alt)' }} />}
                   <span style={{ marginLeft: 8 }}>Token Permissions</span>
                 </h4>
                 {status === 'success' && <p>All required fields are checked.</p>}

--- a/config-ui/src/plugins/register/github/transformation.tsx
+++ b/config-ui/src/plugins/register/github/transformation.tsx
@@ -277,7 +277,7 @@ const renderCollapseItems = ({
                 })
               }
             />
-            <i style={{ marginRight: 4, color: '#E34040' }}>*</i>
+            <i style={{ marginRight: 4, color: 'var(--devlake-color-error-alt)' }}>*</i>
             <HelpTooltip content="GitHub Workflow Runs: https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow" />
           </div>
           <div style={{ margin: '8px 0', paddingLeft: 28 }}>
@@ -368,12 +368,12 @@ const renderCollapseItems = ({
                   content={
                     <>
                       <div>
-                        <CheckCircleOutlined rev="" style={{ marginRight: 4, color: '#4DB764' }} />
+                        <CheckCircleOutlined rev="" style={{ marginRight: 4, color: 'var(--devlake-color-success)' }} />
                         Example 1: PR #321 body contains "<strong>Closes #1234</strong>" (PR #321 and issue #1234 will
                         be mapped by the following RegEx)
                       </div>
                       <div>
-                        <CloseCircleOutlined rev="" style={{ marginRight: 4, color: '#E34040' }} />
+                        <CloseCircleOutlined rev="" style={{ marginRight: 4, color: 'var(--devlake-color-error-alt)' }} />
                         Example 2: PR #321 body contains "<strong>Related to #1234</strong>" (PR #321 and issue #1234
                         will NOT be mapped by the following RegEx)
                       </div>

--- a/config-ui/src/plugins/register/gitlab/transformation.tsx
+++ b/config-ui/src/plugins/register/gitlab/transformation.tsx
@@ -156,7 +156,7 @@ const renderCollapseItems = ({
                 })
               }
             />
-            <i style={{ color: '#E34040' }}>*</i>
+            <i style={{ color: 'var(--devlake-color-error-alt)' }}>*</i>
             <HelpTooltip content="GitLab Pipelines: https://docs.gitlab.com/ee/ci/pipelines/" />
           </div>
           <div style={{ margin: '8px 0', paddingLeft: 28 }}>

--- a/config-ui/src/plugins/register/jenkins/transformation.tsx
+++ b/config-ui/src/plugins/register/jenkins/transformation.tsx
@@ -100,7 +100,7 @@ const renderCollapseItems = ({
                 })
               }
             />
-            <i style={{ color: '#E34040' }}>*</i>
+            <i style={{ color: 'var(--devlake-color-error-alt)' }}>*</i>
             <HelpTooltip content="Jenkins Builds: https://www.jenkins.io/doc/pipeline/steps/pipeline-build-step/" />
           </div>
           <div style={{ margin: '8px 0', paddingLeft: 28 }}>

--- a/config-ui/src/plugins/register/jira/connection-fields/styled.ts
+++ b/config-ui/src/plugins/register/jira/connection-fields/styled.ts
@@ -24,7 +24,7 @@ export const Label = styled.label`
 `;
 
 export const LabelInfo = styled.i`
-  color: #ff8b8b;
+  color: ${({ theme }) => theme.colors.secondary};
 `;
 
 export const LabelDescription = styled.p`

--- a/config-ui/src/plugins/register/jira/transformation-fields/styled.ts
+++ b/config-ui/src/plugins/register/jira/transformation-fields/styled.ts
@@ -32,7 +32,7 @@ export const CrossDomain = styled.div`
 
     span {
       padding: 4px 8px;
-      background-color: #efefef;
+      background-color: ${({ theme }) => theme.colors.bgMuted};
     }
 
     span + span {
@@ -53,7 +53,7 @@ export const RemoteLinkWrapper = styled.div`
 
   .error {
     margin-top: 2px;
-    color: #cd4246;
+    color: ${({ theme }) => theme.colors.errorMuted};
   }
 `;
 
@@ -63,7 +63,7 @@ export const DialogBody = styled.div`
     padding: 8px 16px;
     max-height: 240px;
     overflow-y: auto;
-    background: #efefef;
+    background: ${({ theme }) => theme.colors.bgMuted};
   }
 
   .search {

--- a/config-ui/src/plugins/register/opsgenie/connection-fields/styled.ts
+++ b/config-ui/src/plugins/register/opsgenie/connection-fields/styled.ts
@@ -24,7 +24,7 @@ export const Label = styled.label`
 `;
 
 export const LabelInfo = styled.i`
-  color: #ff8b8b;
+  color: ${({ theme }) => theme.colors.secondary};
 `;
 
 export const LabelDescription = styled.p`
@@ -48,11 +48,11 @@ export const Input = styled.div`
       margin-left: 4px;
 
       span.error {
-        color: #f5222d;
+        color: ${({ theme }) => theme.colors.error};
       }
 
       span.success {
-        color: #4db764;
+        color: ${({ theme }) => theme.colors.success};
       }
     }
   }
@@ -65,7 +65,7 @@ export const Input = styled.div`
 export const Alert = styled.div`
   margin-top: 8px;
   padding: 12px 20px;
-  background: #f9f9fa;
-  border: 1px solid #dbdcdf;
+  background: ${({ theme }) => theme.colors.bgLayout};
+  border: 1px solid ${({ theme }) => theme.colors.border};
   border-radius: 4px;
 `;

--- a/config-ui/src/plugins/register/q-dev/connection-fields/aws-credentials.tsx
+++ b/config-ui/src/plugins/register/q-dev/connection-fields/aws-credentials.tsx
@@ -175,7 +175,7 @@ export const AwsCredentials = ({ type, initialValues, values, setValues, setErro
               onChange={handleAccessKeyChange}
               status={accessKeyError ? 'error' : ''}
             />
-            {accessKeyError && <div style={{ marginTop: 4, color: '#f5222d' }}>{accessKeyError}</div>}
+            {accessKeyError && <div style={{ marginTop: 4, color: 'var(--devlake-color-error)' }}>{accessKeyError}</div>}
           </Block>
 
           <Block
@@ -190,7 +190,7 @@ export const AwsCredentials = ({ type, initialValues, values, setValues, setErro
               onChange={handleSecretKeyChange}
               status={secretKeyError ? 'error' : ''}
             />
-            {secretKeyError && <div style={{ marginTop: 4, color: '#f5222d' }}>{secretKeyError}</div>}
+            {secretKeyError && <div style={{ marginTop: 4, color: 'var(--devlake-color-error)' }}>{secretKeyError}</div>}
           </Block>
         </>
       )}
@@ -200,7 +200,14 @@ export const AwsCredentials = ({ type, initialValues, values, setValues, setErro
           title="IAM Role Authentication"
           description="DevLake will use the IAM role attached to the EC2 instance, ECS task, or Lambda function"
         >
-          <div style={{ padding: '12px', backgroundColor: '#f6f8fa', borderRadius: '6px', color: '#586069' }}>
+          <div
+            style={{
+              padding: '12px',
+              backgroundColor: 'var(--devlake-color-bg-elevated)',
+              borderRadius: '6px',
+              color: 'var(--devlake-color-text-muted)',
+            }}
+          >
             <p style={{ margin: 0 }}>
               Make sure the IAM role has the necessary S3 permissions to access your bucket. No additional credentials
               are required when using IAM role authentication.
@@ -217,7 +224,7 @@ export const AwsCredentials = ({ type, initialValues, values, setValues, setErro
           onChange={handleRegionChange}
           status={regionError ? 'error' : ''}
         />
-        {regionError && <div style={{ marginTop: 4, color: '#f5222d' }}>{regionError}</div>}
+        {regionError && <div style={{ marginTop: 4, color: 'var(--devlake-color-error)' }}>{regionError}</div>}
       </Block>
     </>
   );

--- a/config-ui/src/plugins/register/q-dev/connection-fields/connection-test.tsx
+++ b/config-ui/src/plugins/register/q-dev/connection-fields/connection-test.tsx
@@ -174,7 +174,7 @@ export const QDevConnectionTest = ({ plugin, connectionId, values, initialValues
                 <div>✓ S3 Access: Verified</div>
                 {testResult.details.identityCenterAccess && <div>✓ IAM Identity Center: Configured</div>}
                 {!values.identityStoreId && (
-                  <div style={{ marginTop: 8, color: '#faad14' }}>
+                  <div style={{ marginTop: 8, color: 'var(--devlake-color-warning-alt)' }}>
                     ⚠️ IAM Identity Center not configured - user display names will show as user IDs
                   </div>
                 )}

--- a/config-ui/src/plugins/register/q-dev/connection-fields/identity-center-config.tsx
+++ b/config-ui/src/plugins/register/q-dev/connection-fields/identity-center-config.tsx
@@ -105,7 +105,7 @@ export const IdentityCenterConfig = ({ initialValues, values, setValues, setErro
           onChange={handleStoreIdChange}
           status={storeIdError ? 'error' : ''}
         />
-        {storeIdError && <div style={{ marginTop: 4, color: '#f5222d' }}>{storeIdError}</div>}
+        {storeIdError && <div style={{ marginTop: 4, color: 'var(--devlake-color-error)' }}>{storeIdError}</div>}
       </Block>
 
       <Block
@@ -119,7 +119,7 @@ export const IdentityCenterConfig = ({ initialValues, values, setValues, setErro
           onChange={handleRegionChange}
           status={regionError ? 'error' : ''}
         />
-        {regionError && <div style={{ marginTop: 4, color: '#f5222d' }}>{regionError}</div>}
+        {regionError && <div style={{ marginTop: 4, color: 'var(--devlake-color-error)' }}>{regionError}</div>}
       </Block>
     </>
   );

--- a/config-ui/src/plugins/register/q-dev/connection-fields/s3-config.tsx
+++ b/config-ui/src/plugins/register/q-dev/connection-fields/s3-config.tsx
@@ -70,7 +70,7 @@ export const S3Config = ({ initialValues, values, setValues, setErrors }: Props)
         onChange={handleBucketChange}
         status={bucketError ? 'error' : ''}
       />
-      {bucketError && <div style={{ marginTop: 4, color: '#f5222d' }}>{bucketError}</div>}
+      {bucketError && <div style={{ marginTop: 4, color: 'var(--devlake-color-error)' }}>{bucketError}</div>}
     </Block>
   );
 };

--- a/config-ui/src/plugins/register/webhook/styled.ts
+++ b/config-ui/src/plugins/register/webhook/styled.ts
@@ -27,7 +27,7 @@ export const Wrapper = styled.div`
     margin-bottom: 16px;
     padding: 0;
     font-weight: 600;
-    color: #4db764;
+    color: ${({ theme }) => theme.colors.success};
   }
 
   h5 {
@@ -35,12 +35,12 @@ export const Wrapper = styled.div`
   }
 
   p {
-    color: #292b3f;
+    color: ${({ theme }) => theme.colors.text};
   }
 `;
 
 export const Action = styled.div`
-  color: #7497f7;
+  color: ${({ theme }) => theme.colors.primary};
 
   span {
     cursor: pointer;

--- a/config-ui/src/routes/blueprint/detail/components/sync-policy/styled.ts
+++ b/config-ui/src/routes/blueprint/detail/components/sync-policy/styled.ts
@@ -47,5 +47,5 @@ export const Input = styled.div`
 `;
 
 export const Error = styled.div`
-  color: #e34040;
+  color: ${({ theme }) => theme.colors.errorAlt};
 `;

--- a/config-ui/src/routes/blueprint/detail/styled.ts
+++ b/config-ui/src/routes/blueprint/detail/styled.ts
@@ -51,7 +51,7 @@ export const ConnectionItem = styled.li`
   margin-right: 24px;
   padding: 12px 16px;
   width: 280px;
-  background: #ffffff;
+  background: ${({ theme }) => theme.colors.bgContainer};
   box-shadow: 0px 2.4px 4.8px -0.8px rgba(0, 0, 0, 0.1), 0px 1.6px 8px rgba(0, 0, 0, 0.07);
   border-radius: 4px;
 

--- a/config-ui/src/routes/blueprint/home/index.tsx
+++ b/config-ui/src/routes/blueprint/home/index.tsx
@@ -121,7 +121,11 @@ export const BlueprintHomePage = () => {
               title: 'Blueprint Name',
               key: 'name',
               render: (_, { id, name }) => (
-                <Link to={PATHS.BLUEPRINT(id)} state={{ activeKey: 'configuration' }} style={{ color: '#292b3f' }}>
+                <Link
+                  to={PATHS.BLUEPRINT(id)}
+                  state={{ activeKey: 'configuration' }}
+                  style={{ color: 'var(--devlake-color-text)' }}
+                >
                   <TextTooltip content={name}>{name}</TextTooltip>
                 </Link>
               ),

--- a/config-ui/src/routes/blueprint/home/styled.ts
+++ b/config-ui/src/routes/blueprint/home/styled.ts
@@ -35,7 +35,7 @@ export const Label = styled.label`
 `;
 
 export const LabelInfo = styled.i`
-  color: #ff8b8b;
+  color: ${({ theme }) => theme.colors.secondary};
 `;
 
 export const LabelDescription = styled.p`

--- a/config-ui/src/routes/connection/connections.tsx
+++ b/config-ui/src/routes/connection/connections.tsx
@@ -75,7 +75,7 @@ export const Connections = () => {
   };
 
   return (
-    <S.Wrapper theme={colorPrimary}>
+    <S.Wrapper>
       <h1>Connections</h1>
       <h5>
         Create and manage data connections from the following data sources or Webhooks to be used in syncing data in

--- a/config-ui/src/routes/connection/styled.ts
+++ b/config-ui/src/routes/connection/styled.ts
@@ -18,7 +18,7 @@
 
 import styled from 'styled-components';
 
-export const Wrapper = styled.div<{ theme: string }>`
+export const Wrapper = styled.div`
   h2 {
     margin-top: 36px;
   }
@@ -39,7 +39,7 @@ export const Wrapper = styled.div<{ theme: string }>`
       left: 0;
       width: 48px;
       height: 4px;
-      background-color: ${({ theme }) => theme};
+      background-color: ${({ theme }) => theme.colors.primary};
     }
   }
   ul {
@@ -58,13 +58,15 @@ export const Wrapper = styled.div<{ theme: string }>`
     padding: 20px 0;
     width: 160px;
     border-radius: 8px;
+    border: 1px solid ${({ theme }) => (theme.mode === 'dark' ? theme.colors.border : 'transparent')};
+    background-color: ${({ theme }) => theme.colors.bgContainer};
     box-shadow: 0px 2.4px 4.8px -0.8px rgba(0, 0, 0, 0.1), 0px 1.6px 8px rgba(0, 0, 0, 0.07);
     box-sizing: border-box;
     cursor: pointer;
     transition: all 0.2s linear;
 
     &:hover {
-      background-color: #eeeeee;
+      background-color: ${({ theme }) => theme.colors.bgHover};
     }
 
     & > .beta {
@@ -73,8 +75,8 @@ export const Wrapper = styled.div<{ theme: string }>`
       right: 0;
       padding: 4px 8px;
       font-size: 12px;
-      color: #fff;
-      background-color: #f5a623;
+      color: ${({ theme }) => theme.colors.textInverse};
+      background-color: ${({ theme }) => theme.colors.warning};
       border-radius: 8px;
     }
 
@@ -102,12 +104,12 @@ export const Wrapper = styled.div<{ theme: string }>`
         content: '';
         width: 88px;
         height: 1px;
-        background-color: #dbdcdf;
+        background-color: ${({ theme }) => theme.colors.border};
       }
     }
 
     & > .count {
-      color: #70727f;
+      color: ${({ theme }) => theme.colors.textMuted};
     }
   }
 `;

--- a/config-ui/src/routes/db-migrate/index.tsx
+++ b/config-ui/src/routes/db-migrate/index.tsx
@@ -46,7 +46,7 @@ export const DBMigrate = () => {
       <Card>
         <h2>
           <Space>
-            <ExclamationCircleOutlined style={{ fontSize: 20, color: '#faad14' }} />
+            <ExclamationCircleOutlined style={{ fontSize: 20, color: 'var(--devlake-color-warning-alt)' }} />
             <span>New Migration Scripts Detected</span>
           </Space>
         </h2>

--- a/config-ui/src/routes/error/index.tsx
+++ b/config-ui/src/routes/error/index.tsx
@@ -33,8 +33,8 @@ export const Error = () => {
     <TipLayout>
       <Card>
         <Space>
-          <CloseCircleOutlined style={{ fontSize: 20, color: '#f5222d' }} />
-          <h2 style={{ color: '#f5222d' }}>{error.toString() || 'Unknown Error'}</h2>
+          <CloseCircleOutlined style={{ fontSize: 20, color: 'var(--devlake-color-error)' }} />
+          <h2 style={{ color: 'var(--devlake-color-error)' }}>{error.toString() || 'Unknown Error'}</h2>
         </Space>
         <p>
           Please try again, if the problem persists include the above error message when filing a bug report on{' '}

--- a/config-ui/src/routes/layout/layout.tsx
+++ b/config-ui/src/routes/layout/layout.tsx
@@ -19,16 +19,28 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useLoaderData, Outlet, useNavigate, useLocation } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
-import { Layout as AntdLayout, Menu, Divider, Dropdown, Button } from 'antd';
-import { UserOutlined, LogoutOutlined } from '@ant-design/icons';
+import { Layout as AntdLayout, Menu, Divider, Dropdown, Button, Tooltip } from 'antd';
+import { UserOutlined, LogoutOutlined, SunOutlined, MoonOutlined, DesktopOutlined } from '@ant-design/icons';
 
 import API from '@/api';
 import { PageLoading, Logo, ExternalLink } from '@/components';
-import { init, selectError, selectStatus } from '@/features';
+import { init, selectError, selectStatus, cycleMode, selectThemeMode } from '@/features';
 import { OnboardCard } from '@/routes/onboard/components';
 import { useAppDispatch, useAppSelector } from '@/hooks';
 
 import { menuItems, menuItemsMatch, headerItems } from './config';
+
+const themeIcon = {
+  light: <SunOutlined />,
+  dark: <MoonOutlined />,
+  system: <DesktopOutlined />,
+} as const;
+
+const themeLabel = {
+  light: 'Light theme',
+  dark: 'Dark theme',
+  system: 'Follow system',
+} as const;
 
 const { Sider, Header, Content, Footer } = AntdLayout;
 
@@ -63,6 +75,7 @@ export const Layout = () => {
   const dispatch = useAppDispatch();
   const status = useAppSelector(selectStatus);
   const error = useAppSelector(selectError);
+  const themeMode = useAppSelector(selectThemeMode);
 
   useEffect(() => {
     dispatch(init(plugins));
@@ -153,6 +166,15 @@ export const Layout = () => {
                 {i !== arr.length - 1 && <Divider type="vertical" />}
               </ExternalLink>
             ))}
+          <Divider type="vertical" />
+          <Tooltip title={themeLabel[themeMode]}>
+            <Button
+              type="text"
+              aria-label={themeLabel[themeMode]}
+              icon={themeIcon[themeMode]}
+              onClick={() => dispatch(cycleMode())}
+            />
+          </Tooltip>
           {user?.authenticated && (
             <>
               <Divider type="vertical" />

--- a/config-ui/src/routes/not-found/index.tsx
+++ b/config-ui/src/routes/not-found/index.tsx
@@ -30,7 +30,7 @@ export const NotFound = () => {
       <Card>
         <h2>
           <Space>
-            <ExclamationCircleOutlined style={{ fontSize: 20, color: '#faad14' }} />
+            <ExclamationCircleOutlined style={{ fontSize: 20, color: 'var(--devlake-color-warning-alt)' }} />
             <span>404 Not Found</span>
           </Space>
         </h2>

--- a/config-ui/src/routes/onboard/index.tsx
+++ b/config-ui/src/routes/onboard/index.tsx
@@ -123,7 +123,7 @@ export const Onboard = ({ logo, title }: Props) => {
             <>
               <S.Header>
                 <h1>Connect to your first repository</h1>
-                <CloseOutlined style={{ fontSize: 18, color: '#70727F', cursor: 'pointer' }} onClick={handleClose} />
+                <CloseOutlined style={{ fontSize: 18, color: 'var(--devlake-color-text-subdued)', cursor: 'pointer' }} onClick={handleClose} />
               </S.Header>
               <S.Content>
                 {[1, 2, 3].includes(step) && (

--- a/config-ui/src/routes/onboard/step-0.tsx
+++ b/config-ui/src/routes/onboard/step-0.tsx
@@ -115,7 +115,7 @@ export const Step0 = ({ logo = <Logo direction="horizontal" />, title = 'DevLake
       {contextHolder}
       <div className="logo">
         {logo}
-        <CloseOutlined style={{ fontSize: 18, color: '#70727F', cursor: 'pointer' }} onClick={handleClose} />
+        <CloseOutlined style={{ fontSize: 18, color: 'var(--devlake-color-text-subdued)', cursor: 'pointer' }} onClick={handleClose} />
       </div>
       <Flex vertical justify="center" align="center">
         <h1>

--- a/config-ui/src/routes/onboard/styled.ts
+++ b/config-ui/src/routes/onboard/styled.ts
@@ -21,7 +21,7 @@ import styled from 'styled-components';
 export const Wrapper = styled.div`
   width: 100%;
   height: 100vh;
-  background-color: #f9f9fa;
+  background-color: ${({ theme }) => theme.colors.bgLayout};
 `;
 
 export const Inner = styled.div`
@@ -61,14 +61,14 @@ export const StepItem = styled.li<{ $activated: boolean; $activatedColor: string
     margin-right: 8px;
     width: 32px;
     height: 32px;
-    color: rgba(0, 0, 0, 0.25);
-    border: 1px solid rgba(0, 0, 0, 0.25);
+    color: ${({ theme }) => theme.colors.textDisabled};
+    border: 1px solid ${({ theme }) => theme.colors.borderStep};
     border-radius: 50%;
 
-    ${({ $activated, $activatedColor }) =>
+    ${({ $activated, $activatedColor, theme }) =>
       $activated
         ? `
-          color: #fff;
+          color: ${theme.colors.textInverse};
           background-color: ${$activatedColor};
           border: none;
           `
@@ -91,7 +91,7 @@ export const StepItem = styled.li<{ $activated: boolean; $activatedColor: string
     left: -150px;
     width: 100px;
     height: 1px;
-    background-color: rgba(0, 0, 0, 0.25);
+    background-color: ${({ theme }) => theme.colors.borderStep};
   }
 
   &:first-child::before {
@@ -102,7 +102,7 @@ export const StepItem = styled.li<{ $activated: boolean; $activatedColor: string
 export const StepContent = styled.div`
   display: flex;
   height: 450px;
-  background-color: #fff;
+  background-color: ${({ theme }) => theme.colors.bgContainer};
   box-shadow: 0px 2.4px 4.8px -0.8px rgba(0, 0, 0, 0.1), 0px 1.6px 8px 0px rgba(0, 0, 0, 0.07);
 
   .content {
@@ -115,7 +115,7 @@ export const StepContent = styled.div`
     margin: 12px 0;
     padding: 0 24px;
     font-size: 14px;
-    border-left: 1px solid #f0f0f0;
+    border-left: 1px solid ${({ theme }) => theme.colors.borderSubtle};
     overflow-y: auto;
 
     img {
@@ -142,7 +142,7 @@ export const StepContent = styled.div`
     }
 
     p {
-      color: #6c6c6c;
+      color: ${({ theme }) => theme.colors.textBody};
     }
 
     code {
@@ -151,8 +151,8 @@ export const StepContent = styled.div`
       font-family: Menlo;
       line-height: 20px;
       border-radius: 3px;
-      border: #f0f0f0;
-      background: #f5f5f5;
+      border: 1px solid ${({ theme }) => theme.colors.borderSubtle};
+      background: ${({ theme }) => theme.colors.bgCode};
     }
   }
 `;

--- a/config-ui/src/routes/pipeline/styled.ts
+++ b/config-ui/src/routes/pipeline/styled.ts
@@ -21,19 +21,19 @@ import styled from 'styled-components';
 export const StatusWrapper = styled.div`
   &.ready,
   &.cancel {
-    color: #94959f;
+    color: ${({ theme }) => theme.colors.textTertiary};
   }
 
   &.loading {
-    color: #7497f7;
+    color: ${({ theme }) => theme.colors.primary};
   }
 
   &.success {
-    color: #4db764;
+    color: ${({ theme }) => theme.colors.success};
   }
 
   &.error {
-    color: #f5222d;
+    color: ${({ theme }) => theme.colors.error};
   }
 `;
 
@@ -54,7 +54,7 @@ export const Info = styled.div`
 
     & > span {
       font-size: 12px;
-      color: #94959f;
+      color: ${({ theme }) => theme.colors.textTertiary};
       text-align: center;
     }
 
@@ -68,7 +68,7 @@ export const Info = styled.div`
 
   p.message {
     margin: 8px 0 0;
-    color: #f5222d;
+    color: ${({ theme }) => theme.colors.error};
   }
 `;
 
@@ -100,23 +100,23 @@ export const TasksHeader = styled.ul`
 
     &.ready,
     &.cancel {
-      color: #94959f;
-      background-color: #f9f9fa;
+      color: ${({ theme }) => theme.colors.textTertiary};
+      background-color: ${({ theme }) => theme.colors.bgStatus};
     }
 
     &.loading {
-      color: #7497f7;
-      background-color: #e9efff;
+      color: ${({ theme }) => theme.colors.primary};
+      background-color: ${({ theme }) => theme.colors.infoBg};
     }
 
     &.success {
-      color: #4db764;
-      background-color: #edfbf0;
+      color: ${({ theme }) => theme.colors.success};
+      background-color: ${({ theme }) => theme.colors.successBg};
     }
 
     &.error {
-      color: #e34040;
-      background-color: #feefef;
+      color: ${({ theme }) => theme.colors.errorAlt};
+      background-color: ${({ theme }) => theme.colors.errorBg};
     }
   }
 
@@ -146,7 +146,7 @@ export const Task = styled.div`
   justify-content: space-between;
   padding: 16px 0;
   height: 80px;
-  border-bottom: 1px solid #dbe4fd;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.borderTask};
   box-sizing: border-box;
 
   .info {
@@ -181,7 +181,7 @@ export const Task = styled.div`
       text-overflow: ellipsis;
 
       &.error {
-        color: #f5222d;
+        color: ${({ theme }) => theme.colors.error};
       }
     }
   }

--- a/config-ui/src/routes/project/home/index.tsx
+++ b/config-ui/src/routes/project/home/index.tsx
@@ -150,7 +150,7 @@ export const ProjectHomePage = () => {
               <Link
                 to={PATHS.PROJECT(name)}
                 state={{ activeKey: 'configuration' }}
-                style={{ color: '#292b3f' }}
+                style={{ color: 'var(--devlake-color-text)' }}
                 ref={nameRef}
               >
                 {name}

--- a/config-ui/src/theme/ThemeProvider.tsx
+++ b/config-ui/src/theme/ThemeProvider.tsx
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { ReactNode, useEffect, useMemo, useState } from 'react';
+import { ConfigProvider } from 'antd';
+import { ThemeProvider as StyledThemeProvider } from 'styled-components';
+
+import { useAppSelector } from '@/hooks';
+import { selectThemeMode, resolveThemeMode } from '@/features/theme/slice';
+
+import { getTheme, ResolvedTheme } from './tokens';
+
+interface Props {
+  children: ReactNode;
+}
+
+const CSS_VAR_MAP: Record<string, keyof ReturnType<typeof getTheme>['colors']> = {
+  '--devlake-color-text': 'text',
+  '--devlake-color-text-muted': 'textTertiary',
+  '--devlake-color-text-body': 'textBody',
+  '--devlake-color-text-subdued': 'textMuted',
+  '--devlake-color-bg': 'bgContainer',
+  '--devlake-color-bg-elevated': 'bgElevated',
+  '--devlake-color-border': 'border',
+  '--devlake-color-success': 'success',
+  '--devlake-color-error': 'error',
+  '--devlake-color-error-alt': 'errorAlt',
+  '--devlake-color-warning': 'warning',
+  '--devlake-color-warning-alt': 'warningAlt',
+  '--devlake-color-warning-soft': 'warningSoft',
+};
+
+export const ThemeProvider = ({ children }: Props) => {
+  const mode = useAppSelector(selectThemeMode);
+  const [resolved, setResolved] = useState<ResolvedTheme>(() => resolveThemeMode(mode));
+
+  useEffect(() => {
+    setResolved(resolveThemeMode(mode));
+
+    if (mode !== 'system' || typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const media = window.matchMedia('(prefers-color-scheme: dark)');
+    const onChange = () => setResolved(media.matches ? 'dark' : 'light');
+    media.addEventListener('change', onChange);
+    return () => media.removeEventListener('change', onChange);
+  }, [mode]);
+
+  const customPrimary = import.meta.env.DEVLAKE_COLOR_CUSTOM;
+  const theme = useMemo(() => getTheme(resolved, customPrimary), [resolved, customPrimary]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined') return;
+    const root = document.documentElement;
+    root.dataset.theme = resolved;
+    root.style.colorScheme = resolved;
+    for (const [cssVar, key] of Object.entries(CSS_VAR_MAP)) {
+      root.style.setProperty(cssVar, theme.colors[key]);
+    }
+  }, [resolved, theme]);
+
+  return (
+    <ConfigProvider theme={theme.antd}>
+      <StyledThemeProvider theme={theme}>{children}</StyledThemeProvider>
+    </ConfigProvider>
+  );
+};

--- a/config-ui/src/theme/index.ts
+++ b/config-ui/src/theme/index.ts
@@ -16,30 +16,5 @@
  *
  */
 
-import styled from 'styled-components';
-
-export const Label = styled.label`
-  font-size: 16px;
-  font-weight: 600;
-`;
-
-export const LabelInfo = styled.i`
-  color: ${({ theme }) => theme.colors.secondary};
-`;
-
-export const LabelDescription = styled.p`
-  margin: 0;
-`;
-
-export const RateLimit = styled.div`
-  display: flex;
-  align-items: center;
-
-  & > span {
-    margin-left: 8px;
-  }
-`;
-
-export const RateLimitInfo = styled.p`
-  white-space: pre-line;
-`;
+export * from './tokens';
+export * from './ThemeProvider';

--- a/config-ui/src/theme/styled.d.ts
+++ b/config-ui/src/theme/styled.d.ts
@@ -16,30 +16,12 @@
  *
  */
 
-import styled from 'styled-components';
+import 'styled-components';
+import type { AppThemeColors, ResolvedTheme } from './tokens';
 
-export const Label = styled.label`
-  font-size: 16px;
-  font-weight: 600;
-`;
-
-export const LabelInfo = styled.i`
-  color: ${({ theme }) => theme.colors.secondary};
-`;
-
-export const LabelDescription = styled.p`
-  margin: 0;
-`;
-
-export const RateLimit = styled.div`
-  display: flex;
-  align-items: center;
-
-  & > span {
-    margin-left: 8px;
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    mode: ResolvedTheme;
+    colors: AppThemeColors;
   }
-`;
-
-export const RateLimitInfo = styled.p`
-  white-space: pre-line;
-`;
+}

--- a/config-ui/src/theme/tokens.ts
+++ b/config-ui/src/theme/tokens.ts
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { theme as antdTheme, ThemeConfig } from 'antd';
+
+export type ThemeMode = 'light' | 'dark' | 'system';
+export type ResolvedTheme = 'light' | 'dark';
+
+const primaryShades = {
+  lightest: '#DBE4FD',
+  lighter: '#BDCEFB',
+  light: '#99B3F9',
+  base: '#7497F7',
+  dark: '#5D7CD2',
+  darker: '#4C66AD',
+  darkest: '#3C5088',
+  tint100: '#F0F4FE',
+};
+
+export type AppThemeColors = {
+  // Brand
+  primary: string;
+  primaryHover: string;
+
+  // Status / accent
+  success: string;
+  successBg: string;
+  error: string;
+  errorAlt: string;
+  errorMuted: string;
+  errorBg: string;
+  warning: string;
+  warningAlt: string;
+  warningSoft: string;
+  secondary: string;
+  infoBg: string;
+
+  // Surfaces
+  bgLayout: string;
+  bgContainer: string;
+  bgElevated: string;
+  bgHover: string;
+  bgMuted: string;
+  bgCode: string;
+  bgStatus: string;
+
+  // Borders
+  border: string;
+  borderSubtle: string;
+  borderTask: string;
+  borderStep: string;
+
+  // Text
+  text: string;
+  textSecondary: string;
+  textTertiary: string;
+  textMuted: string;
+  textBody: string;
+  textFaint: string;
+  textInverse: string;
+  textDisabled: string;
+};
+
+export interface AppTheme {
+  mode: ResolvedTheme;
+  colors: AppThemeColors;
+  antd: ThemeConfig;
+}
+
+const lightColors: AppThemeColors = {
+  primary: primaryShades.base,
+  primaryHover: primaryShades.dark,
+
+  success: '#4DB764',
+  successBg: '#EDFBF0',
+  error: '#F5222D',
+  errorAlt: '#E34040',
+  errorMuted: '#CD4246',
+  errorBg: '#FEEFEF',
+  warning: '#F5A623',
+  warningAlt: '#FAAD14',
+  warningSoft: '#F4BE55',
+  secondary: '#FF8B8B',
+  infoBg: '#E9EFFF',
+
+  bgLayout: '#F9F9FA',
+  bgContainer: '#FFFFFF',
+  bgElevated: '#F3F3F3',
+  bgHover: '#EEEEEE',
+  bgMuted: '#EFEFEF',
+  bgCode: '#F5F5F5',
+  bgStatus: '#F9F9FA',
+
+  border: '#DBDCDF',
+  borderSubtle: '#F0F0F0',
+  borderTask: '#DBE4FD',
+  borderStep: 'rgba(0, 0, 0, 0.25)',
+
+  text: '#292B3F',
+  textSecondary: '#4D4E5F',
+  textTertiary: '#94959F',
+  textMuted: '#70727F',
+  textBody: '#6C6C6C',
+  textFaint: '#AAAAAA',
+  textInverse: '#FFFFFF',
+  textDisabled: 'rgba(0, 0, 0, 0.25)',
+};
+
+const darkColors: AppThemeColors = {
+  primary: primaryShades.base,
+  primaryHover: primaryShades.lighter,
+
+  success: '#4DB764',
+  successBg: 'rgba(77, 183, 100, 0.15)',
+  error: '#F5222D',
+  errorAlt: '#FF6B6B',
+  errorMuted: '#FF8080',
+  errorBg: 'rgba(245, 34, 45, 0.15)',
+  warning: '#F5A623',
+  warningAlt: '#FAAD14',
+  warningSoft: '#F4BE55',
+  secondary: '#FF8B8B',
+  infoBg: primaryShades.darkest,
+
+  bgLayout: '#1B1B1D',
+  bgContainer: '#242526',
+  bgElevated: '#2D2D2F',
+  bgHover: '#303032',
+  bgMuted: '#2D2D2F',
+  bgCode: '#2D2D2F',
+  bgStatus: '#2D2D2F',
+
+  border: '#3A3A3C',
+  borderSubtle: '#2D2D2F',
+  borderTask: primaryShades.darkest,
+  borderStep: '#3A3A3C',
+
+  text: '#E3E3E6',
+  textSecondary: '#BDCEFB',
+  textTertiary: '#94959F',
+  textMuted: '#A0A1A8',
+  textBody: '#A0A1A8',
+  textFaint: '#70727F',
+  textInverse: '#1B1B1D',
+  textDisabled: '#70727F',
+};
+
+const buildAntdConfig = (colors: AppThemeColors, mode: ResolvedTheme): ThemeConfig => ({
+  algorithm: mode === 'dark' ? antdTheme.darkAlgorithm : antdTheme.defaultAlgorithm,
+  token: {
+    colorPrimary: colors.primary,
+    colorSuccess: colors.success,
+    colorError: colors.error,
+    colorWarning: colors.warning,
+    colorBgLayout: colors.bgLayout,
+    colorBgContainer: colors.bgContainer,
+    colorBgElevated: colors.bgElevated,
+    colorBorder: colors.border,
+    colorBorderSecondary: colors.borderSubtle,
+    colorText: colors.text,
+    colorTextSecondary: colors.textSecondary,
+    colorTextTertiary: colors.textTertiary,
+    colorTextDisabled: colors.textDisabled,
+  },
+});
+
+const buildTheme = (mode: ResolvedTheme, customPrimary?: string): AppTheme => {
+  const base = mode === 'dark' ? darkColors : lightColors;
+  const colors = customPrimary ? { ...base, primary: customPrimary, primaryHover: customPrimary } : base;
+  return { mode, colors, antd: buildAntdConfig(colors, mode) };
+};
+
+export const getTheme = (mode: ResolvedTheme, customPrimary?: string): AppTheme => buildTheme(mode, customPrimary);


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
Adds a system-aware dark theme with a header toggle (light, dark, system) that persists in localStorage. All colors now flow through `src/theme/tokens.ts` into both the antd component library and styled-components, replacing hardcoded hex across `styled.ts` files and inline styles.

Light mode is preserved the same as before, dark mode is based on the colors of the dark mode of the website.

### Does this close any open issues?
https://github.com/apache/incubator-devlake/issues/8863

### Screenshots
<img width="586" height="373" alt="image" src="https://github.com/user-attachments/assets/700b6b29-a605-4025-ae38-ec4ed543bcc4" />
<img width="1552" height="445" alt="image" src="https://github.com/user-attachments/assets/4fc2ac8c-14fb-45a6-8b97-fe103ad08a21" />
<img width="1030" height="912" alt="image" src="https://github.com/user-attachments/assets/4761e8db-46a2-42d2-96af-0bbc2d1be4c3" />
<img width="1276" height="291" alt="image" src="https://github.com/user-attachments/assets/d7b5aa3a-8655-4fbf-a1ac-be41dd07c7f0" />
<img width="1316" height="636" alt="image" src="https://github.com/user-attachments/assets/a4941fcf-5177-4fe6-921e-04576505f8d2" />
<img width="828" height="677" alt="image" src="https://github.com/user-attachments/assets/eee82449-f45d-44d7-8b0f-c3e32161eacf" />


### Other Information
Open to any suggestions for the colors!