### PR TITLE
chore(docker): bump PostgreSQL to 18.1 and MySQL to 8.4.10

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - default
     command: sleep infinity
   mysql:
-    image: mysql:8
+    image: mysql:8.4.10
     volumes:
       - mysql-storage:/var/lib/mysql
     restart: always

--- a/backend/test/e2e/remote/docker-compose.test.yml
+++ b/backend/test/e2e/remote/docker-compose.test.yml
@@ -19,7 +19,7 @@ version: "3"
 services:
 
   mysql-test:
-    image: mysql:8.0.26
+    image: mysql:8.4.10
     platform: linux/x86_64
     volumes:
       - mysql-test-storage:/var/lib/mysql
@@ -33,12 +33,12 @@ services:
       MYSQL_PASSWORD: merico
 
   postgres-test:
-    image: postgres:14.2-alpine
+    image: postgres:18.1-alpine
     restart: always
     ports:
       - "3308:5432"
     volumes:
-      - postgres-test-storage:/var/lib/postgresql/data
+      - postgres-test-storage:/var/lib/postgresql
     environment:
       POSTGRES_DB: lake
       POSTGRES_USER: merico

--- a/devops/deployment/temporal/docker-compose-temporal.yml
+++ b/devops/deployment/temporal/docker-compose-temporal.yml
@@ -16,7 +16,7 @@
 version: "3"
 services:
   mysql:
-    image: mysql:8.0.26
+    image: mysql:8.4.10
     volumes:
       - mysql-storage:/var/lib/mysql
     restart: always

--- a/docker-compose-dev-mysql.yml
+++ b/docker-compose-dev-mysql.yml
@@ -18,7 +18,7 @@ name: devlake-mysql
 
 services:
   mysql:
-    image: mysql:8
+    image: mysql:8.4.10
     volumes:
       - mysql-storage:/var/lib/mysql
     restart: always

--- a/docker-compose-dev-postgresql.yml
+++ b/docker-compose-dev-postgresql.yml
@@ -16,8 +16,8 @@
 name: devlake-postgresql
 
 services:
-  postgres: 
-    image: postgres:17.2
+  postgres:
+    image: postgres:18.1
     volumes:
       - postgres-storage:/var/lib/postgresql
     restart: always

--- a/docker-compose.datasources.yml
+++ b/docker-compose.datasources.yml
@@ -20,7 +20,7 @@ version: "3"
 services:
 
   mysql-ds:
-    image: mysql:8
+    image: mysql:8.4.10
     volumes:
       - ./.docker/mysql-ds:/var/lib/mysql
       # init.sql only runs on bootstrap. If you want to manually add the extra databases, run the SQL statements in the init.sql as MySQL root user

--- a/grafana/scripts/entrypoint.sh
+++ b/grafana/scripts/entrypoint.sh
@@ -204,7 +204,7 @@ else
   },
   "jsonData": {
     "sslmode": "${SSL_MODE}",
-    "postgresVersion": 1400,
+    "postgresVersion": 1800,
     "database": "${POSTGRES_DATABASE}"
   },
   "access": "proxy",


### PR DESCRIPTION
### Summary

Bump the database engine images used by the local dev, devcontainer, temporal deployment and remote e2e compose files:

- PostgreSQL `17.2` (dev) / `14.2-alpine` (e2e) -> `18.1` / `18.1-alpine`
- MySQL `8` / `8.0.26` -> `8.4.10`

### Details

- **PostgreSQL 18 volume mount (e2e):** `backend/test/e2e/remote/docker-compose.test.yml` now mounts the `postgres-test` volume at `/var/lib/postgresql` (the parent of PostgreSQL 18's new versioned data directory) instead of the legacy `/var/lib/postgresql/data`, matching the layout already used by `docker-compose-dev-postgresql.yml`.
- **Grafana datasource provisioning:** `grafana/scripts/entrypoint.sh` sets `postgresVersion` to `1800` so the provisioned PostgreSQL datasource targets PostgreSQL 18.

### Related / dependencies

- **Recommended before this on PostgreSQL: #9001** (`fix(dalgorm): make DropIndexes idempotent by skipping missing indexes`). It is a functionally independent fix, but without it a pre-existing migration (`change _tool_sonarqube_issue_code_blocks.component type to text`) aborts on PostgreSQL with `SQLSTATE 42704` when dropping an already-absent index. That failure is unrelated to the image bumps here, but it does surface during the PostgreSQL migration run. On MySQL this PR is unaffected by #9001.

### Out of scope

- Grafana database env parametrization / port changes.
- Any Go, Python, Node, or dashboard changes.

### Testing

- `docker compose config -q` passes for all changed compose files.
- `bash -n grafana/scripts/entrypoint.sh` passes.
- Manual gate — MySQL: fresh database starts, migrations run, smoke flow OK, data persists across restart.
- Manual gate — PostgreSQL 18: fresh database with `FORCE_MIGRATION=true`, container starts and accepts connections, migrations complete (with #9001 applied), `/ready` OK, Grafana datasource targets PG18; volume persists across restart.

### Rollback

Revert this commit to restore the previous image tags and the legacy e2e volume mount.

