### PR TITLE
fix(azuredevops): add missing migrations for Job model fields from #8671

### DIFF
--- a/backend/python/plugins/azuredevops/azuredevops/migrations.py
+++ b/backend/python/plugins/azuredevops/azuredevops/migrations.py
@@ -247,3 +247,15 @@ def add_updated_url_column_length_in_raw_azuredevops_builds(b: MigrationScriptBu
     END $$;
     """, Dialect.POSTGRESQL)
 
+
+@migration(20251231120000, name="add job fields added in environment_pattern feature")
+def add_job_fields_for_environment_pattern(b: MigrationScriptBuilder):
+    table = '_tool_azuredevops_jobs'
+    b.add_column(table, 'identifier', 'varchar(255)')
+    b.add_column(table, 'type', 'varchar(255)')
+    b.add_column(table, 'parent_id', 'varchar(255)')
+
+
+@migration(20251231120001, name="add environment_pattern to gitrepositoryconfigs")
+def add_environment_pattern_to_gitrepositoryconfigs(b: MigrationScriptBuilder):
+    b.add_column('_tool_azuredevops_gitrepositoryconfigs', 'environment_pattern', 'text')


### PR DESCRIPTION
## Summary

Fixes a schema mismatch introduced by #8671 where the Azure DevOps Python plugin's `Job` model gained `identifier`, `type`, and `parent_id` fields, and `GitRepositoryConfig` gained `environment_pattern`, but no database migrations were added.

This caused the **Convert Jobs** subtask to fail on MySQL with:

```
Unknown column '_tool_azuredevops_jobs.identifier' in 'field list'
```

Affected releases: `v1.0.3-beta9` through `v1.0.3-beta12`.

## Changes

- Add migration `20251231120000` to add `identifier`, `type`, and `parent_id` columns to `_tool_azuredevops_jobs`
- Add migration `20251231120001` to add `environment_pattern` column to `_tool_azuredevops_gitrepositoryconfigs`

Uses `add_column` operations which skip columns that already exist (safe for users who applied manual SQL workarounds).

## Test plan

- [x] Start DevLake with an existing DB missing these columns and confirm migrations run on startup
- [x] Run Azure DevOps pipeline collect including **Convert Jobs** — should complete without SQL errors
- [x] Verify fresh install also gets columns via migrations (init schema + new migrations)
- [x] Confirm scope config with `environment_pattern` can be saved after migration


Made with [Cursor](https://cursor.com)