### PR TITLE
fix(jira): rename "Jira Server" to "Jira Data Center" in UI labels

### DIFF
--- a/config-ui/src/plugins/register/jira/config.tsx
+++ b/config-ui/src/plugins/register/jira/config.tsx
@@ -49,7 +49,7 @@ export const JiraConfig: IPluginConfig = {
           'By default, DevLake uses dynamic rate limit for optimized data collection for Jira. But you can adjust the collection speed by setting up your desirable rate limit.',
         learnMore: DOC_URL.PLUGIN.JIRA.RATE_LIMIT,
         externalInfo:
-          'Jira Cloud does not specify a maximum value of rate limit. For Jira Server, please contact your admin for more information.',
+          'Jira Cloud does not specify a maximum value of rate limit. For Jira Data Center, please contact your admin for more information.',
         defaultValue: 10000,
       },
     ],

--- a/config-ui/src/plugins/register/jira/config.tsx
+++ b/config-ui/src/plugins/register/jira/config.tsx
@@ -49,7 +49,7 @@ export const JiraConfig: IPluginConfig = {
           'By default, DevLake uses dynamic rate limit for optimized data collection for Jira. But you can adjust the collection speed by setting up your desirable rate limit.',
         learnMore: DOC_URL.PLUGIN.JIRA.RATE_LIMIT,
         externalInfo:
-          'Jira Cloud does not specify a maximum value of rate limit. For Jira Data Center, please contact your admin for more information.',
+          'Jira Cloud does not specify a maximum value of rate limit.  For Jira Server / Jira Data Center, please contact your admin for more information.',
         defaultValue: 10000,
       },
     ],

--- a/config-ui/src/plugins/register/jira/connection-fields/auth.tsx
+++ b/config-ui/src/plugins/register/jira/connection-fields/auth.tsx
@@ -124,7 +124,7 @@ export const Auth = ({ type, initialValues, values, setValues, setErrors }: Prop
       <Block title="Jira Version" required>
         <Radio.Group value={version} onChange={handleChangeVersion}>
           <Radio value="cloud">Jira Cloud</Radio>
-          <Radio value="server">Jira Data Center</Radio>
+          <Radio value="server">Jira Server / Jira Data Center</Radio>
         </Radio.Group>
 
         <Block
@@ -136,7 +136,7 @@ export const Auth = ({ type, initialValues, values, setValues, setErrors }: Prop
                 ? 'Provide the Jira instance API endpoint. For Jira Cloud, e.g. https://your-company.atlassian.net/rest/. Please note that the endpoint URL should end with /.'
                 : ''}
               {version === 'server'
-                ? 'Provide the Jira instance API endpoint. For Jira Data Center, e.g. https://jira.your-company.com/rest/. Please note that the endpoint URL should end with /.'
+                ? 'Provide the Jira instance API endpoint. For Jira Server / Jira Data Center, e.g. https://jira.your-company.com/rest/. Please note that the endpoint URL should end with /.'
                 : ''}
             </>
           }

--- a/config-ui/src/plugins/register/jira/connection-fields/auth.tsx
+++ b/config-ui/src/plugins/register/jira/connection-fields/auth.tsx
@@ -124,7 +124,7 @@ export const Auth = ({ type, initialValues, values, setValues, setErrors }: Prop
       <Block title="Jira Version" required>
         <Radio.Group value={version} onChange={handleChangeVersion}>
           <Radio value="cloud">Jira Cloud</Radio>
-          <Radio value="server">Jira Server</Radio>
+          <Radio value="server">Jira Data Center</Radio>
         </Radio.Group>
 
         <Block
@@ -136,7 +136,7 @@ export const Auth = ({ type, initialValues, values, setValues, setErrors }: Prop
                 ? 'Provide the Jira instance API endpoint. For Jira Cloud, e.g. https://your-company.atlassian.net/rest/. Please note that the endpoint URL should end with /.'
                 : ''}
               {version === 'server'
-                ? 'Provide the Jira instance API endpoint. For Jira Server, e.g. https://jira.your-company.com/rest/. Please note that the endpoint URL should end with /.'
+                ? 'Provide the Jira instance API endpoint. For Jira Data Center, e.g. https://jira.your-company.com/rest/. Please note that the endpoint URL should end with /.'
                 : ''}
             </>
           }


### PR DESCRIPTION
## Summary

Renames the user-facing label "Jira Server" to "Jira Data Center" across the Jira plugin UI, reflecting Atlassian's official deprecation and rebranding of the product.

## Changes

- `config-ui/src/plugins/register/jira/connection-fields/auth.tsx` — updated radio button label and endpoint URL hint text
- `config-ui/src/plugins/register/jira/config.tsx` — updated rate limit help text

## What was intentionally left unchanged

Internal Go identifiers (`JiraServerInfo`, `DeploymentServer`) and the database table name (`_tool_jira_server_infos`) were not renamed. These are internal implementation details and renaming them would require a database migration, which is out of scope for a UI label fix.

## Does this close any open issues?

Closes #8856