### PR TITLE
fix(gh-copilot): preserve hyphenated enterprise slugs

### DIFF
--- a/backend/plugins/gh-copilot/service/api_path.go
+++ b/backend/plugins/gh-copilot/service/api_path.go
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func copilotAPIPath(namespace, slug, resource string) string {
+	return fmt.Sprintf("%s/%s/%s", namespace, url.PathEscape(strings.TrimSpace(slug)), strings.TrimPrefix(resource, "/"))
+}

--- a/backend/plugins/gh-copilot/service/api_path_test.go
+++ b/backend/plugins/gh-copilot/service/api_path_test.go
@@ -1,0 +1,30 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCopilotAPIPathPreservesHyphenatedEnterpriseSlug(t *testing.T) {
+	path := copilotAPIPath("enterprises", "my-enterprise", "copilot/billing/seats")
+
+	assert.Equal(t, "enterprises/my-enterprise/copilot/billing/seats", path)
+}

--- a/backend/plugins/gh-copilot/service/connection_test_helper.go
+++ b/backend/plugins/gh-copilot/service/connection_test_helper.go
@@ -85,7 +85,7 @@ func TestConnection(ctx stdctx.Context, br corectx.BasicRes, connection *models.
 	// Note: /enterprises/{ent}/copilot/billing does not exist — use /billing/seats instead.
 	if hasEnterprise {
 		entSlug := strings.TrimSpace(connection.Enterprise)
-		seatsPath := fmt.Sprintf("enterprises/%s/copilot/billing/seats", entSlug)
+		seatsPath := copilotAPIPath("enterprises", entSlug, "copilot/billing/seats")
 		entSummary, entErr := fetchSeatsSummary(apiClient, seatsPath)
 		if entErr != nil {
 			return nil, entErr
@@ -97,7 +97,7 @@ func TestConnection(ctx stdctx.Context, br corectx.BasicRes, connection *models.
 
 	// Test org endpoint when configured.
 	if hasOrg {
-		orgSummary, orgErr := fetchBillingSummary(apiClient, fmt.Sprintf("orgs/%s/copilot/billing", connection.Organization))
+		orgSummary, orgErr := fetchBillingSummary(apiClient, copilotAPIPath("orgs", connection.Organization, "copilot/billing"))
 		if orgErr != nil {
 			return nil, orgErr
 		}

--- a/backend/plugins/gh-copilot/tasks/api_path.go
+++ b/backend/plugins/gh-copilot/tasks/api_path.go
@@ -1,0 +1,28 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+func copilotAPIPath(namespace, slug, resource string) string {
+	return fmt.Sprintf("%s/%s/%s", namespace, url.PathEscape(strings.TrimSpace(slug)), strings.TrimPrefix(resource, "/"))
+}

--- a/backend/plugins/gh-copilot/tasks/api_path_test.go
+++ b/backend/plugins/gh-copilot/tasks/api_path_test.go
@@ -1,0 +1,30 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCopilotAPIPathPreservesHyphenatedEnterpriseSlug(t *testing.T) {
+	path := copilotAPIPath("enterprises", "my-enterprise", "copilot/billing/seats")
+
+	require.Equal(t, "enterprises/my-enterprise/copilot/billing/seats", path)
+}

--- a/backend/plugins/gh-copilot/tasks/enterprise_metrics_collector.go
+++ b/backend/plugins/gh-copilot/tasks/enterprise_metrics_collector.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -81,10 +80,9 @@ func CollectEnterpriseMetrics(taskCtx plugin.SubTaskContext) errors.Error {
 	dayIter := newDayIterator(start, until)
 
 	err = collector.InitCollector(helper.ApiCollectorArgs{
-		ApiClient: apiClient,
-		Input:     dayIter,
-		UrlTemplate: fmt.Sprintf("enterprises/%s/copilot/metrics/reports/enterprise-1-day",
-			connection.Enterprise),
+		ApiClient:   apiClient,
+		Input:       dayIter,
+		UrlTemplate: copilotAPIPath("enterprises", connection.Enterprise, "copilot/metrics/reports/enterprise-1-day"),
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			input := reqData.Input.(*dayInput)
 			q := url.Values{}

--- a/backend/plugins/gh-copilot/tasks/org_metrics_collector.go
+++ b/backend/plugins/gh-copilot/tasks/org_metrics_collector.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -76,10 +75,9 @@ func CollectOrgMetrics(taskCtx plugin.SubTaskContext) errors.Error {
 	dayIter := newDayIterator(start, until)
 
 	err = collector.InitCollector(helper.ApiCollectorArgs{
-		ApiClient: apiClient,
-		Input:     dayIter,
-		UrlTemplate: fmt.Sprintf("orgs/%s/copilot/metrics/reports/organization-1-day",
-			connection.Organization),
+		ApiClient:   apiClient,
+		Input:       dayIter,
+		UrlTemplate: copilotAPIPath("orgs", connection.Organization, "copilot/metrics/reports/organization-1-day"),
 		Query: func(reqData *helper.RequestData) (url.Values, errors.Error) {
 			input := reqData.Input.(*dayInput)
 			q := url.Values{}

--- a/backend/plugins/gh-copilot/tasks/seat_collector.go
+++ b/backend/plugins/gh-copilot/tasks/seat_collector.go
@@ -90,9 +90,9 @@ func CollectCopilotSeatAssignments(taskCtx plugin.SubTaskContext) errors.Error {
 	var urlTemplate string
 	switch {
 	case connection.HasEnterprise():
-		urlTemplate = fmt.Sprintf("enterprises/%s/copilot/billing/seats", connection.Enterprise)
+		urlTemplate = copilotAPIPath("enterprises", connection.Enterprise, "copilot/billing/seats")
 	case connection.Organization != "":
-		urlTemplate = fmt.Sprintf("orgs/%s/copilot/billing/seats", connection.Organization)
+		urlTemplate = copilotAPIPath("orgs", connection.Organization, "copilot/billing/seats")
 	default:
 		taskCtx.GetLogger().Warn(nil, "skipping seat collection: no enterprise or organization configured on connection %d", connection.ID)
 		return nil

--- a/backend/plugins/gh-copilot/tasks/user_metrics_collector.go
+++ b/backend/plugins/gh-copilot/tasks/user_metrics_collector.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -95,9 +94,9 @@ func CollectUserMetrics(taskCtx plugin.SubTaskContext) errors.Error {
 	var urlTemplate string
 
 	if connection.HasEnterprise() {
-		urlTemplate = fmt.Sprintf("enterprises/%s/copilot/metrics/reports/users-1-day", connection.Enterprise)
+		urlTemplate = copilotAPIPath("enterprises", connection.Enterprise, "copilot/metrics/reports/users-1-day")
 	} else if connection.Organization != "" {
-		urlTemplate = fmt.Sprintf("orgs/%s/copilot/metrics/reports/users-1-day", connection.Organization)
+		urlTemplate = copilotAPIPath("orgs", connection.Organization, "copilot/metrics/reports/users-1-day")
 	} else {
 		return nil
 	}

--- a/backend/plugins/gh-copilot/tasks/user_teams_collector.go
+++ b/backend/plugins/gh-copilot/tasks/user_teams_collector.go
@@ -19,7 +19,6 @@ package tasks
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -45,9 +44,9 @@ func CollectUserTeams(taskCtx plugin.SubTaskContext) errors.Error {
 	var urlTemplate string
 
 	if connection.HasEnterprise() {
-		urlTemplate = fmt.Sprintf("enterprises/%s/copilot/metrics/reports/user-teams-1-day", connection.Enterprise)
+		urlTemplate = copilotAPIPath("enterprises", connection.Enterprise, "copilot/metrics/reports/user-teams-1-day")
 	} else if connection.Organization != "" {
-		urlTemplate = fmt.Sprintf("orgs/%s/copilot/metrics/reports/user-teams-1-day", connection.Organization)
+		urlTemplate = copilotAPIPath("orgs", connection.Organization, "copilot/metrics/reports/user-teams-1-day")
 	} else {
 		return nil
 	}

--- a/config-ui/src/plugins/components/connection-form/index.tsx
+++ b/config-ui/src/plugins/components/connection-form/index.tsx
@@ -59,6 +59,7 @@ const buildUpdateTestPayload = (connection: any, values: any, customHeaders: ICu
   dbUrl: isEqual(connection?.dbUrl, values.dbUrl) ? undefined : values.dbUrl,
   companyId: isEqual(connection?.companyId, values.companyId) ? undefined : values.companyId,
   organization: isEqual(connection?.organization, values.organization) ? undefined : values.organization,
+  enterprise: isEqual(connection?.enterprise, values.enterprise) ? undefined : values.enterprise,
   customHeaders: isEqual(connection?.customHeaders, customHeaders) ? undefined : customHeaders,
 });
 
@@ -85,6 +86,7 @@ const buildCreateTestPayload = (initialValues: any, values: any, customHeaders: 
     'dbUrl',
     'companyId',
     'organization',
+    'enterprise',
     'customHeaders',
   ]);
 

--- a/docker-compose-dev-postgresql.yml
+++ b/docker-compose-dev-postgresql.yml
@@ -16,7 +16,7 @@
 name: devlake-postgresql
 
 services:
-  postgres:
+  postgres: 
     image: postgres:17.2
     volumes:
       - postgres-storage:/var/lib/postgresql


### PR DESCRIPTION
Fixes #8860.

This preserves GitHub Copilot enterprise slugs when building API paths, including slugs with hyphens. The connection test payload now includes `enterprise`, and all GH Copilot enterprise/org collector URLs use a shared path builder that trims and path-escapes the slug without changing `-` to `_`.