### PR TITLE
feat(jira): add JIRA_SKIP_UNPARSEABLE_ISSUES to skip unparseable issu…

### DIFF
--- a/backend/plugins/jira/tasks/issue_collector.go
+++ b/backend/plugins/jira/tasks/issue_collector.go
@@ -135,6 +135,12 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 			}
 			err = json.Unmarshal(blob, &data)
 			if err != nil {
+				// By default surface the error so it's visible. Set JIRA_SKIP_UNPARSEABLE_ISSUES=true
+				// to skip unparseable pages instead of failing the collection.
+				if taskCtx.GetConfigReader().GetBool("JIRA_SKIP_UNPARSEABLE_ISSUES") {
+					logger.Warn(err, "skipping unparseable Jira issue page")
+					return nil, nil
+				}
 				return nil, errors.Convert(err)
 			}
 			return data.Issues, nil


### PR DESCRIPTION
### Summary

Adds an opt-in config `JIRA_SKIP_UNPARSEABLE_ISSUES` to the Jira `collectIssues` subtask.
When an issue page returns a 2xx status but a body that can't be parsed as JSON (e.g. a
truncated/partial response), the subtask currently fails and aborts the whole Jira collection.
With this flag set to `true`, the unparseable page is logged and skipped so the rest of the
collection finishes. Default (`false`) keeps current behaviour.

Closes #8949