### PR TITLE
fix(dalgorm): make DropIndexes idempotent by skipping missing indexes

### DIFF
--- a/backend/impls/dalgorm/dalgorm.go
+++ b/backend/impls/dalgorm/dalgorm.go
@@ -452,9 +452,18 @@ func (d *Dalgorm) RenameTable(oldName, newName string) errors.Error {
 
 // DropIndexes drops indexes for specified table
 func (d *Dalgorm) DropIndexes(table string, indexNames ...string) errors.Error {
+	migrator := d.db.Migrator()
 	for _, indexName := range indexNames {
-		err := d.db.Migrator().DropIndex(table, indexName)
-		if err != nil {
+		// Skip indexes that are not present so the operation is idempotent and
+		// database-neutral. GORM's DropIndex emits a bare `DROP INDEX` (without
+		// `IF EXISTS`), which makes PostgreSQL fail with SQLSTATE 42704 when the
+		// index is missing (e.g. it was already removed by an earlier column
+		// rewrite). Guarding with HasIndex keeps genuine errors from being
+		// swallowed while making repeated/partial migrations safe.
+		if !migrator.HasIndex(table, indexName) {
+			continue
+		}
+		if err := migrator.DropIndex(table, indexName); err != nil {
 			return d.convertGormError(err)
 		}
 	}


### PR DESCRIPTION
### Summary

Make `Dalgorm.DropIndexes` idempotent by skipping indexes that are not present, so dropping an already-absent index no longer aborts a migration.

### Problem

`Dalgorm.DropIndexes` calls GORM's `Migrator().DropIndex`, which emits a bare `DROP INDEX` **without** `IF EXISTS`. On PostgreSQL this fails hard with `ERROR: index "..." does not exist (SQLSTATE 42704)` when the target index is missing, causing the migrator to panic and the server to crash on startup.

This is reproducible on PostgreSQL with the migration `change _tool_sonarqube_issue_code_blocks.component type to text`, which unconditionally drops `idx__tool_sonarqube_issue_code_blocks_component`. That index is no longer present after the earlier `modify component type to varchar(500)` migration rewrites the column via `ChangeColumnsType` (rename column, then AutoMigrate skips the name-colliding index, then the old column and its index are dropped). The result is a table with `component varchar(500)` and **no** component index, so the later unconditional `DropIndexes` aborts.

Observed panic:

```
ERROR: index "idx__tool_sonarqube_issue_code_blocks_component" does not exist (SQLSTATE 42704)
DROP INDEX "idx__tool_sonarqube_issue_code_blocks_component"
panic: ... (500)
server/services.InitExecuteMigration()
```

### Fix

Guard each drop with `migrator.HasIndex(table, indexName)` and skip indexes that do not exist. This makes the operation idempotent and database-neutral while still surfacing genuine drop errors (it does not blanket-swallow errors).

### Related

- #9003 (`chore(docker): bump PostgreSQL to 18.1 and MySQL to 8.4.10`) surfaces this crash during its PostgreSQL manual gate and recommends this fix be applied first. The two PRs are functionally independent and do not touch overlapping files.

### Testing

- `go build ./impls/dalgorm/...`
- Manual PostgreSQL migration run: with the fix, the previously-crashing migration chain completes and the server reaches ready state; without it, PostgreSQL aborts on the missing index.

A DB-backed unit test was intentionally omitted to avoid introducing an sqlite driver dependency that is not currently in `go.mod`.

### Rollback

Revert this single-file change; behaviour returns to the unconditional drop.

