### PR TITLE
fix: docker file path in build-grafana-image target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ build-config-ui-image:
 	cd config-ui; docker build -t $(IMAGE_REPO)/devlake-config-ui:$(TAG) --file ./Dockerfile .
 
 build-grafana-image:
-	cd grafana; docker build -t $(IMAGE_REPO)/devlake-dashboard:$(TAG) --file ./backend/Dockerfile .
+	cd grafana; docker build -t $(IMAGE_REPO)/devlake-dashboard:$(TAG) --file ./Dockerfile .
 
 build-images: build-server-image build-config-ui-image build-grafana-image
 


### PR DESCRIPTION
### Summary
What does this PR do?

`build-grafana-image` target from Makefile file has wrong docker file path `./backend/Dockerfile`. So the docker image build fails with `file not found` error.
This MR changes the file path from `./backend/Dockerfile` to `./Dockerfile`, allowing the image to build successfully.

### Does this close any open issues?
No

### Screenshots
N/A

### Other Information
N/A
