### PR TITLE
feat(jira): Allow filter jira board using devlake project name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,4 @@ venv
 /backend/plugins/gitextractor/parser/demo_repo/
 
 __debug_bin*
+.copilot-specs-cache/

--- a/backend/core/models/blueprint.go
+++ b/backend/core/models/blueprint.go
@@ -77,6 +77,8 @@ type BlueprintScope struct {
 	PluginName   string `json:"-" gorm:"primaryKey;type:varchar(255)" validate:"required"`
 	ConnectionId uint64 `json:"-" gorm:"primaryKey" validate:"required"`
 	ScopeId      string `json:"scopeId" gorm:"primaryKey;type:varchar(255)" validate:"required"`
+	// ProjectName is set at plan-build time from the blueprint project name; not persisted.
+	ProjectName string `json:"projectName,omitempty" gorm:"-"`
 }
 
 func (BlueprintScope) TableName() string {

--- a/backend/helpers/pluginhelper/api/ds_scope_config_api_helper.go
+++ b/backend/helpers/pluginhelper/api/ds_scope_config_api_helper.go
@@ -18,6 +18,8 @@ limitations under the License.
 package api
 
 import (
+	"strconv"
+
 	"github.com/apache/incubator-devlake/core/context"
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
@@ -58,8 +60,15 @@ func (connApi *DsScopeConfigApiHelper[C, S, SC]) GetAll(input *plugin.ApiResourc
 }
 
 func (connApi *DsScopeConfigApiHelper[C, S, SC]) GetProjectsByScopeConfig(input *plugin.ApiResourceInput) (out *plugin.ApiResourceOutput, err errors.Error) {
-	var scopeConfig *SC
-	scopeConfig, err = connApi.FindByPk(input)
+	scopeConfigIdStr, ok := input.Params["scopeConfigId"]
+	if !ok {
+		return nil, errors.BadInput.New("missing scopeConfigId")
+	}
+	scopeConfigId, e := strconv.ParseUint(scopeConfigIdStr, 10, 64)
+	if e != nil {
+		return nil, errors.BadInput.New("invalid scopeConfigId")
+	}
+	scopeConfig, err := connApi.ScopeConfigSrvHelper.FindByScopeConfigId(scopeConfigId)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/helpers/srvhelper/scope_config_service_helper.go
+++ b/backend/helpers/srvhelper/scope_config_service_helper.go
@@ -59,6 +59,19 @@ func (scopeConfigSrv *ScopeConfigSrvHelper[C, S, SC]) GetAllByConnectionId(conne
 	return scopeConfigs, err
 }
 
+// FindByScopeConfigId loads a scope config by its autoincrement ID without requiring connectionId.
+func (scopeConfigSrv *ScopeConfigSrvHelper[C, S, SC]) FindByScopeConfigId(id uint64) (*SC, errors.Error) {
+	var config SC
+	err := scopeConfigSrv.db.First(&config, dal.Where("id = ?", id))
+	if err != nil {
+		if scopeConfigSrv.db.IsErrorNotFound(err) {
+			return nil, errors.NotFound.New("scope config not found")
+		}
+		return nil, err
+	}
+	return &config, nil
+}
+
 func (scopeConfigSrv *ScopeConfigSrvHelper[C, S, SC]) GetProjectsByScopeConfig(pluginName string, scopeConfig *SC) (*models.ProjectScopeOutput, errors.Error) {
 	s := new(S)
 	// find out the primary key of the scope model
@@ -88,7 +101,7 @@ func (scopeConfigSrv *ScopeConfigSrvHelper[C, S, SC]) GetProjectsByScopeConfig(p
 		dal.From("_devlake_blueprint_scopes bps"),
 		dal.Join("LEFT JOIN _devlake_blueprints bp ON (bp.id = bps.blueprint_id)"),
 		dal.Join(join),
-		dal.Where("bps.plugin_name = ? AND bps.connection_id = ? AND scope_config_id = ?", pluginName, (*scopeConfig).ScopeConfigConnectionId(), (*scopeConfig).ScopeConfigId()),
+		dal.Where(fmt.Sprintf("bps.plugin_name = ? AND bps.connection_id = ? AND %s.scope_config_id = ?", scopeTable), pluginName, (*scopeConfig).ScopeConfigConnectionId(), (*scopeConfig).ScopeConfigId()),
 	))
 	projectScopeMap := make(map[string]*models.ProjectScope)
 	for _, bps := range bpss {

--- a/backend/plugins/gitlab/impl/impl.go
+++ b/backend/plugins/gitlab/impl/impl.go
@@ -273,6 +273,9 @@ func (p Gitlab) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 			"GET":    api.GetScopeConfig,
 			"DELETE": api.DeleteScopeConfig,
 		},
+		"connections/:connectionId/scope-configs/:scopeConfigId/projects": {
+			"GET": api.GetProjectsByScopeConfig,
+		},
 		"connections/:connectionId/proxy/rest/*path": {
 			"GET": api.Proxy,
 		},

--- a/backend/plugins/jira/api/blueprint_v200.go
+++ b/backend/plugins/jira/api/blueprint_v200.go
@@ -54,7 +54,7 @@ func MakeDataSourcePipelinePlanV200(
 		return nil, nil, err
 	}
 
-	plan, err := makeDataSourcePipelinePlanV200(subtaskMetas, scopeDetails, connection)
+	plan, err := makeDataSourcePipelinePlanV200(subtaskMetas, scopeDetails, bpScopes, connection)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -69,6 +69,7 @@ func MakeDataSourcePipelinePlanV200(
 func makeDataSourcePipelinePlanV200(
 	subtaskMetas []plugin.SubTaskMeta,
 	scopeDetails []*srvhelper.ScopeDetail[models.JiraBoard, models.JiraScopeConfig],
+	bpScopes []*coreModels.BlueprintScope,
 	connection *models.JiraConnection,
 ) (coreModels.PipelinePlan, errors.Error) {
 	plan := make(coreModels.PipelinePlan, len(scopeDetails))
@@ -79,6 +80,10 @@ func makeDataSourcePipelinePlanV200(
 		}
 
 		scope, scopeConfig := scopeDetail.Scope, scopeDetail.ScopeConfig
+		projectName := ""
+		if i < len(bpScopes) {
+			projectName = bpScopes[i].ProjectName
+		}
 		// construct task options for Jira
 		task, err := helper.MakePipelinePlanTask(
 			"jira",
@@ -87,6 +92,7 @@ func makeDataSourcePipelinePlanV200(
 			JiraTaskOptions{
 				ConnectionId: scope.ConnectionId,
 				BoardId:      scope.BoardId,
+				ProjectName:  projectName,
 			},
 		)
 		if err != nil {

--- a/backend/plugins/jira/models/migrationscripts/20260625_add_filter_by_project_name_to_scope_config.go
+++ b/backend/plugins/jira/models/migrationscripts/20260625_add_filter_by_project_name_to_scope_config.go
@@ -1,0 +1,51 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/apache/incubator-devlake/helpers/migrationhelper"
+)
+
+var _ plugin.MigrationScript = (*addFilterByProjectNameToScopeConfig)(nil)
+
+type addFilterByProjectNameToScopeConfig struct{}
+
+type jiraScopeConfig20260625 struct {
+	ConnectionId        uint64 `gorm:"primaryKey"`
+	ID                  uint64 `gorm:"primaryKey;autoIncrement"`
+	FilterByProjectName bool   `json:"filterByProjectName"`
+}
+
+func (jiraScopeConfig20260625) TableName() string {
+	return "_tool_jira_scope_configs"
+}
+
+func (*addFilterByProjectNameToScopeConfig) Up(basicRes context.BasicRes) errors.Error {
+	return migrationhelper.AutoMigrateTables(basicRes, new(jiraScopeConfig20260625))
+}
+
+func (*addFilterByProjectNameToScopeConfig) Version() uint64 {
+	return 20260625120000
+}
+
+func (*addFilterByProjectNameToScopeConfig) Name() string {
+	return "add filter_by_project_name to jira scope configs"
+}

--- a/backend/plugins/jira/models/migrationscripts/register.go
+++ b/backend/plugins/jira/models/migrationscripts/register.go
@@ -55,5 +55,6 @@ func All() []plugin.MigrationScript {
 		new(flushJiraIssues),
 		new(updateScopeConfig),
 		new(addFixVersions20250619),
+		new(addFilterByProjectNameToScopeConfig),
 	}
 }

--- a/backend/plugins/jira/models/scope_config.go
+++ b/backend/plugins/jira/models/scope_config.go
@@ -44,6 +44,7 @@ type JiraScopeConfig struct {
 	common.ScopeConfig         `mapstructure:",squash" json:",inline" gorm:"embedded"`
 	EpicKeyField               string                 `mapstructure:"epicKeyField,omitempty" json:"epicKeyField" gorm:"type:varchar(255)"`
 	StoryPointField            string                 `mapstructure:"storyPointField,omitempty" json:"storyPointField" gorm:"type:varchar(255)"`
+	FilterByProjectName        bool                   `mapstructure:"filterByProjectName,omitempty" json:"filterByProjectName"`
 	RemotelinkCommitShaPattern string                 `mapstructure:"remotelinkCommitShaPattern,omitempty" json:"remotelinkCommitShaPattern" gorm:"type:varchar(255)"`
 	RemotelinkRepoPattern      []CommitUrlPattern     `mapstructure:"remotelinkRepoPattern,omitempty" json:"remotelinkRepoPattern" gorm:"type:json;serializer:json"`
 	TypeMappings               map[string]TypeMapping `mapstructure:"typeMappings,omitempty" json:"typeMappings" gorm:"type:json;serializer:json"`

--- a/backend/plugins/jira/tasks/issue_collector.go
+++ b/backend/plugins/jira/tasks/issue_collector.go
@@ -81,6 +81,25 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 	if apiCollector.GetSince() != nil {
 		jql = buildJQL(*apiCollector.GetSince(), loc)
 	}
+	if data.Options.ScopeConfig != nil && data.Options.ScopeConfig.FilterByProjectName {
+		projectName := strings.TrimSpace(data.Options.ProjectName)
+		if projectName != "" {
+			filter := fmt.Sprintf("component = '%s'", projectName)
+			parts := strings.SplitN(jql, " ORDER BY ", 2)
+			if len(parts) == 2 {
+				whereClause := strings.TrimSpace(parts[0])
+				orderClause := "ORDER BY " + strings.TrimSpace(parts[1])
+				if whereClause == "" {
+					jql = fmt.Sprintf("%s %s", filter, orderClause)
+				} else {
+					jql = fmt.Sprintf("(%s) AND %s %s", whereClause, filter, orderClause)
+				}
+			} else {
+				jql = fmt.Sprintf("(%s) AND %s", jql, filter)
+			}
+		}
+	}
+	logger.Info("collecting Jira issues with JQL: %s", jql)
 
 	err = apiCollector.InitCollector(api.ApiCollectorArgs{
 		ApiClient: data.ApiClient,

--- a/backend/plugins/jira/tasks/task_data.go
+++ b/backend/plugins/jira/tasks/task_data.go
@@ -31,6 +31,7 @@ type JiraOptions struct {
 	ScopeConfig   *models.JiraScopeConfig `json:"scopeConfig" mapstructure:"scopeConfig"`
 	ScopeConfigId uint64                  `json:"scopeConfigId" mapstructure:"scopeConfigId"`
 	PageSize      int                     `json:"pageSize" mapstructure:"pageSize"`
+	ProjectName   string                  `json:"projectName" mapstructure:"projectName"`
 }
 
 type JiraTaskData struct {

--- a/backend/server/services/blueprint_makeplan_v200.go
+++ b/backend/server/services/blueprint_makeplan_v200.go
@@ -53,6 +53,10 @@ func GeneratePlanJsonV200(
 		}
 		if pluginBp, ok := p.(plugin.DataSourcePluginBlueprintV200); ok {
 			var pluginScopes []plugin.Scope
+			// Propagate the DevLake project name into each scope so plugins can apply per-project filters dynamically.
+			for _, scope := range connection.Scopes {
+				scope.ProjectName = projectName
+			}
 			sourcePlans[i], pluginScopes, err = pluginBp.MakeDataSourcePipelinePlanV200(
 				connection.ConnectionId,
 				connection.Scopes,

--- a/config-ui/src/api/scope-config/index.ts
+++ b/config-ui/src/api/scope-config/index.ts
@@ -38,5 +38,5 @@ export const update = (plugin: string, connectionId: ID, id: ID, data: any) =>
     data,
   });
 
-export const check = (plugin: string, id: ID): Promise<ICheck> =>
+export const check = (plugin: string, connectionId: ID, id: ID): Promise<ICheck> =>
   request(`/plugins/${plugin}/scope-config/${id}/projects`);

--- a/config-ui/src/plugins/components/scope-config/index.tsx
+++ b/config-ui/src/plugins/components/scope-config/index.tsx
@@ -71,7 +71,7 @@ export const ScopeConfig = ({
   const handleHideDialog = () => setType(undefined);
 
   const handleCheckScopeConfig = async (id: ID) => {
-    const [success, res] = await operator(() => API.scopeConfig.check(plugin, id), { hideToast: true });
+    const [success, res] = await operator(() => API.scopeConfig.check(plugin, connectionId, id), { hideToast: true });
 
     if (success) {
       const projects = (res.projects ?? []).map((it: any) => ({
@@ -189,7 +189,7 @@ export const ScopeConfig = ({
   const handleUpdate = async (trId: ID) => {
     handleHideDialog();
 
-    const [success, res] = await operator(() => API.scopeConfig.check(plugin, trId), { hideToast: true });
+    const [success, res] = await operator(() => API.scopeConfig.check(plugin, connectionId, trId), { hideToast: true });
 
     if (success) {
       handleShowProjectsModal(res.projects ?? []);

--- a/config-ui/src/plugins/register/jira/config.tsx
+++ b/config-ui/src/plugins/register/jira/config.tsx
@@ -61,6 +61,7 @@ export const JiraConfig: IPluginConfig = {
     entities: ['TICKET', 'CROSS'],
     transformation: {
       storyPointField: '',
+      filterByProjectName: false,
       typeMappings: {},
       remotelinkCommitShaPattern: '',
       remotelinkRepoPattern: [],

--- a/config-ui/src/plugins/register/jira/transformation.tsx
+++ b/config-ui/src/plugins/register/jira/transformation.tsx
@@ -19,7 +19,7 @@
 import { useState, useEffect } from 'react';
 import { uniqWith } from 'lodash';
 import { CaretRightOutlined } from '@ant-design/icons';
-import { theme, Collapse, Tag, Form, Select } from 'antd';
+import { theme, Collapse, Tag, Form, Select, Checkbox } from 'antd';
 
 import API from '@/api';
 import { PageLoading, HelpTooltip, ExternalLink } from '@/components';
@@ -264,6 +264,26 @@ const renderCollapseItems = ({
                 })
               }
             />
+          </Form.Item>
+          <Form.Item
+            label={
+              <>
+                <span>Filter by Project</span>
+                <HelpTooltip content="When enabled, Jira issues are filtered by component = the DevLake project name at collection time. One scope config works across all projects automatically." />
+              </>
+            }
+          >
+            <Checkbox
+              checked={transformation.filterByProjectName ?? false}
+              onChange={(e) =>
+                onChangeTransformation({
+                  ...transformation,
+                  filterByProjectName: e.target.checked,
+                })
+              }
+            >
+              Filter issues by component = &lt;project name&gt;
+            </Checkbox>
           </Form.Item>
         </Form>
       ),


### PR DESCRIPTION
> Please complete _ALL_ items in this checklist, and remove before submitting

- [ x ] I have read through the [Contributing Documentation](https://devlake.apache.org/community/).
- [ x ] I have added relevant tests.
- [ x ] I have added relevant documentation.
- [ x ] I will add labels to the PR, such as `pr-type/bug-fix`, `pr-type/feature-development`, etc.


### Summary
What does this PR do?
Add JIRA scope config support for filtering boards by the devlake project name 

JIRA users can have large boards that track many components, the only solution at the moment is to have a board per deployable unit. but when you have 1000s of deployable units this needlessly explodes the number of JIRA boards needed.

Practical impact of these changes:

1. One Jira scope config can be reused across multiple DevLake projects.
2. Jira issue collection can automatically narrow results per project by matching Jira component to project name.
3. Reduces manual per-project board/filter setup for teams using shared Jira board configs.

### Screenshots
<img width="892" height="654" alt="image" src="https://github.com/user-attachments/assets/ec96f94b-98ad-40ef-8716-f5f7bc794eef" />

### Other Information
Question posted: https://github.com/apache/devlake/issues/8955
