### PR TITLE
chore(python): bump Python runtime from 3.9 to 3.11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
     "ghcr.io/jungaretti/features/make:1": {},
     "ghcr.io/devcontainers/features/docker-in-docker:2.12.0": {},
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.9"
+      "version": "3.11"
     },
     "ghcr.io/devcontainers-extra/features/poetry:2": {},
     "ghcr.io/devcontainers/features/node:1": {

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -113,7 +113,7 @@ RUN cd /usr/local/deps/target/lib && \
     done
 
 
-FROM python:3.9-slim-bookworm as base
+FROM python:3.11-slim-bookworm as base
 
 RUN apt-get update && \
     apt-get install -y python3-dev python3-pip tar pkg-config curl libssh2-1 zlib1g libffi-dev default-libmysqlclient-dev libpq-dev tini git openssh-client corkscrew && \

--- a/backend/python/DevelopmentSetup.md
+++ b/backend/python/DevelopmentSetup.md
@@ -22,12 +22,12 @@ limitations under the License.
 For the Python plugin tests to run properly, the following steps must be taken:
 
 1. The following packages are required for Ubuntu: `libffi-dev default-libmysqlclient-dev libpq-dev`
-2. `python3.9` is required by the time of this document. 
-   - Try `deadsnakes` if you are using Ubuntu 22.04 or above, the `python3.9-dev` is required.
-   - Use `virtualenv` if you are having multiple python versions. `virtualenv -p python3.9 path/to/venv` and `source path/to/venv/bin/activate.sh` should do the trick
-3. both `mysql-client` and `postgresql` are required. 
+2. `python3.11` is required by the time of this document.
+   - Try `deadsnakes` if you are using Ubuntu 22.04 or above, the `python3.11-dev` is required.
+   - Use `virtualenv` if you are having multiple python versions. `virtualenv -p python3.11 path/to/venv` and `source path/to/venv/bin/activate.sh` should do the trick
+3. both `mysql-client` and `postgresql` are required.
    - `postgresql` is required for `psycopg2` to work
-4. [poetry](https://python-poetry.org/) is required. 
+4. [poetry](https://python-poetry.org/) is required.
    - run `cd backend/python/pydevlake && poetry install`
    - run `cd backend/python/plugins/azuredevops && poetry install`
 5. `sqlalchemy` won't work with `localhost` in the database connection string, use `127.0.0.1` instead

--- a/backend/python/plugins/azuredevops/pyproject.toml
+++ b/backend/python/plugins/azuredevops/pyproject.toml
@@ -21,7 +21,7 @@ authors = ["Hezheng Yin <hezheng@merico.dev>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python = ">=3.11,<3.12"
 pydevlake = { path = "../../pydevlake", develop = true }
 
 

--- a/backend/python/pydevlake/pyproject.toml
+++ b/backend/python/pydevlake/pyproject.toml
@@ -22,7 +22,7 @@ license = "Apache-2.0"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python = ">=3.11,<3.12"
 sqlmodel = "^0.0.8"
 mysqlclient = "^2.1.1"
 requests = "^2.28.1"

--- a/backend/python/test/fakeplugin/pyproject.toml
+++ b/backend/python/test/fakeplugin/pyproject.toml
@@ -20,7 +20,7 @@ description = "Fake python plugin used only in tests"
 authors = []
 
 [tool.poetry.dependencies]
-python = "~3.9"
+python = ">=3.11,<3.12"
 pydevlake = { path = "../../pydevlake", develop = true }
 
 

--- a/backend/python/uv.sh
+++ b/backend/python/uv.sh
@@ -50,7 +50,7 @@ sync_project() {
     rm -rf .venv
   fi
   if [ ! -x .venv/bin/python ]; then
-    uv venv --python "${DEVLAKE_PYTHON_VERSION:-3.9}" .venv
+    uv venv --python "${DEVLAKE_PYTHON_VERSION:-3.11}" .venv
   fi
   uv pip install --python .venv/bin/python -e .
 }


### PR DESCRIPTION
### Summary

Bump the Python runtime used across the project from **3.9** to **3.11**. This is a
pure runtime bump: no library versions are changed and the existing Pydantic v1
code keeps working on 3.11.

### Changes

| File | Change |
|------|--------|
| `backend/Dockerfile` | server image base `python:3.9-slim-bookworm` → `python:3.11-slim-bookworm` |
| `backend/python/uv.sh` | default `uv venv` python `3.9` → `3.11` |
| `backend/python/pydevlake/pyproject.toml` | `python = "~3.9"` → `">=3.11,<3.12"` |
| `backend/python/plugins/azuredevops/pyproject.toml` | `python = "~3.9"` → `">=3.11,<3.12"` |
| `backend/python/test/fakeplugin/pyproject.toml` | `python = "~3.9"` → `">=3.11,<3.12"` |
| `.devcontainer/devcontainer.json` | python feature `3.9` → `3.11` |
| `backend/python/DevelopmentSetup.md` | docs now reference `python3.11` |

### Explicitly out of scope

- **No library upgrades.** `sqlmodel`, `pydantic`, `pytest`, `inflect`, `fire`,
  `jsonpointer` etc. stay unchanged. Pydantic v2 / SQLModel migration and the
  corresponding `poetry.lock` regeneration are handled in a **follow-up PR** to keep
  this change reviewable and independently revertable.
- No Node/frontend changes (the devcontainer Node feature stays at `18`).

### Testing

Automated (on Python 3.11.15):
- `make build-pydevlake` ✅ (resolves with `pydantic 1.10.26`, `sqlmodel 0.0.8`)
- `make unit-test-python` ✅ (azuredevops: 8 passed / 1 skipped, pydevlake: 10 passed)

Manual:
- Built the server image `base` stage from `backend/Dockerfile` → image reports
  `Python 3.11.15`, Python remote plugins build successfully.
- Started the azuredevops remote plugin and validated its `plugin-info` RPC
  handshake payload (name, extension, 12 subtasks, 14 migration scripts) on 3.11.
- Ran a real data-collection flow (Jira, git, SonarQube) end to end.

### Known unrelated issue

`devcontainer build` currently fails to pull `mcr.microsoft.com/devcontainers/go:1-1.26-bookworm`
(`.devcontainer/Dockerfile`). This base-image reference is **not** touched by this PR
and fails identically on `main`; it is independent of the Python 3.11 change.

### Rollback

Revert this single commit; it only changes version strings and has no schema or data impact.

