### PR TITLE
feat(push-api): implement push API with authentication and validation logic

### DIFF
--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -106,9 +106,11 @@ func CreateApiServer() *gin.Engine {
 	router.GET("/version", version.Get)
 
 	// Auth chain order matters: REST API key first (its own short-circuit),
-	// then OIDC session, then oauth2-proxy header (only sets USER if not yet
-	// set), then the terminal 401 gate, finally CSRF on unsafe methods.
+	// then the push API key gate, then OIDC session, then oauth2-proxy header
+	// (only sets USER if not yet set), then the terminal 401 gate, finally
+	// CSRF on unsafe methods.
 	router.Use(RestAuthentication(router, basicRes))
+	router.Use(RequirePushAuthentication(basicRes))
 	router.Use(auth.OIDCAuthentication())
 	router.Use(OAuth2ProxyAuthentication(basicRes))
 	router.Use(auth.RequireAuth())

--- a/backend/server/api/middlewares.go
+++ b/backend/server/api/middlewares.go
@@ -20,11 +20,12 @@ package api
 import (
 	"encoding/base64"
 	"fmt"
-	"github.com/apache/incubator-devlake/core/log"
 	"net/http"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/apache/incubator-devlake/core/log"
 
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/dal"
@@ -113,7 +114,6 @@ func RestAuthentication(router *gin.Engine, basicRes context.BasicRes) gin.Handl
 		path := c.Request.URL.Path
 		// Only open api needs to check api key
 		if !strings.HasPrefix(path, "/rest") {
-			logger.Debug("path %s will continue", path)
 			c.Next()
 			return
 		}
@@ -128,6 +128,53 @@ func RestAuthentication(router *gin.Engine, basicRes context.BasicRes) gin.Handl
 			c.Abort()
 			return
 		}
+	}
+}
+
+func RequirePushAuthentication(basicRes context.BasicRes) gin.HandlerFunc {
+	logger := basicRes.GetLogger()
+	return func(c *gin.Context) {
+		path := c.Request.URL.Path
+		if !strings.HasPrefix(path, "/push/") {
+			c.Next()
+			return
+		}
+
+		authHeader := c.GetHeader("Authorization")
+		if authHeader == "" {
+			c.Abort()
+			c.JSON(http.StatusUnauthorized, &apiBody{
+				Success: false,
+				Message: "token is missing",
+			})
+			return
+		}
+		apiKeyStr := strings.TrimPrefix(authHeader, "Bearer ")
+		if apiKeyStr == authHeader || apiKeyStr == "" {
+			c.Abort()
+			c.JSON(http.StatusUnauthorized, &apiBody{
+				Success: false,
+				Message: "token is not present or malformed",
+			})
+			return
+		}
+
+		db := basicRes.GetDal()
+		if db == nil {
+			logger.Error(nil, "db is not initialised")
+			c.Abort()
+			c.JSON(http.StatusInternalServerError, &apiBody{
+				Success: false,
+				Message: "database is not initialised",
+			})
+			return
+		}
+
+		apiKeyHelper := apikeyhelper.NewApiKeyHelper(basicRes, logger)
+		if !CheckAuthorizationHeader(c, logger, db, apiKeyHelper, authHeader, path) {
+			return
+		}
+		c.Next()
 	}
 }
 

--- a/backend/server/api/middlewares_test.go
+++ b/backend/server/api/middlewares_test.go
@@ -1,0 +1,74 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	corectx "github.com/apache/incubator-devlake/core/context"
+	contextimpl "github.com/apache/incubator-devlake/impls/context"
+	"github.com/apache/incubator-devlake/impls/logruslog"
+	"github.com/gin-gonic/gin"
+	"github.com/spf13/viper"
+)
+
+func newPushTestBasicRes() corectx.BasicRes {
+	cfg := viper.New()
+	cfg.Set("ENCRYPTION_SECRET", strings.Repeat("a", 32))
+	return contextimpl.NewDefaultBasicRes(cfg, logruslog.Global, nil)
+}
+
+func TestRequirePushAuthenticationRejectsMissingToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(RequirePushAuthentication(newPushTestBasicRes()))
+	router.POST("/push/:tableName", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/push/commits", strings.NewReader(`[{}]`))
+	req.Header.Set("Content-Type", "application/json")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusUnauthorized)
+	}
+}
+
+func TestRequirePushAuthenticationRejectsMalformedToken(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	router.Use(RequirePushAuthentication(newPushTestBasicRes()))
+	router.POST("/push/:tableName", func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/push/commits", strings.NewReader(`[{}]`))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Basic dGVzdDp0ZXN0")
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want %d", resp.Code, http.StatusUnauthorized)
+	}
+}

--- a/backend/server/api/push/README.md
+++ b/backend/server/api/push/README.md
@@ -21,12 +21,19 @@ limitations under the License.
 This is a generic API service that gives our users the ability to inject data directly to their own database using a
 simple, all-purpose endpoint.
 
+The push API is disabled by default. To enable it safely, you must:
+- configure `PUSH_API_ALLOWED_TABLES` with the specific non-internal tables that may be written
+- send a Bearer API key whose `allowedPath` matches the `/push/...` endpoint you are calling
+
 ## The Endpoint
 
 POST to ```localhost:8080/push/:tableName```
 
 Where "tableName" is the name of the table you wish to insert into
 For example, "commits" would be ```/push/commits```
