### PR TITLE
fix(linker): handle empty pr issue regexp

### DIFF
--- a/backend/plugins/linker/impl/impl.go
+++ b/backend/plugins/linker/impl/impl.go
@@ -20,6 +20,7 @@ package impl
 import (
 	"encoding/json"
 	"regexp"
+	"strings"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -84,13 +85,11 @@ func (p Linker) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]i
 	taskData := &tasks.LinkerTaskData{
 		Options: op,
 	}
-	if op.PrToIssueRegexp != "" {
-		re, err := regexp.Compile(op.PrToIssueRegexp)
-		if err != nil {
-			return taskData, errors.Convert(err)
-		}
-		taskData.PrToIssueRegexp = re
+	re, compileErr := regexp.Compile(op.PrToIssueRegexp)
+	if compileErr != nil {
+		return taskData, errors.Convert(compileErr)
 	}
+	taskData.PrToIssueRegexp = re
 	return taskData, nil
 }
 
@@ -108,6 +107,10 @@ func (p Linker) MakeMetricPluginPipelinePlanV200(projectName string, options jso
 	err := json.Unmarshal(options, op)
 	if err != nil {
 		return nil, errors.Default.WrapRaw(err)
+	}
+	op.PrToIssueRegexp = strings.TrimSpace(op.PrToIssueRegexp)
+	if op.PrToIssueRegexp == "" {
+		return nil, nil
 	}
 	plan := coreModels.PipelinePlan{
 		{

--- a/backend/plugins/linker/impl/impl_test.go
+++ b/backend/plugins/linker/impl/impl_test.go
@@ -1,0 +1,73 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package impl
+
+import (
+	"encoding/json"
+	"testing"
+
+	coreModels "github.com/apache/incubator-devlake/core/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeMetricPluginPipelinePlanV200SkipsEmptyRegexp(t *testing.T) {
+	var linker Linker
+
+	plan, err := linker.MakeMetricPluginPipelinePlanV200("project", json.RawMessage(`{}`))
+
+	assert.Nil(t, err)
+	assert.Nil(t, plan)
+}
+
+func TestMakeMetricPluginPipelinePlanV200BuildsPlan(t *testing.T) {
+	var linker Linker
+	options, err := json.Marshal(map[string]string{
+		"prToIssueRegexp": `#(\d+)`,
+	})
+	assert.Nil(t, err)
+
+	plan, err := linker.MakeMetricPluginPipelinePlanV200("project", options)
+
+	assert.Nil(t, err)
+	assert.Equal(t, coreModels.PipelinePlan{
+		{
+			{
+				Plugin: "linker",
+				Options: map[string]interface{}{
+					"projectName":     "project",
+					"prToIssueRegexp": `#(\d+)`,
+				},
+				Subtasks: []string{
+					"LinkPrToIssue",
+				},
+			},
+		},
+	}, plan)
+}
+
+func TestPrepareTaskDataRejectsEmptyRegexp(t *testing.T) {
+	var linker Linker
+
+	taskData, err := linker.PrepareTaskData(nil, map[string]interface{}{
+		"projectName":     "project",
+		"prToIssueRegexp": "",
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, taskData)
+}

--- a/backend/plugins/linker/tasks/link_pr_and_issue.go
+++ b/backend/plugins/linker/tasks/link_pr_and_issue.go
@@ -74,6 +74,9 @@ func clearHistoryData(db dal.Dal, data *LinkerTaskData) errors.Error {
 func LinkPrToIssue(taskCtx plugin.SubTaskContext) errors.Error {
 	db := taskCtx.GetDal()
 	data := taskCtx.GetData().(*LinkerTaskData)
+	if data.PrToIssueRegexp == nil {
+		return errors.BadInput.New("prToIssueRegexp is required")
+	}
 
 	if err := clearHistoryData(db, data); err != nil {
 		return err

--- a/backend/plugins/linker/tasks/task_data.go
+++ b/backend/plugins/linker/tasks/task_data.go
@@ -18,9 +18,11 @@ limitations under the License.
 package tasks
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"regexp"
 )
 
 type LinkerOptions struct {
@@ -38,6 +40,10 @@ func DecodeAndValidateTaskOptions(options map[string]interface{}) (*LinkerOption
 	err := helper.Decode(options, &op, nil)
 	if err != nil {
 		return nil, errors.Default.Wrap(err, "error decoding linker task options")
+	}
+	op.PrToIssueRegexp = strings.TrimSpace(op.PrToIssueRegexp)
+	if op.PrToIssueRegexp == "" {
+		return nil, errors.BadInput.New("prToIssueRegexp is required")
 	}
 	return &op, nil
 }

--- a/backend/plugins/linker/tasks/task_data_test.go
+++ b/backend/plugins/linker/tasks/task_data_test.go
@@ -1,0 +1,43 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeAndValidateTaskOptionsRequiresPrToIssueRegexp(t *testing.T) {
+	options, err := DecodeAndValidateTaskOptions(map[string]interface{}{
+		"projectName": "project",
+	})
+
+	assert.NotNil(t, err)
+	assert.Nil(t, options)
+}
+
+func TestDecodeAndValidateTaskOptionsTrimsPrToIssueRegexp(t *testing.T) {
+	options, err := DecodeAndValidateTaskOptions(map[string]interface{}{
+		"projectName":     "project",
+		"prToIssueRegexp": "  #(\\d+)  ",
+	})
+
+	assert.Nil(t, err)
+	assert.Equal(t, "#(\\d+)", options.PrToIssueRegexp)
+}


### PR DESCRIPTION
### Summary

This PR fixes a linker crash when `prToIssueRegexp` is empty.

Normal-mode projects can enable the linker metric without a configured regexp, which currently produces a linker task with an empty regexp. `PrepareTaskData` leaves `PrToIssueRegexp` nil in that case, and `LinkPrToIssue` later panics when it calls `FindAllString` on the nil regexp.

Changes:

- Skip linker metric pipeline generation when `prToIssueRegexp` is empty.
- Reject explicit linker task options with an empty `prToIssueRegexp`.
- Add a defensive nil-regexp guard in `LinkPrToIssue`.
- Add unit coverage for empty and trimmed regexp handling.

### Does this close any open issues?

No linked issue.

### Screenshots

Not applicable.

### Other Information

Validation:

- `go test ./plugins/linker/tasks ./plugins/linker/impl` from `backend/`
- `git diff --check`
