### PR TITLE
fix(webhook): set resolution_date and lead_time_minutes on incident c…

### DIFF
--- a/backend/plugins/webhook/api/issues.go
+++ b/backend/plugins/webhook/api/issues.go
@@ -265,6 +265,16 @@ func closeIssue(input *plugin.ApiResourceInput, err errors.Error, connection *mo
 	}
 	domainIssue.Status = ticket.DONE
 	domainIssue.OriginalStatus = ``
+	now := time.Now()
+	if domainIssue.ResolutionDate == nil {
+		domainIssue.ResolutionDate = &now
+	}
+	if domainIssue.LeadTimeMinutes == nil || *domainIssue.LeadTimeMinutes == 0 {
+		if domainIssue.CreatedDate != nil {
+			temp := uint(domainIssue.ResolutionDate.Sub(*domainIssue.CreatedDate).Minutes())
+			domainIssue.LeadTimeMinutes = &temp
+		}
+	}
 	// save
 	err = tx.Update(domainIssue)
 	if err != nil {
@@ -278,6 +288,15 @@ func closeIssue(input *plugin.ApiResourceInput, err errors.Error, connection *mo
 		if err == nil {
 			domainIncident.Status = ticket.DONE
 			domainIncident.OriginalStatus = ``
+			if domainIncident.ResolutionDate == nil {
+				domainIncident.ResolutionDate = &now
+			}
+			if domainIncident.LeadTimeMinutes == nil || *domainIncident.LeadTimeMinutes == 0 {
+				if domainIncident.CreatedDate != nil {
+					temp := uint(domainIncident.ResolutionDate.Sub(*domainIncident.CreatedDate).Minutes())
+					domainIncident.LeadTimeMinutes = &temp
+				}
+			}
 			// save
 			err = tx.Update(domainIncident)
 			if err != nil {


### PR DESCRIPTION
## Summary

Fixes #8906

## What happened

When closing an incident via the webhook API (`POST /plugins/webhook/:connectionId/issue/:issueKey/close`), the `resolution_date` field was never set on either the `issues` or `incidents` table. The DORA FDRT (Failed Deployment Recovery Time) metric is calculated from `incidents.resolution_date`, so incidents closed this way never appeared in the DORA dashboard.

## Root Cause

In `backend/plugins/webhook/api/issues.go`, the `closeIssue` function set `Status` to `DONE` and cleared `OriginalStatus` for both the issue and incident records, but never set `ResolutionDate` or recalculated `LeadTimeMinutes`.

## Changes

**`backend/plugins/webhook/api/issues.go`**

- Set `ResolutionDate` to `time.Now()` if not already set when closing an issue
- Recalculate `LeadTimeMinutes` from `CreatedDate` to `ResolutionDate` if not already set when closing an issue
- Same two changes applied to the incident record