### PR TITLE
fix(jira): use Jira created timestamp and inner join for changelog convertor (#8834)

### DIFF
--- a/backend/plugins/jira/tasks/issue_changelog_convertor.go
+++ b/backend/plugins/jira/tasks/issue_changelog_convertor.go
@@ -95,16 +95,17 @@ func ConvertIssueChangelogs(subtaskCtx plugin.SubTaskContext) errors.Error {
 					_tool_jira_issue_changelogs.connection_id = _tool_jira_issue_changelog_items.connection_id
 					AND _tool_jira_issue_changelogs.changelog_id = _tool_jira_issue_changelog_items.changelog_id
 				)`),
-				dal.Join(`left join _tool_jira_board_issues on (
-					_tool_jira_board_issues.connection_id = _tool_jira_issue_changelogs.connection_id
-					AND _tool_jira_board_issues.issue_id = _tool_jira_issue_changelogs.issue_id
-				)`),
-				dal.Where("_tool_jira_issue_changelog_items.connection_id = ? AND _tool_jira_board_issues.board_id = ?", connectionId, boardId),
-			}
+				dal.Join(`inner join _tool_jira_board_issues on (
+				    _tool_jira_board_issues.connection_id = _tool_jira_issue_changelogs.connection_id
+				    AND _tool_jira_board_issues.issue_id = _tool_jira_issue_changelogs.issue_id
+				    AND _tool_jira_board_issues.board_id = ?
+				)`, boardId),
+				dal.Where("_tool_jira_issue_changelog_items.connection_id = ?", connectionId),			}
 			if stateManager.IsIncremental() {
 				since := stateManager.GetSince()
 				if since != nil {
-					clauses = append(clauses, dal.Where("_tool_jira_issue_changelog_items.created_at >= ? ", since))
+					clauses = append(clauses, dal.Where("_tool_jira_issue_changelogs.created >= ?", since))
+
 				}
 			}
 			return db.Cursor(clauses...)


### PR DESCRIPTION
Fixes #8834

## Problem
Two bugs in ConvertIssueChangelogs cause changelog items to be silently
dropped from the domain layer:

1. Incremental filter (line 107) filters on `_tool_jira_issue_changelog_items.created_at`
   which is the DevLake internal DB insertion timestamp (NoPKModel.CreatedAt),
   not the Jira changelog's Created date. Changelog items inserted in the same
   batch can fall on either side of the `since` cutoff, silently dropping items
   from that batch on the next incremental run.

2. LEFT JOIN on `_tool_jira_board_issues` with `board_id` filter in WHERE clause
   is a LEFT JOIN used as INNER JOIN. Any issue not in board_issues produces a
   NULL board_id row which the WHERE silently drops. Moving board_id into the
   JOIN condition as INNER JOIN makes intent explicit and eliminates duplicate
   rows when an issue belongs to multiple boards.

## Changes
- `backend/plugins/jira/tasks/issue_changelog_convertor.go`:
  - Change `LEFT JOIN _tool_jira_board_issues` to `INNER JOIN` with `board_id = ?`
    in the join condition instead of WHERE
  - Change incremental filter from `_tool_jira_issue_changelog_items.created_at`
    to `_tool_jira_issue_changelogs.created`