### PR TITLE
[Feature][Lake] Add bulk scope config apply and cross-connection scope config sharing

### DIFF
--- a/config-ui/src/api/scope-config/index.ts
+++ b/config-ui/src/api/scope-config/index.ts
@@ -40,3 +40,6 @@ export const update = (plugin: string, connectionId: ID, id: ID, data: any) =>
 
 export const check = (plugin: string, id: ID): Promise<ICheck> =>
   request(`/plugins/${plugin}/scope-config/${id}/projects`);
+
+export const listAll = (plugin: string) =>
+  request(`/plugins/${plugin}/scope-configs`);

--- a/config-ui/src/plugins/components/scope-config-select/index.tsx
+++ b/config-ui/src/plugins/components/scope-config-select/index.tsx
@@ -37,13 +37,14 @@ export const ScopeConfigSelect = ({ plugin, connectionId, scopeConfigId, onCance
   const [version, setVersion] = useState(1);
   const [trId, setTrId] = useState<ID>();
   const [open, setOpen] = useState(false);
+  const [showAll, setShowAll] = useState(false);
+  
+  const { ready, data } = useRefreshData(() => showAll ? API.scopeConfig.listAll(plugin) : API.scopeConfig.list(plugin, connectionId),[version, showAll],);
 
-  const { ready, data } = useRefreshData(() => API.scopeConfig.list(plugin, connectionId), [version]);
-
-  const dataSource = useMemo(
-    () => (data ? (scopeConfigId ? [{ id: 'None', name: 'No Scope Config' }].concat(data) : data) : []),
-    [data, scopeConfigId],
-  );
+  const dataSource = useMemo(() => {
+  const filtered = showAll ? data : data;
+  return filtered ? (scopeConfigId ? [{ id: 'None', name: 'No Scope Config' }].concat(filtered) : filtered) : [];
+}, [data, scopeConfigId, showAll]);
 
   const defaultName = useMemo(() => `shared-config-<${(data ?? []).length}>`, [data]);
 
@@ -67,11 +68,17 @@ export const ScopeConfigSelect = ({ plugin, connectionId, scopeConfigId, onCance
 
   return (
     <Flex vertical gap="middle">
-      <Flex style={{ marginTop: 20 }}>
+      <Flex style={{ marginTop: 20 }} gap="small" align="center">
         <Button type="primary" icon={<PlusOutlined />} onClick={handleShowDialog}>
-          Add New Scope Config
+        Add New Scope Config
         </Button>
-      </Flex>
+        <Button
+        type={showAll ? 'primary' : 'default'}
+        onClick={() => setShowAll((v) => !v)}
+          >
+            {showAll ? 'Showing: All Connections' : 'This Connection Only'}
+            </Button>
+            </Flex>
       <Table
         rowKey="id"
         size="small"

--- a/config-ui/src/plugins/components/scope-config-select/index.tsx
+++ b/config-ui/src/plugins/components/scope-config-select/index.tsx
@@ -39,13 +39,16 @@ export const ScopeConfigSelect = ({ plugin, connectionId, scopeConfigId, onCance
   const [open, setOpen] = useState(false);
   const [showAll, setShowAll] = useState(false);
   
-  const { ready, data } = useRefreshData(() => showAll ? API.scopeConfig.listAll(plugin) : API.scopeConfig.list(plugin, connectionId),[version, showAll],);
+  const { ready, data } = useRefreshData(
+    () => showAll ? API.scopeConfig.listAll(plugin) : API.scopeConfig.list(plugin, connectionId),
+    [version, showAll],
+  );
 
-  const dataSource = useMemo(() => {
-  const filtered = showAll ? data : data;
-  return filtered ? (scopeConfigId ? [{ id: 'None', name: 'No Scope Config' }].concat(filtered) : filtered) : [];
-}, [data, scopeConfigId, showAll]);
-
+  const dataSource = useMemo(
+    () => (data ? (scopeConfigId ? [{ id: 'None', name: 'No Scope Config' }].concat(data) : data) : []),
+    [data, scopeConfigId],
+  );
+  
   const defaultName = useMemo(() => `shared-config-<${(data ?? []).length}>`, [data]);
 
   useEffect(() => {
@@ -70,15 +73,15 @@ export const ScopeConfigSelect = ({ plugin, connectionId, scopeConfigId, onCance
     <Flex vertical gap="middle">
       <Flex style={{ marginTop: 20 }} gap="small" align="center">
         <Button type="primary" icon={<PlusOutlined />} onClick={handleShowDialog}>
-        Add New Scope Config
+          Add New Scope Config
         </Button>
         <Button
-        type={showAll ? 'primary' : 'default'}
-        onClick={() => setShowAll((v) => !v)}
-          >
-            {showAll ? 'Showing: All Connections' : 'This Connection Only'}
-            </Button>
-            </Flex>
+          type={showAll ? 'primary' : 'default'}
+          onClick={() => setShowAll((v) => !v)}
+        >
+          {showAll ? 'Showing: All Connections' : 'This Connection Only'}
+        </Button>
+      </Flex>
       <Table
         rowKey="id"
         size="small"

--- a/config-ui/src/routes/blueprint/connection-detail/table.tsx
+++ b/config-ui/src/routes/blueprint/connection-detail/table.tsx
@@ -17,11 +17,13 @@
  */
 
 import { useState } from 'react';
-import { Table } from 'antd';
+import { AppstoreAddOutlined } from '@ant-design/icons';
+import { Table, Button, Flex, Modal, Tag, message } from 'antd';
 
 import API from '@/api';
 import { useRefreshData } from '@/hooks';
-import { getPluginScopeId, getPluginScopeName, ScopeConfig } from '@/plugins';
+import { getPluginConfig, getPluginScopeId, getPluginScopeName, ScopeConfig, ScopeConfigSelect } from '@/plugins';
+import { operator } from '@/utils';
 
 interface Props {
   plugin: string;
@@ -31,6 +33,11 @@ interface Props {
 
 export const BlueprintConnectionDetailTable = ({ plugin, connectionId, scopeIds }: Props) => {
   const [version, setVersion] = useState(1);
+  const [selectedScopeIds, setSelectedScopeIds] = useState<ID[]>([]);
+  const [bulkModalOpen, setBulkModalOpen] = useState(false);
+  const [bulkOperating, setBulkOperating] = useState(false);
+
+  const pluginConfig = getPluginConfig(plugin);
 
   const { ready, data } = useRefreshData(async () => {
     const scopes = await Promise.all(scopeIds.map((scopeId) => API.scope.get(plugin, connectionId, scopeId)));
@@ -42,34 +49,105 @@ export const BlueprintConnectionDetailTable = ({ plugin, connectionId, scopeIds 
     }));
   }, [version]);
 
-  return (
-    <Table
-      loading={!ready}
-      rowKey="id"
-      size="middle"
-      columns={[
-        {
-          title: 'Data Scope',
-          dataIndex: 'name',
-          key: 'name',
-        },
-        {
-          title: 'Scope Config',
-          key: 'scopeConfig',
-          render: (_, { id, name, scopeConfigId, scopeConfigName }) => (
-            <ScopeConfig
-              plugin={plugin}
-              connectionId={connectionId}
-              scopeId={id}
-              scopeName={name}
-              scopeConfigId={scopeConfigId}
-              scopeConfigName={scopeConfigName}
-              onSuccess={() => setVersion(version + 1)}
-            />
+  const handleRefresh = () => {
+    setSelectedScopeIds([]);
+    setVersion((v) => v + 1);
+  };
+  
+  // Apply one scope config to all selected data scopes in bulk
+  const handleBulkApplyScopeConfig = async (scopeConfigId: ID) => {
+    setBulkOperating(true);
+    const configId = scopeConfigId === 'None' ? null : +scopeConfigId;
+    const [success] = await operator(
+      () =>
+        Promise.all(
+          selectedScopeIds.map((scopeId) =>
+            API.scope.update(plugin, connectionId, scopeId, { scopeConfigId: configId }),
           ),
-        },
-      ]}
-      dataSource={data ?? []}
-    />
+        ),
+      { setOperating: setBulkOperating },
+    );
+    if (success) {
+      message.success(`Scope config applied to ${selectedScopeIds.length} data scope(s).`);
+      setBulkModalOpen(false);
+      handleRefresh();
+    }
+  };
+
+  const hasScopeConfig = !!pluginConfig.scopeConfig;
+
+  return (
+    <>
+      {/* Bulk toolbar — shown only when rows are selected and plugin supports scope configs */}
+      {hasScopeConfig && selectedScopeIds.length > 0 && (
+        <Flex align="center" gap="small" style={{ marginBottom: 12 }}>
+          <Tag color="blue">{selectedScopeIds.length} selected</Tag>
+          <Button
+            type="primary"
+            icon={<AppstoreAddOutlined />}
+            loading={bulkOperating}
+            onClick={() => setBulkModalOpen(true)}
+          >
+            Apply Scope Config to Selected
+          </Button>
+          <Button onClick={() => setSelectedScopeIds([])}>Clear Selection</Button>
+        </Flex>
+      )}
+
+      <Table
+        loading={!ready}
+        rowKey="id"
+        size="middle"
+        rowSelection={
+          hasScopeConfig
+            ? {
+                type: 'checkbox',
+                selectedRowKeys: selectedScopeIds,
+                onChange: (keys) => setSelectedScopeIds(keys as ID[]),
+              }
+            : undefined
+        }
+        columns={[
+          {
+            title: 'Data Scope',
+            dataIndex: 'name',
+            key: 'name',
+          },
+          {
+            title: 'Scope Config',
+            key: 'scopeConfig',
+            render: (_, { id, name, scopeConfigId, scopeConfigName }) => (
+              <ScopeConfig
+                plugin={plugin}
+                connectionId={connectionId}
+                scopeId={id}
+                scopeName={name}
+                scopeConfigId={scopeConfigId}
+                scopeConfigName={scopeConfigName}
+                onSuccess={handleRefresh}
+              />
+            ),
+          },
+        ]}
+        dataSource={data ?? []}
+      />
+      {/* Bulk scope config picker modal */}
+      <Modal
+        destroyOnClose
+        open={bulkModalOpen}
+        width={960}
+        centered
+        footer={null}
+        title={`Apply Scope Config to ${selectedScopeIds.length} Selected Data Scope(s)`}
+        onCancel={() => setBulkModalOpen(false)}
+      >
+        <ScopeConfigSelect
+          plugin={plugin}
+          connectionId={connectionId}
+          onCancel={() => setBulkModalOpen(false)}
+          onSubmit={handleBulkApplyScopeConfig}
+        />
+      </Modal>
+    </>
   );
 };


### PR DESCRIPTION
## Summary
Closes #8896

This PR implements two related feature requests to improve scope config 
management for users maintaining multiple projects/connections in a single 
DevLake instance.

## Changes

### Feature 1 — Multi-select data scopes with bulk scope config apply
**File:** `config-ui/src/routes/blueprint/connection-detail/table.tsx`

- Added checkbox row selection to the data scope table
- Added a bulk action toolbar that appears when rows are selected, showing:
  - Selected count badge
  - "Apply Scope Config to Selected" button
  - "Clear Selection" button
- Clicking the button opens a scope config picker modal
- The chosen scope config is applied to all selected data scopes in parallel
  via existing `PATCH /plugins/{plugin}/connections/{connectionId}/scopes/{scopeId}`

### Feature 2 — Share scope configs across connections
**File:** `config-ui/src/plugins/components/scope-config-select/index.tsx`  
**File:** `config-ui/src/api/scope-config/index.ts`

- Added `listAll` API function to fetch scope configs across all connections
  for a plugin
- Added "This Connection Only / Showing: All Connections" toggle button in
  the scope config picker
- Users can now reuse an existing scope config from any connection instead
  of recreating it each time

## How to Test
1. Go to a Project → Blueprint → Connection detail page
2. Select multiple data scopes using the checkboxes
3. Click "Apply Scope Config to Selected" and pick a config → all selected
   scopes should be updated
4. Click "Associate Scope Config" on any single scope → toggle 
   "This Connection Only" to "Showing: All Connections" → configs from 
   all connections should appear in the list

## No Backend Changes Required
The existing `ListScopeConfigs` backend handler already returns all scope 
configs without filtering by `connection_id`. The frontend now exposes 
this via the toggle.