### PR TITLE
fix(bitbucket): handle API errors in workspace listing and guard empty pipeline Id

### DIFF
--- a/backend/plugins/bitbucket/api/remote_api.go
+++ b/backend/plugins/bitbucket/api/remote_api.go
@@ -80,6 +80,15 @@ func listBitbucketWorkspaces(
 	if err != nil {
 		return
 	}
+	if res.StatusCode > 299 {
+		body, e := io.ReadAll(res.Body)
+		if e != nil {
+			err = errors.BadInput.Wrap(e, "failed to read response body")
+			return
+		}
+		err = errors.HttpStatus(res.StatusCode).New(string(body))
+		return
+	}
 
 	resBody := &models.WorkspaceResponse{}
 	err = api.UnmarshalResponse(res, resBody)

--- a/config-ui/src/routes/onboard/components/card.tsx
+++ b/config-ui/src/routes/onboard/components/card.tsx
@@ -49,11 +49,11 @@ export const OnboardCard = ({ style }: Props) => {
 
   const tasksRes = useAutoRefresh(
     async () => {
-      if ((data && data.done) || !record) {
+      if ((data && data.done) || !record || !record.pipelineId) {
         return;
       }
 
-      return await API.pipeline.subTasks(record?.pipelineId as string);
+      return await API.pipeline.subTasks(record.pipelineId as string);
     },
     [record],
     {

--- a/config-ui/src/routes/onboard/step-4.tsx
+++ b/config-ui/src/routes/onboard/step-4.tsx
@@ -112,7 +112,10 @@ export const Step4 = () => {
 
   const { data } = useAutoRefresh(
     async () => {
-      return await API.pipeline.subTasks(record?.pipelineId as string);
+      if (!record?.pipelineId) {
+        return;
+      }
+      return await API.pipeline.subTasks(record.pipelineId as string);
     },
     [record],
     {


### PR DESCRIPTION


- Add HTTP status code check in listBitbucketWorkspaces, mirroring the existing check in listBitbucketRepos. A non-2xx Bitbucket response was silently unmarshalled as an empty WorkspaceResponse, causing the UI to show No data to select with no error surfaced to the user.

- Guard against calling the pipeline subtasks API with an empty pipelineId in card.tsx and step-4.tsx. The record is initialised with pipelineId="" in step-2 before a pipeline has been triggered, causing the frontend to issue GET /pipelines//subtasks and receive a 400 invalid pipeline ID format error from the backend.

<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?
- **Backend** (`backend/plugins/bitbucket/api/remote_api.go`): `listBitbucketWorkspaces` did not check the HTTP status code before unmarshalling, unlike sibling `listBitbucketRepos`. When Bitbucket returns a non-2xx error, `json.Unmarshal` silently produces a zero-value `WorkspaceResponse` (empty `values`), so the endpoint returned HTTP 200 with `children: []` causing "No data to select" in the UI with no visible error.

- **Frontend** (`card.tsx`, `step-4.tsx`): After a Bitbucket connection is created in Step 2, the record is stored with `pipelineId: ""`. Both the onboard card and Step 4 called `API.pipeline.subTasks(record.pipelineId)` without checking if `pipelineId` was non-empty, sending `GET /pipelines//subtasks` to the backend and producing the logged `400 invalid pipeline ID format` error.

### Does this close any open issues?
Closes 8868

