### PR TITLE
fix(opsgenie): align access-rights error with docs

### DIFF
--- a/backend/plugins/opsgenie/api/connection_api.go
+++ b/backend/plugins/opsgenie/api/connection_api.go
@@ -48,7 +48,7 @@ func testOpsgenieConn(ctx context.Context, connection models.OpsgenieConn) (*plu
 	}
 
 	if response.StatusCode == http.StatusForbidden {
-		return nil, errors.HttpStatus(http.StatusForbidden).New("API Key need 'Read' and 'Configuration access' Access rights")
+		return nil, errors.HttpStatus(http.StatusForbidden).New("API Key needs 'Read', 'Create/Update', and 'Configuration Access' access rights")
 	}
 
 	if response.StatusCode == http.StatusOK || response.StatusCode == http.StatusAccepted {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

<!--
Thanks for submitting a pull request!

We appreciate you spending the time to work on these changes.
Please fill out as many sections below as possible.
-->

### Summary
The 403 error message shown during the Opsgenie connection test does not match the permissions described in the setup documentation.

https://devlake.apache.org/docs/Configuration/Opsgenie#api-access-key
> The following permissions are required to collect data from repositories:
> - Read
> - Create and Update
> - Configuration Access

This PR updates the message to align with the docs and avoids implying that Read + Configuration Access alone are sufficient.

### Does this close any open issues?
No related open issue found.

### Screenshots
N/A

### Other Information
N/A
