### PR TITLE
fix(circleci): skip HTTP 500 errors and apply TimeAfter window on full sync

### DIFF
--- a/backend/plugins/circleci/tasks/job_collector.go
+++ b/backend/plugins/circleci/tasks/job_collector.go
@@ -73,8 +73,10 @@ func CollectJobs(taskCtx plugin.SubTaskContext) errors.Error {
 					dal.Where("connection_id = ? and project_slug = ?", data.Options.ConnectionId, data.Options.ProjectSlug),
 				}
 
-				if isIncremental {
-					clauses = append(clauses, dal.Where("created_date > ?", createdAfter))
+				// Incremental: workflows newer than last successful collectJobs.
+				// Full sync: workflows within SyncPolicy.TimeAfter window.
+				if createdAfter != nil {
+					clauses = append(clauses, dal.Where("created_date >= ?", createdAfter))
 				}
 
 				db := taskCtx.GetDal()
@@ -88,7 +90,7 @@ func CollectJobs(taskCtx plugin.SubTaskContext) errors.Error {
 				UrlTemplate:    "/v2/workflow/{{ .Input.Id }}/job",
 				Query:          BuildQueryParamsWithPageToken,
 				ResponseParser: ParseCircleciPageTokenResp,
-				AfterResponse:  ignoreDeletedBuilds, // Ignore the 404 response if a workflow has been deleted
+				AfterResponse:  ignoreDeletedOrBrokenBuilds,
 			},
 			GetCreated: func(item json.RawMessage) (time.Time, errors.Error) {
 				var job struct { // Individual job response lacks created_at field, so have to use started_at
@@ -105,7 +107,7 @@ func CollectJobs(taskCtx plugin.SubTaskContext) errors.Error {
 				UrlTemplate:    "/v2/workflow/{{ .Input.Id }}/job", // The individual job endpoint has different fields so need to recollect all jobs for a workflow
 				Query:          BuildQueryParamsWithPageToken,
 				ResponseParser: ParseCircleciPageTokenResp,
-				AfterResponse:  ignoreDeletedBuilds,
+				AfterResponse:  ignoreDeletedOrBrokenBuilds,
 			},
 			BuildInputIterator: func() (api.Iterator, errors.Error) {
 				db := taskCtx.GetDal()

--- a/backend/plugins/circleci/tasks/shared.go
+++ b/backend/plugins/circleci/tasks/shared.go
@@ -123,10 +123,15 @@ func ParseCircleciPageTokenResp(res *http.Response) ([]json.RawMessage, errors.E
 	return data.Items, err
 }
 
-func ignoreDeletedBuilds(res *http.Response) errors.Error {
-	// CircleCI API will return a 404 response for a workflow/job that has been deleted
-	// due to their data retention policy. We should ignore these errors.
-	if res.StatusCode == http.StatusNotFound {
+// ignoreDeletedOrBrokenBuilds skips per-item API failures that should not
+// abort an entire collector subtask. 404 means the resource was deleted
+// (retention); 500 means the CircleCI Server record is corrupt/stuck
+// (e.g. pipeline exists but its /workflow endpoint errors).
+func ignoreDeletedOrBrokenBuilds(res *http.Response) errors.Error {
+	switch res.StatusCode {
+	case http.StatusNotFound:
+		return api.ErrIgnoreAndContinue
+	case http.StatusInternalServerError:
 		return api.ErrIgnoreAndContinue
 	}
 	return nil

--- a/backend/plugins/circleci/tasks/shared_test.go
+++ b/backend/plugins/circleci/tasks/shared_test.go
@@ -1,0 +1,62 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func makeResponse(statusCode int) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Body:       io.NopCloser(bytes.NewBufferString("")),
+		Request:    &http.Request{},
+	}
+}
+
+func TestIgnoreDeletedOrBrokenBuilds(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		want       error
+	}{
+		{"404 returns ErrIgnoreAndContinue", http.StatusNotFound, api.ErrIgnoreAndContinue},
+		{"500 returns ErrIgnoreAndContinue", http.StatusInternalServerError, api.ErrIgnoreAndContinue},
+		{"200 returns nil", http.StatusOK, nil},
+		{"403 returns nil", http.StatusForbidden, nil},
+		{"502 returns nil", http.StatusBadGateway, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := makeResponse(tt.statusCode)
+			got := ignoreDeletedOrBrokenBuilds(res)
+			if tt.want == nil {
+				assert.Nil(t, got)
+			} else {
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+

--- a/backend/plugins/circleci/tasks/workflow_collector.go
+++ b/backend/plugins/circleci/tasks/workflow_collector.go
@@ -60,8 +60,10 @@ func CollectWorkflows(taskCtx plugin.SubTaskContext) errors.Error {
 					dal.Where("connection_id = ? AND project_slug = ?", data.Options.ConnectionId, data.Options.ProjectSlug),
 				}
 
-				if isIncremental {
-					clauses = append(clauses, dal.Where("created_date > ?", createdAfter))
+				// Incremental: pipelines newer than last successful collectWorkflows.
+				// Full sync: pipelines within SyncPolicy.TimeAfter window.
+				if createdAfter != nil {
+					clauses = append(clauses, dal.Where("created_date >= ?", createdAfter))
 				}
 
 				db := taskCtx.GetDal()
@@ -75,7 +77,7 @@ func CollectWorkflows(taskCtx plugin.SubTaskContext) errors.Error {
 				UrlTemplate:    "/v2/pipeline/{{ .Input.Id }}/workflow",
 				Query:          BuildQueryParamsWithPageToken,
 				ResponseParser: ParseCircleciPageTokenResp,
-				AfterResponse:  ignoreDeletedBuilds, // Ignore the 404 response if a workflow has been deleted
+				AfterResponse:  ignoreDeletedOrBrokenBuilds,
 			},
 			GetCreated: extractCreatedAt,
 		},
@@ -88,7 +90,7 @@ func CollectWorkflows(taskCtx plugin.SubTaskContext) errors.Error {
 					err := api.UnmarshalResponse(res, &data)
 					return []json.RawMessage{data}, err
 				},
-				AfterResponse: ignoreDeletedBuilds,
+				AfterResponse: ignoreDeletedOrBrokenBuilds,
 			},
 			BuildInputIterator: func() (api.Iterator, errors.Error) {
 				clauses := []dal.Clause{


### PR DESCRIPTION
### Summary

Two bug fixes for the CircleCI workflow and job collectors:

**1. Skip HTTP 500 responses from corrupt CircleCI Server records**

CircleCI Server occasionally returns `500 Internal Server Error` for pipelines whose internal records are corrupt or stuck (e.g. a pipeline exists in the DB but its `/workflow` endpoint errors). Previously, this caused `ignoreDeletedBuilds` to fall through and abort the entire collector subtask. Both the workflow and job collectors now use a renamed `ignoreDeletedOrBrokenBuilds` hook that treats `500` the same as `404` (data-retention deletion) — a non-fatal, per-item skip so collection continues past broken entries.

```
Before                                     After
─────────────────────────────────────────  ─────────────────────────────────────────
HTTP 404  →  ErrIgnoreAndContinue (skip)   HTTP 404  →  ErrIgnoreAndContinue (skip)
HTTP 500  →  error propagated, run aborts  HTTP 500  →  ErrIgnoreAndContinue (skip)
```

**2. Apply `SyncPolicy.TimeAfter` window on full sync**

The DB iterator clause that limits which pipelines/workflows trigger downstream API calls previously only activated when `isIncremental == true`. This meant a full sync with a `TimeAfter` policy still iterated every historical tool-layer row and issued an API request for each one. The condition is now `if createdAfter != nil`, so both incremental and windowed full syncs skip rows outside the time window.

The boundary condition also changed from `>` to `>=` so the exact bookmark timestamp is not silently dropped.

```
Before                                     After
─────────────────────────────────────────  ─────────────────────────────────────────
Full sync + TimeAfter  →  all rows iterated,    Full sync + TimeAfter  →  rows before
  API call per row regardless of age              window skipped, boundary inclusive
Incremental            →  rows after bookmark   Incremental            →  unchanged
  (exclusive)
```

### Does this close any open issues?

Closes #8948

### Screenshots

N/A — no UI changes.

### Other Information
