### PR TITLE
fix(core): increase cq_issue_code_blocks.component to TEXT

### DIFF
--- a/backend/core/models/domainlayer/codequality/cq_issue_code_blocks.go
+++ b/backend/core/models/domainlayer/codequality/cq_issue_code_blocks.go
@@ -22,7 +22,7 @@ import "github.com/apache/incubator-devlake/core/models/domainlayer"
 type CqIssueCodeBlock struct {
 	domainlayer.DomainEntity
 	IssueKey    string `json:"key" gorm:"index"`
-	Component   string `gorm:"index"`
+	Component   string `gorm:"type:text"`
 	StartLine   int
 	EndLine     int
 	StartOffset int

--- a/backend/core/models/migrationscripts/20260716_change_cq_issue_code_blocks_component_type.go
+++ b/backend/core/models/migrationscripts/20260716_change_cq_issue_code_blocks_component_type.go
@@ -1,0 +1,42 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var _ plugin.MigrationScript = (*changeCqIssueCodeBlocksComponentType)(nil)
+
+type changeCqIssueCodeBlocksComponentType struct{}
+
+func (script *changeCqIssueCodeBlocksComponentType) Up(basicRes context.BasicRes) errors.Error {
+	db := basicRes.GetDal()
+	errors.Must(db.DropIndex("cq_issue_code_blocks", "component"))
+	return db.ModifyColumnType("cq_issue_code_blocks", "component", "text")
+}
+
+func (*changeCqIssueCodeBlocksComponentType) Version() uint64 {
+	return 20260716000001
+}
+
+func (*changeCqIssueCodeBlocksComponentType) Name() string {
+	return "change cq_issue_code_blocks.component type to text"
+}

--- a/backend/core/models/migrationscripts/register.go
+++ b/backend/core/models/migrationscripts/register.go
@@ -145,6 +145,7 @@ func All() []plugin.MigrationScript {
 		new(modifyCicdDeploymentsToText),
 		new(increaseCqIssuesProjectKeyLength),
 		new(addAuthSessions),
+		new(changeCqIssueCodeBlocksComponentType),
 		new(addCqProjectMetricsHistory),
 	}
 }


### PR DESCRIPTION
### Summary

`cq_issue_code_blocks.component` had no explicit type, so GORM
defaulted it to `varchar(191)` on MySQL. Long SonarQube component
identifiers exceed this, causing data collection to fail with
"Data too long for column 'component'".

Fixed by changing the column to `TEXT`, matching the same fix
already applied to the sibling `cq_issues` table. The index is
dropped first since MySQL can't have an index on a TEXT column
without a prefix length.

Closes #8993