### PR TITLE
fix(jenkins): truncate primary_view to fit varchar(255) column

### DIFF
--- a/backend/.golangci.yaml
+++ b/backend/.golangci.yaml
@@ -243,6 +243,7 @@ linters:
       - third_party$
       - builtin$
       - examples$
+      - mocks$
 formatters:
   enable:
     - gofmt

--- a/backend/plugins/jenkins/models/response.go
+++ b/backend/plugins/jenkins/models/response.go
@@ -61,6 +61,11 @@ func (j Job) ToJenkinsJob() *JenkinsJob {
 		}
 	}
 
+	primaryView := j.URL + j.Path + j.Class
+	if len(primaryView) > 255 {
+		primaryView = primaryView[:255]
+	}
+
 	return &JenkinsJob{
 		FullName:    j.FullName,
 		Name:        j.Name,
@@ -70,7 +75,7 @@ func (j Job) ToJenkinsJob() *JenkinsJob {
 		Base:        j.Base,
 		Url:         j.URL,
 		Description: j.Description,
-		PrimaryView: j.URL + j.Path + j.Class,
+		PrimaryView: primaryView,
 	}
 }
 


### PR DESCRIPTION
### Summary
This PR fixes a database error that occurs when extracting Jenkins jobs.

### Bug
When extracting Jenkins jobs, the  field was computed as , which could exceed the  column limit and cause:



### Fix
Truncate the concatenated value to 255 characters before saving.

### Closes
Closes https://github.com/apache/devlake/issues/8897