### PR TITLE
fix(migrations): remove hard-coded bigint types for postgres

### DIFF
--- a/backend/plugins/q_dev/models/migrationscripts/20251123_add_scope_config_id_to_s3_slice.go
+++ b/backend/plugins/q_dev/models/migrationscripts/20251123_add_scope_config_id_to_s3_slice.go
@@ -26,7 +26,7 @@ import (
 type addScopeConfigIdToS3Slice struct{}
 
 type QDevS3Slice20251123 struct {
-	ScopeConfigId uint64 `gorm:"type:BIGINT DEFAULT 0"`
+	ScopeConfigId uint64 `gorm:"default:0"`
 }
 
 func (QDevS3Slice20251123) TableName() string {

--- a/backend/plugins/testmo/models/migrationscripts/20250629_add_scope_config_id_to_projects.go
+++ b/backend/plugins/testmo/models/migrationscripts/20250629_add_scope_config_id_to_projects.go
@@ -27,7 +27,7 @@ import (
 type addScopeConfigIdToProjects struct{}
 
 type TestmoProject20250629 struct {
-	ScopeConfigId uint64 `gorm:"type:BIGINT NOT NULL DEFAULT 0"`
+	ScopeConfigId uint64 `gorm:"not null;default:0"`
 }
 
 func (TestmoProject20250629) TableName() string {


### PR DESCRIPTION
Fixes #8867.

Updated the Testmo and Q Dev scope_config_id migrations to avoid hard-coded BIGINT SQL type declarations in GORM tags. The migrations continue using migrationhelper.AutoMigrateTables, but now allow GORM to generate dialect-compatible column definitions for both MySQL and PostgreSQL.

Validated with git diff --check and targeted searches for the previous BIGINT UNSIGNED/raw ALTER TABLE patterns.