### PR TITLE
Deprecating the DBT plugin

### DIFF
--- a/backend/plugins/dbt/impl/impl.go
+++ b/backend/plugins/dbt/impl/impl.go
@@ -52,6 +52,7 @@ func (p Dbt) GetTablesInfo() []dal.Tabler {
 }
 
 func (p Dbt) PrepareTaskData(taskCtx plugin.TaskContext, options map[string]interface{}) (interface{}, errors.Error) {
+	taskCtx.GetLogger().Warn(nil, "The dbt plugin is deprecated and will be removed on August 31, 2026. Please migrate to alternative transformation approaches.")
 	var op tasks.DbtOptions
 	err := helper.Decode(options, &op, nil)
 	if err != nil {


### PR DESCRIPTION
### Summary
Deprecating the DBT plugin due to potential vulnerability and lack of users


### Does this close any open issues?
Related to apache/devlake#8970
