### PR TITLE
fix(azuredevops): handle 204 No Content in collectApiTimelineRecords timeline response

### DIFF
--- a/backend/plugins/azuredevops_go/tasks/shared.go
+++ b/backend/plugins/azuredevops_go/tasks/shared.go
@@ -153,8 +153,11 @@ func change203To401(res *http.Response) errors.Error {
 // that failed due to a YAML syntax error never produce a usable timeline), instead
 // of aborting the entire subtask.
 func ignoreInvalidTimelineResponse(res *http.Response) errors.Error {
-	// Keep existing behaviour: treat 404 as a graceful skip (build was deleted).
-	if res.StatusCode == http.StatusNotFound {
+	// Treat 404 (build deleted) and 204 (build has no timeline data) as
+	// graceful skips so the subtask continues instead of failing.
+	// The 204 guard must come before the body is read because a 204 response
+	// has an empty body by definition and would cause the JSON parser to fail.
+	if res.StatusCode == http.StatusNotFound || res.StatusCode == http.StatusNoContent {
 		return api.ErrIgnoreAndContinue
 	}
 

--- a/backend/plugins/azuredevops_go/tasks/shared_test.go
+++ b/backend/plugins/azuredevops_go/tasks/shared_test.go
@@ -41,6 +41,12 @@ func TestIgnoreInvalidTimelineResponse_404(t *testing.T) {
 	assert.Equal(t, api.ErrIgnoreAndContinue, err, "404 should return ErrIgnoreAndContinue")
 }
 
+func TestIgnoreInvalidTimelineResponse_204(t *testing.T) {
+	res := makeResponse(http.StatusNoContent, "")
+	err := ignoreInvalidTimelineResponse(res)
+	assert.Equal(t, api.ErrIgnoreAndContinue, err, "204 No Content should return ErrIgnoreAndContinue")
+}
+
 func TestIgnoreInvalidTimelineResponse_EmptyBody(t *testing.T) {
 	res := makeResponse(http.StatusOK, "")
 	err := ignoreInvalidTimelineResponse(res)


### PR DESCRIPTION
## Summary

Fixes the `collectApiTimelineRecords` subtask failing when the Azure DevOps
Timeline API returns `204 No Content` for deleted or empty builds.

## Root Cause

`ignoreInvalidTimelineResponse()` only guarded against `404 Not Found`.
When a `204 No Content` response was received, execution fell through to
`io.ReadAll(res.Body)` on an empty body. While the downstream empty-body
check would eventually skip the record, reading the body of a `204` response
before checking the status code is unsafe — some HTTP clients/proxies set
`Body = nil` on `204`, which causes a nil-pointer panic.

## Fix

Added an explicit `http.StatusNoContent` guard alongside the existing
`http.StatusNotFound` check, **before** the body is ever read.

## Changes

- `tasks/shared.go` — extend the status guard in `ignoreInvalidTimelineResponse`
  to include `204 No Content`
- `tasks/shared_test.go` — add `TestIgnoreInvalidTimelineResponse_204` to
  cover the new guard

## Testing

All existing tests continue to pass. New test `TestIgnoreInvalidTimelineResponse_204`
verifies that a `204` response returns `api.ErrIgnoreAndContinue` without
reading the body.

## Related

Closes #8944