### PR TITLE
fix(ui): guard against empty plugin prop on connection creation page

### DIFF
--- a/config-ui/src/plugins/components/connection-form/index.tsx
+++ b/config-ui/src/plugins/components/connection-form/index.tsx
@@ -110,13 +110,17 @@ export const ConnectionForm = ({ plugin, connectionId, onSuccess }: Props) => {
   const {
     name,
     connection: { docLink, fields, initialValues },
-  } = getPluginConfig(plugin);
+  } = getPluginConfig(plugin) ?? {};
 
   const disabled = useMemo(() => {
     return Object.values(errors).some(Boolean);
   }, [errors]);
 
   const sanitizedCustomHeaders = useMemo(() => sanitizeCustomHeaders(values.customHeaders), [values.customHeaders]);
+
+  if (!plugin || !name) {
+    return null;
+  }
 
   const handleTest = async () => {
     const isUpdate = type === 'update' && !!connectionId;

--- a/config-ui/src/routes/connection/connections.tsx
+++ b/config-ui/src/routes/connection/connections.tsx
@@ -61,8 +61,9 @@ export const Connections = () => {
     setPlugin(plugin);
   };
 
-  const handleShowFormDialog = () => {
+  const handleShowFormDialog = (pluginName?: string) => {
     setType('form');
+    if (pluginName) setPlugin(pluginName);
   };
 
   const handleHideDialog = () => {
@@ -168,7 +169,7 @@ export const Connections = () => {
           <ConnectionList plugin={plugin} onCreate={handleShowFormDialog} />
         </Modal>
       )}
-      {type === 'form' && pluginConfig && (
+      {type === 'form' && plugin && pluginConfig && (
         <Modal
           open
           width={820}


### PR DESCRIPTION
## Summary

Fixes #8914

## What happened

When clicking "New Connection" from the connection list modal, the `plugin`
state was still an empty string `''` when `ConnectionForm` rendered. This
caused `getPluginConfig('')` to return a fallback config with an empty `name`,
leading to:

TypeError: Cannot read properties of undefined (reading 'name')

## Root Cause

In `connections.tsx`, `handleShowFormDialog` set `type = 'form'` but did
not ensure `plugin` was set. The form modal only checked `pluginConfig` but
not `plugin` itself, so `ConnectionForm` received an empty string as the
`plugin` prop.

## Changes

**`config-ui/src/routes/connection/connections.tsx`**
- Added `plugin &&` guard to the form modal condition to prevent
  `ConnectionForm` from rendering with an empty plugin

**`config-ui/src/plugins/components/connection-form/index.tsx`**
- Added `?? {}` fallback on `getPluginConfig` destructuring
- Added `if (!plugin || !name) return null` guard after all hooks
  as a defensive measure

## How to Test

1. Take the latest main branch
2. Navigate to the Connections page
3. Click on any data source plugin
4. Click "New Connection" in the list modal
5. The connection creation form should open correctly without errors