### PR TITLE
fix(config-ui): Recover "Create a New Connection" action

### DIFF
--- a/config-ui/src/plugins/components/connection-list/index.tsx
+++ b/config-ui/src/plugins/components/connection-list/index.tsx
@@ -113,7 +113,7 @@ export const ConnectionList = ({ plugin, onCreate }: Props) => {
         dataSource={connections}
         pagination={false}
       />
-      <Button style={{ marginTop: 16 }} type="primary" icon={<PlusOutlined />} onClick={onCreate}>
+      <Button style={{ marginTop: 16 }} type="primary" icon={<PlusOutlined />} onClick={() => onCreate()}>
         Create a New Connection
       </Button>
       <Modal


### PR DESCRIPTION
### Summary
This PR fixes "Create a New Connection" action. The issue is that clicking the "Create a New Connection" button causes `Error: Objects are not valid as a React child` error. It happens because react event object is passed as a pluginName argument to handleShowFormDialog function on button click. So the fix calls onCreate function with no arguments.

### Does this close any open issues?
No

### Screenshots
<img width="1205" height="791" alt="image" src="https://github.com/user-attachments/assets/59c910b4-b359-4c8c-8041-771d63990512" />


