### PR TITLE
fix(security): update nginx-unprivileged to 1.30.3

### DIFF
--- a/config-ui/Dockerfile
+++ b/config-ui/Dockerfile
@@ -31,7 +31,7 @@ COPY . .
 RUN yarn install
 RUN yarn build
 
-FROM nginxinc/nginx-unprivileged:1.29
+FROM nginxinc/nginx-unprivileged:1.30.3
 USER 0
 #ADD https://github.com/ufoscout/docker-compose-wait/releases/download/2.9.0/wait /wait
 #RUN chmod +x /wait


### PR DESCRIPTION
Fixes #8937 
## Summary
Bumps nginx base image in config-ui/Dockerfile from 1.29 to 1.30.3 to fix CVE-2026-49975 (HTTP/2 Bomb DoS vulnerability).

## Changes
- `config-ui/Dockerfile`: updated nginx-unprivileged from 1.29 → 1.30.3

## References
- CVE: https://www.cvedetails.com/cve/CVE-2026-49975