### PR TITLE
fix(server): remove auth from proceed-db-migration endpoint

### DIFF
--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -127,7 +127,7 @@ func SetupApiServer(router *gin.Engine) {
 	router.UseRawPath = true
 	// router.UnescapePathValues = false
 
-	// Endpoint to proceed database migration — must be unauthenticated because
+	// Endpoint to proceed database migration — listed in auth.publicPaths because
 	// auth tables may not exist yet when migration is pending.
 	router.GET("/proceed-db-migration", func(ctx *gin.Context) {
 		// Execute database migration

--- a/backend/server/api/api.go
+++ b/backend/server/api/api.go
@@ -127,8 +127,9 @@ func SetupApiServer(router *gin.Engine) {
 	router.UseRawPath = true
 	// router.UnescapePathValues = false
 
-	// Endpoint to proceed database migration (now requires authentication)
-	router.GET("/proceed-db-migration", auth.RequireAuth(), func(ctx *gin.Context) {
+	// Endpoint to proceed database migration — must be unauthenticated because
+	// auth tables may not exist yet when migration is pending.
+	router.GET("/proceed-db-migration", func(ctx *gin.Context) {
 		// Execute database migration
 		errors.Must(services.ExecuteMigration())
 		// Return success response

--- a/backend/server/api/auth/middleware.go
+++ b/backend/server/api/auth/middleware.go
@@ -34,15 +34,16 @@ import (
 // and clear its session even when the cookie has lapsed; both handlers
 // short-circuit gracefully when no user is set.
 var publicPaths = map[string]struct{}{
-	"/ping":      {},
-	"/ready":     {},
-	"/health":    {},
-	"/version":   {},
-	PathMethods:  {},
-	PathLogin:    {},
-	PathCallback: {},
-	PathLogout:   {},
-	PathUserInfo: {},
+	"/ping":                 {},
+	"/ready":                {},
+	"/health":               {},
+	"/version":              {},
+	"/proceed-db-migration": {},
+	PathMethods:             {},
+	PathLogin:               {},
+	PathCallback:            {},
+	PathLogout:              {},
+	PathUserInfo:            {},
 }
 
 func OIDCAuthentication() gin.HandlerFunc { return defaultService.OIDCAuthentication() }


### PR DESCRIPTION
### Summary

Removes `auth.RequireAuth()` middleware from the `/proceed-db-migration` endpoint. When `AUTH_ENABLED=true`, auth tables (e.g. `auth_sessions`) may not exist yet if the pending migration is the one that creates them — resulting in a bootstrap deadlock where the migration endpoint requires auth but auth requires the migration to have run.

This restores the pre-auth-hardening behavior for this endpoint, which is idempotent and only executes pending migration scripts.

### Does this close any open issues?

N/A

### Other Information

- The endpoint remains idempotent (only runs pending migrations) and is typically accessed via the config-ui proxy, not exposed publicly.
- Config-ui's "Proceed" button already calls this endpoint without authentication handling.
- This unblocks any PR that adds new migration scripts (e.g. Jira plugin schema changes) from failing on auth-enabled deployments.