+
+Internal `_devlake_*` tables are never writable through this endpoint, even if
+they are listed in `PUSH_API_ALLOWED_TABLES`.
 
 ## The JSON body
 
@@ -43,6 +50,5 @@ Please Note: You must know the schema you are inserting into (column names, type
     }
 ]
 ```
-
 
 

--- a/backend/server/services/pushapi.go
+++ b/backend/server/services/pushapi.go
@@ -18,30 +18,15 @@ limitations under the License.
 package services
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/server/services/pushapiaccess"
 )
 
 // InsertRow FIXME ...
 func InsertRow(table string, rows []map[string]interface{}) (int64, errors.Error) {
-	if !regexp.MustCompile(`^[a-zA-Z0-9_]+$`).MatchString(table) {
-		return 0, errors.BadInput.New("table name invalid")
-	}
-
-	if allowedTables := cfg.GetString("PUSH_API_ALLOWED_TABLES"); allowedTables != "" {
-		allow := false
-		for _, t := range strings.Split(allowedTables, ",") {
-			if strings.TrimSpace(t) == table {
-				allow = true
-				break
-			}
-		}
-		if !allow {
-			return 0, errors.Forbidden.New("table name is not in the allowed list")
-		}
+	if err := pushapiaccess.ValidateTable(table, cfg.GetString("PUSH_API_ALLOWED_TABLES")); err != nil {
+		return 0, err
 	}
 
 	err := db.Create(rows, dal.From(table))

--- a/backend/server/services/pushapiaccess/access.go
+++ b/backend/server/services/pushapiaccess/access.go
@@ -1,0 +1,54 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pushapiaccess
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/apache/incubator-devlake/core/errors"
+)
+
+var tableNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
+
+const internalTablePrefix = "_devlake_"
+
+func ValidateTable(table string, allowedTables string) errors.Error {
+	if !tableNameRegex.MatchString(table) {
+		return errors.BadInput.New("table name invalid")
+	}
+	if strings.HasPrefix(table, internalTablePrefix) {
+		return errors.Forbidden.New("writing internal tables via push API is forbidden")
+	}
+
+	allowlist := map[string]struct{}{}
+	for _, t := range strings.Split(allowedTables, ",") {
+		name := strings.TrimSpace(t)
+		if name == "" || strings.HasPrefix(name, internalTablePrefix) {
+			continue
+		}
+		allowlist[name] = struct{}{}
+	}
+	if len(allowlist) == 0 {
+		return errors.Forbidden.New("push API is disabled unless PUSH_API_ALLOWED_TABLES is configured")
+	}
+	if _, ok := allowlist[table]; !ok {
+		return errors.Forbidden.New("table name is not in the allowed list")
+	}
+	return nil
+}

--- a/backend/server/services/pushapiaccess/access_test.go
+++ b/backend/server/services/pushapiaccess/access_test.go
@@ -1,0 +1,70 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pushapiaccess
+
+import "testing"
+
+func TestValidateTable(t *testing.T) {
+	cases := []struct {
+		name          string
+		table         string
+		allowedTables string
+		wantErr       bool
+	}{
+		{
+			name:          "allows configured application table",
+			table:         "commits",
+			allowedTables: "commits, issues",
+		},
+		{
+			name:          "rejects invalid table name",
+			table:         "commits;drop",
+			allowedTables: "commits",
+			wantErr:       true,
+		},
+		{
+			name:    "default denies when allowlist unset",
+			table:   "commits",
+			wantErr: true,
+		},
+		{
+			name:          "rejects internal tables even when allowlisted",
+			table:         "_devlake_pipelines",
+			allowedTables: "_devlake_pipelines,commits",
+			wantErr:       true,
+		},
+		{
+			name:          "rejects tables missing from allowlist",
+			table:         "pull_requests",
+			allowedTables: "commits,issues",
+			wantErr:       true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateTable(tc.table, tc.allowedTables)
+			if tc.wantErr && err == nil {
+				t.Fatal("expected an error but got nil")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+	}
+}

--- a/env.example
+++ b/env.example
@@ -34,7 +34,9 @@ SKIP_SUBTASK_PROGRESS=false
 PORT=8080
 MODE=release
 
-# PUSH_API_ALLOWED_TABLES=table1,table2
+# Push API is disabled by default. To enable it, list only application tables
+# here. Internal _devlake_* tables are always forbidden.
+PUSH_API_ALLOWED_TABLES=
 NOTIFICATION_ENDPOINT=
 NOTIFICATION_SECRET=
 


### PR DESCRIPTION
### Summary
- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [x] I have added relevant tests.
- [x] I have added relevant documentation.
- [x] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

### Summary
- default-denies the push API unless `PUSH_API_ALLOWED_TABLES` is explicitly configured
- blocks writes to internal `_devlake_*` tables even if they are mistakenly added to the allowlist
- requires a Bearer API key on `/push/*` regardless of `AUTH_ENABLED`, and adds focused middleware and validation tests

### Does this close any open issues?
Closes N/A

### Screenshots
N/A

### Other Information
- updated `env.example` and `backend/server/api/push/README.md` to reflect the secure push API defaults
- added coverage in `backend/server/api/middlewares_test.go` and `backend/server/services/pushapiaccess/access_test.go`