### PR TITLE
build: pin swag CLI to v1.16.6 and oauth2-proxy to v7.15.3, add backend/.dockerignore

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,24 @@
+# Build artifacts: regenerated inside the image (GOBIN=/app/bin + make build-plugin/build-server).
+# Shipping the host's pre-built bin/ (multiple GB of plugin .so files) bloats the
+# build context and the builder layer, which can exhaust the Docker VM and crash BuildKit.
+bin/
+
+# Generated mocks (regenerated via make mock inside the image)
+mocks/
+
+# Runtime logs
+logs/
+
+# Python build/venv artifacts (regenerated; Dockerfile.server reinstalls from
+# requirements.txt / pyproject and runs python/build.sh). Source under python/ is kept.
+**/.venv/
+**/__pycache__/
+**/*.pyc
+python/.devlake-python-build-root/
+
+# Test / coverage output
+*.out
+coverage.txt
+
+# OS / editor junk
+.DS_Store

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -50,7 +50,7 @@ RUN if [ "$(arch)" != "x86_64" ] ; then \
     fi
 
 RUN go install github.com/vektra/mockery/v2@v2.53.6
-RUN go install github.com/swaggo/swag/cmd/swag@v1.16.1
+RUN go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
 COPY --from=debian-amd64 /usr/include /rootfs-amd64/usr/include
 COPY --from=debian-amd64 /usr/lib/x86_64-linux-gnu /rootfs-amd64/usr/lib/x86_64-linux-gnu

--- a/backend/Dockerfile.local
+++ b/backend/Dockerfile.local
@@ -48,7 +48,7 @@ RUN mkdir -p /tmp/build && cd /tmp/build && \
     ldconfig
 
 RUN go install github.com/vektra/mockery/v2@v2.53.6
-RUN go install github.com/swaggo/swag/cmd/swag@v1.16.1
+RUN go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
 WORKDIR /app
 COPY . /app

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -28,7 +28,7 @@ all: build
 
 go-dep:
 	go install github.com/vektra/mockery/v2@v2.53.6
-	go install github.com/swaggo/swag/cmd/swag@v1.16.1
+	go install github.com/swaggo/swag/cmd/swag@v1.16.6
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 
 go-dev-tools:

--- a/docker-compose-dev-mysql.yml
+++ b/docker-compose-dev-mysql.yml
@@ -97,7 +97,7 @@ services:
       - devlake
 
   authproxy:
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0-amd64
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3-amd64
     network_mode: "host"
     ports:
       - 4181:4180

--- a/docker-compose-dev-postgresql.yml
+++ b/docker-compose-dev-postgresql.yml
@@ -93,7 +93,7 @@ services:
       - devlake
 
   authproxy:
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.4.0-amd64
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.15.3-amd64
     network_mode: "host"
     ports:
       - 4180:4180


### PR DESCRIPTION
### Summary

Make the backend container build inputs reproducible and shrink the Docker
build context. This is a low-risk infrastructure/tooling change with **no
functional or runtime code changes**.

- **swag CLI pin → v1.16.6** across `backend/Makefile`, `backend/Dockerfile`
  and `backend/Dockerfile.local`, so local, CI and image builds all generate
  Swagger docs with the same tool version (previously v1.16.1).
- **oauth2-proxy dev image pin → v7.15.3-amd64** in both
  `docker-compose-dev-mysql.yml` and `docker-compose-dev-postgresql.yml`
  (previously v7.4.0-amd64).
- **New `backend/.dockerignore`** keeping regenerated build artifacts out of
  the Docker build context: `bin/`, `mocks/`, `logs/`, Python venv/build
  output, coverage files and OS junk. Source under `python/` is retained.

### Explicitly out of scope

- No MySQL/PostgreSQL image bumps.
- No Node/nginx/npm or frontend lockfile changes.
- No Grafana or Python library changes.
- No `Dockerfile.server` / build-cache restructuring.

### Automated tests / checks

- `git diff --check` clean (no whitespace errors).
- `docker compose -f docker-compose-dev-mysql.yml config -q` and the
  PostgreSQL equivalent validate successfully.
- `docker build --check` for `backend/Dockerfile` and
  `backend/Dockerfile.local` report no errors (only pre-existing
  `FromAsCasing` style warnings, unrelated to this change).
- `swag init` with v1.16.6 regenerates Swagger docs with no additional
  generated diff.

### Manual testing

- Verified the effective pinned versions in the changed files.
- Confirmed the Docker build context excludes the regenerated artifacts via
  the new `.dockerignore` while retaining `python/` sources.

### Rollback

Revert this single commit; it only changes pinned tool/image versions and
adds a `.dockerignore`.

### Known follow-ups / dependencies

Independent of other version-upgrade PRs. MySQL, PostgreSQL, Grafana, Python
and frontend bumps are handled in separate PRs.

