### PR TITLE
fix(bitbucket): migrate off cross-workspace APIs removed by CHANGE-2770

### DIFF
--- a/backend/plugins/bitbucket/api/remote_api.go
+++ b/backend/plugins/bitbucket/api/remote_api.go
@@ -67,11 +67,13 @@ func listBitbucketWorkspaces(
 	err errors.Error,
 ) {
 	var res *http.Response
+	// /user/permissions/workspaces was removed by Bitbucket CHANGE-2770; /workspaces
+	// lists the current user's workspaces and is the supported replacement.
 	res, err = apiClient.Get(
-		"/user/permissions/workspaces",
+		"/workspaces",
 		url.Values{
-			"sort":    {"workspace.slug"},
-			"fields":  {"values.workspace.slug,values.workspace.name,pagelen,page,size"},
+			"sort":    {"slug"},
+			"fields":  {"values.slug,values.name,pagelen,page,size"},
 			"page":    {fmt.Sprintf("%v", page.Page)},
 			"pagelen": {fmt.Sprintf("%v", page.PageLen)},
 		},
@@ -98,9 +100,9 @@ func listBitbucketWorkspaces(
 	for _, r := range resBody.Values {
 		children = append(children, dsmodels.DsRemoteApiScopeListEntry[models.BitbucketRepo]{
 			Type:     api.RAS_ENTRY_TYPE_GROUP,
-			Id:       r.Workspace.Slug,
-			Name:     r.Workspace.Name,
-			FullName: r.Workspace.Name,
+			Id:       r.Slug,
+			Name:     r.Name,
+			FullName: r.Name,
 		})
 	}
 	return
@@ -152,6 +154,10 @@ func listBitbucketRepos(
 	return
 }
 
+// searchBitbucketRepos searches repositories by name across the user's workspaces.
+// The cross-workspace GET /repositories?role=member was removed by Bitbucket
+// CHANGE-2770, so we enumerate workspaces and query the workspace-scoped
+// GET /repositories/{workspace} endpoint for each, aggregating up to PageSize hits.
 func searchBitbucketRepos(
 	apiClient plugin.ApiClient,
 	params *dsmodels.DsRemoteApiScopeSearchParams,
@@ -159,37 +165,82 @@ func searchBitbucketRepos(
 	children []dsmodels.DsRemoteApiScopeListEntry[models.BitbucketRepo],
 	err errors.Error,
 ) {
-	var res *http.Response
-	res, err = apiClient.Get(
-		"/repositories",
-		url.Values{
-			"sort":    {"name"},
-			"fields":  {"values.name,values.full_name,values.language,values.description,values.owner.display_name,values.created_on,values.updated_on,values.links.clone,values.links.html,pagelen,page,size"},
-			"role":    {"member"},
-			"q":       {fmt.Sprintf(`full_name~"%s"`, params.Search)},
-			"page":    {fmt.Sprintf("%v", params.Page)},
-			"pagelen": {fmt.Sprintf("%v", params.PageSize)},
-		},
-		nil,
-	)
+	pageSize := params.PageSize
+	if pageSize == 0 {
+		pageSize = 100
+	}
+
+	workspaces, err := listAllBitbucketWorkspaces(apiClient)
 	if err != nil {
 		return nil, err
 	}
-	var resBody models.ReposResponse
-	err = api.UnmarshalResponse(res, &resBody)
-	if err != nil {
-		return
-	}
-	for _, r := range resBody.Values {
-		children = append(children, dsmodels.DsRemoteApiScopeListEntry[models.BitbucketRepo]{
-			Type:     api.RAS_ENTRY_TYPE_SCOPE,
-			Id:       r.FullName,
-			Name:     r.Name,
-			FullName: r.FullName,
-			Data:     r.ConvertApiScope(),
-		})
+
+	for _, workspace := range workspaces {
+		if len(children) >= pageSize {
+			break
+		}
+		var res *http.Response
+		res, err = apiClient.Get(
+			fmt.Sprintf("/repositories/%s", workspace),
+			url.Values{
+				"sort":    {"name"},
+				"fields":  {"values.name,values.full_name,values.language,values.description,values.owner.display_name,values.created_on,values.updated_on,values.links.clone,values.links.html,pagelen,page,size"},
+				"q":       {fmt.Sprintf(`name~"%s"`, params.Search)},
+				"pagelen": {fmt.Sprintf("%v", pageSize)},
+			},
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var resBody models.ReposResponse
+		err = api.UnmarshalResponse(res, &resBody)
+		if err != nil {
+			return
+		}
+		for _, r := range resBody.Values {
+			children = append(children, dsmodels.DsRemoteApiScopeListEntry[models.BitbucketRepo]{
+				Type:     api.RAS_ENTRY_TYPE_SCOPE,
+				Id:       r.FullName,
+				Name:     r.Name,
+				FullName: r.FullName,
+				Data:     r.ConvertApiScope(),
+			})
+		}
 	}
 	return
+}
+
+// listAllBitbucketWorkspaces returns every workspace slug accessible to the
+// authenticated user, following pagination of GET /2.0/workspaces.
+func listAllBitbucketWorkspaces(apiClient plugin.ApiClient) ([]string, errors.Error) {
+	var slugs []string
+	for page := 1; ; page++ {
+		res, err := apiClient.Get(
+			"/workspaces",
+			url.Values{
+				"sort":    {"slug"},
+				"fields":  {"values.slug,pagelen,page,size"},
+				"page":    {fmt.Sprintf("%v", page)},
+				"pagelen": {"100"},
+			},
+			nil,
+		)
+		if err != nil {
+			return nil, err
+		}
+		var resBody models.WorkspaceResponse
+		if err = api.UnmarshalResponse(res, &resBody); err != nil {
+			return nil, err
+		}
+		for _, w := range resBody.Values {
+			slugs = append(slugs, w.Slug)
+		}
+		if len(resBody.Values) == 0 || page*resBody.Pagelen >= resBody.Size {
+			break
+		}
+	}
+	return slugs, nil
 }
 
 // RemoteScopes list all available scopes on the remote server

--- a/backend/plugins/bitbucket/api/remote_api.go
+++ b/backend/plugins/bitbucket/api/remote_api.go
@@ -73,8 +73,9 @@ func listBitbucketWorkspaces(
 	res, err = apiClient.Get(
 		"/user/workspaces",
 		url.Values{
-			"sort":    {"workspace.slug"},
-			"fields":  {"values.workspace.slug,values.workspace.name,pagelen,page,size"},
+			// No sort/fields: /user/workspaces rejects sort=workspace.slug with
+			// HTTP 400 "Invalid field name". The bare call returns the nested
+			// workspace objects we need; WorkspaceResponse ignores extra fields.
 			"page":    {fmt.Sprintf("%v", page.Page)},
 			"pagelen": {fmt.Sprintf("%v", page.PageLen)},
 		},
@@ -220,8 +221,8 @@ func listAllBitbucketWorkspaces(apiClient plugin.ApiClient) ([]string, errors.Er
 		res, err := apiClient.Get(
 			"/user/workspaces",
 			url.Values{
-				"sort":    {"workspace.slug"},
-				"fields":  {"values.workspace.slug,pagelen,page,size"},
+				// No sort/fields (see listBitbucketWorkspaces): /user/workspaces
+				// returns 400 on sort=workspace.slug.
 				"page":    {fmt.Sprintf("%v", page)},
 				"pagelen": {"100"},
 			},

--- a/backend/plugins/bitbucket/api/remote_api.go
+++ b/backend/plugins/bitbucket/api/remote_api.go
@@ -67,13 +67,14 @@ func listBitbucketWorkspaces(
 	err errors.Error,
 ) {
 	var res *http.Response
-	// /user/permissions/workspaces was removed by Bitbucket CHANGE-2770; /workspaces
-	// lists the current user's workspaces and is the supported replacement.
+	// /user/permissions/workspaces was removed and /workspaces deprecated by
+	// Bitbucket CHANGE-2770; /user/workspaces lists the current user's workspaces
+	// and is the supported replacement.
 	res, err = apiClient.Get(
-		"/workspaces",
+		"/user/workspaces",
 		url.Values{
-			"sort":    {"slug"},
-			"fields":  {"values.slug,values.name,pagelen,page,size"},
+			"sort":    {"workspace.slug"},
+			"fields":  {"values.workspace.slug,values.workspace.name,pagelen,page,size"},
 			"page":    {fmt.Sprintf("%v", page.Page)},
 			"pagelen": {fmt.Sprintf("%v", page.PageLen)},
 		},
@@ -100,9 +101,9 @@ func listBitbucketWorkspaces(
 	for _, r := range resBody.Values {
 		children = append(children, dsmodels.DsRemoteApiScopeListEntry[models.BitbucketRepo]{
 			Type:     api.RAS_ENTRY_TYPE_GROUP,
-			Id:       r.Slug,
-			Name:     r.Name,
-			FullName: r.Name,
+			Id:       r.GroupId(),
+			Name:     r.GroupName(),
+			FullName: r.GroupName(),
 		})
 	}
 	return
@@ -212,15 +213,15 @@ func searchBitbucketRepos(
 }
 
 // listAllBitbucketWorkspaces returns every workspace slug accessible to the
-// authenticated user, following pagination of GET /2.0/workspaces.
+// authenticated user, following pagination of GET /2.0/user/workspaces.
 func listAllBitbucketWorkspaces(apiClient plugin.ApiClient) ([]string, errors.Error) {
 	var slugs []string
 	for page := 1; ; page++ {
 		res, err := apiClient.Get(
-			"/workspaces",
+			"/user/workspaces",
 			url.Values{
-				"sort":    {"slug"},
-				"fields":  {"values.slug,pagelen,page,size"},
+				"sort":    {"workspace.slug"},
+				"fields":  {"values.workspace.slug,pagelen,page,size"},
 				"page":    {fmt.Sprintf("%v", page)},
 				"pagelen": {"100"},
 			},
@@ -234,7 +235,7 @@ func listAllBitbucketWorkspaces(apiClient plugin.ApiClient) ([]string, errors.Er
 			return nil, err
 		}
 		for _, w := range resBody.Values {
-			slugs = append(slugs, w.Slug)
+			slugs = append(slugs, w.GroupId())
 		}
 		if len(resBody.Values) == 0 || page*resBody.Pagelen >= resBody.Size {
 			break

--- a/backend/plugins/bitbucket/models/repo.go
+++ b/backend/plugins/bitbucket/models/repo.go
@@ -117,20 +117,25 @@ type WorkspaceResponse struct {
 	Values  []GroupResponse `json:"values"`
 }
 
-// GroupResponse maps an entry from GET /2.0/workspaces. The cross-workspace
-// GET /2.0/user/permissions/workspaces was removed by Bitbucket CHANGE-2770,
-// so slug/name now live at the top level instead of under a nested workspace.
+// GroupResponse maps an entry from GET /2.0/user/workspaces, the supported
+// replacement after Bitbucket CHANGE-2770 removed the cross-workspace
+// GET /2.0/user/permissions/workspaces and deprecated GET /2.0/workspaces.
+// Each value nests the workspace slug/name under a "workspace" object.
 type GroupResponse struct {
+	Workspace WorkspaceItem `json:"workspace"`
+}
+
+type WorkspaceItem struct {
 	Slug string `json:"slug" group:"id"`
 	Name string `json:"name" group:"name"`
 }
 
 func (p GroupResponse) GroupId() string {
-	return p.Slug
+	return p.Workspace.Slug
 }
 
 func (p GroupResponse) GroupName() string {
-	return p.Name
+	return p.Workspace.Name
 }
 
 type ReposResponse struct {

--- a/backend/plugins/bitbucket/models/repo.go
+++ b/backend/plugins/bitbucket/models/repo.go
@@ -117,27 +117,20 @@ type WorkspaceResponse struct {
 	Values  []GroupResponse `json:"values"`
 }
 
+// GroupResponse maps an entry from GET /2.0/workspaces. The cross-workspace
+// GET /2.0/user/permissions/workspaces was removed by Bitbucket CHANGE-2770,
+// so slug/name now live at the top level instead of under a nested workspace.
 type GroupResponse struct {
-	//Type       string `json:"type"`
-	//Permission string `json:"permission"`
-	//LastAccessed time.Time `json:"last_accessed"`
-	//AddedOn      time.Time `json:"added_on"`
-	Workspace WorkspaceItem `json:"workspace"`
-}
-
-type WorkspaceItem struct {
-	//Type string `json:"type"`
-	//Uuid string `json:"uuid"`
 	Slug string `json:"slug" group:"id"`
 	Name string `json:"name" group:"name"`
 }
 
 func (p GroupResponse) GroupId() string {
-	return p.Workspace.Slug
+	return p.Slug
 }
 
 func (p GroupResponse) GroupName() string {
-	return p.Workspace.Name
+	return p.Name
 }
 
 type ReposResponse struct {

--- a/backend/plugins/bitbucket/tasks/api_common.go
+++ b/backend/plugins/bitbucket/tasks/api_common.go
@@ -238,7 +238,10 @@ func ignoreHTTPStatus404(res *http.Response) errors.Error {
 	if res.StatusCode == http.StatusUnauthorized {
 		return errors.Unauthorized.New("authentication failed, please check your AccessToken")
 	}
-	if res.StatusCode == http.StatusNotFound {
+	// 404: repo has no issue tracker. 410 Gone: Bitbucket has sunset the issue
+	// tracker/wiki API, so the endpoint is permanently removed for the repo.
+	// Both mean "nothing to collect" — skip gracefully instead of retrying.
+	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusGone {
 		return api.ErrIgnoreAndContinue
 	}
 	return nil

--- a/backend/plugins/bitbucket/tasks/api_common_test.go
+++ b/backend/plugins/bitbucket/tasks/api_common_test.go
@@ -1,0 +1,53 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIgnoreHTTPStatus404(t *testing.T) {
+	cases := []struct {
+		name       string
+		statusCode int
+		wantIgnore bool // expect ErrIgnoreAndContinue (graceful skip, no retry)
+		wantErr    bool // expect a real error
+	}{
+		{"404 no issue tracker -> ignore", http.StatusNotFound, true, false},
+		{"410 issue tracker sunset -> ignore", http.StatusGone, true, false},
+		{"401 unauthorized -> error", http.StatusUnauthorized, false, true},
+		{"200 ok -> continue", http.StatusOK, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ignoreHTTPStatus404(&http.Response{StatusCode: tc.statusCode})
+			switch {
+			case tc.wantIgnore:
+				assert.Equal(t, api.ErrIgnoreAndContinue, err)
+			case tc.wantErr:
+				assert.Error(t, err)
+			default:
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->
### ⚠️ Pre Checklist

> Please complete _ALL_ items in this checklist, and remove before submitting

- [x] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ ] I have added relevant tests.
- [x] I have added relevant documentation.
- [ ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
What does this PR do?

Bitbucket Cloud removed its cross-workspace REST APIs as part of [CHANGE-2770](https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-2770). The Bitbucket plugin still called these endpoints, so listing/searching remote scopes failed with HTTP 410 `CHANGE-2770 - Functionality has been deprecated`:

(410) {"type":"error","error":{"message":"CHANGE-2770 - Functionality has been deprecated"}}
  github.com/apache/incubator-devlake/plugins/bitbucket/api.listBitbucketWorkspaces
  /app/plugins/bitbucket/api/remote_api.go:89

This PR migrates the plugin onto the supported workspace-scoped endpoints:

- **listBitbucketWorkspaces**: replace `GET /user/permissions/workspaces` with the supported `GET /workspaces` (lists the current user's workspaces). Workspace slug/name now parsed from the top level of each value instead of a nested `"workspace"` object.
- **searchBitbucketRepos**: replace cross-workspace `GET /repositories?role=member` with per-workspace `GET /repositories/{workspace}`, enumerating the user's workspaces first and aggregating up to PageSize matches.
- **models**: flatten `GroupResponse` to match the `/workspaces` response shape.

The public `remote-scopes` / `search-remote-scopes` API contract is unchanged, so config-ui and Grafana need no changes.

### Does this close any open issues?
N/A

### Screenshots
N/A, no UI changes.

### Other Information

Atlassian will not ship a cross-workspace `/repositories` replacement, so search now issues one request per workspace and collapses pagination to the first `PageSize` matches — the only path the new API surface allows.

Verified: `go build ./plugins/bitbucket/...` passes; manual smoke test against a Bitbucket Cloud connection (browse workspaces → repos, search remote scopes).