### PR TITLE
fix(sonarqube): tolerate missing migration indexes

### DIFF
--- a/backend/impls/dalgorm/dalgorm.go
+++ b/backend/impls/dalgorm/dalgorm.go
@@ -453,6 +453,9 @@ func (d *Dalgorm) RenameTable(oldName, newName string) errors.Error {
 // DropIndexes drops indexes for specified table
 func (d *Dalgorm) DropIndexes(table string, indexNames ...string) errors.Error {
 	for _, indexName := range indexNames {
+		if !d.db.Migrator().HasIndex(table, indexName) {
+			continue
+		}
 		err := d.db.Migrator().DropIndex(table, indexName)
 		if err != nil {
 			return d.convertGormError(err)

--- a/backend/plugins/sonarqube/e2e/issue_code_block_long_component_test.go
+++ b/backend/plugins/sonarqube/e2e/issue_code_block_long_component_test.go
@@ -80,6 +80,12 @@ func TestSonarqubeIssueCodeBlockLongComponent(t *testing.T) {
 		&sonarqubeIssueCodeBlockBeforeText{},
 		&cqIssueCodeBlockBeforeText{},
 	))
+	require.NoError(t, dataflowTester.Db.Migrator().DropIndex(
+		"cq_issue_code_blocks", "idx_cq_issue_code_blocks_component",
+	))
+	require.NoError(t, dataflowTester.Db.Migrator().DropIndex(
+		"_tool_sonarqube_issue_code_blocks", "idx__tool_sonarqube_issue_code_blocks_component",
+	))
 
 	existingComponent := "existing:component"
 	require.NoError(t, dataflowTester.Db.Create(&sonarqubeIssueCodeBlockBeforeText{


### PR DESCRIPTION
### Summary

Make `Dalgorm.DropIndexes` idempotent by skipping absent indexes. This prevents MySQL error 1091 when the SonarQube and domain migrations at version `20260701000000` encounter legacy tables without their component indexes.

The regression test removes both legacy indexes before applying the two migrations, then verifies data preservation, `text` component columns, and absent indexes.

### Does this close any open issues?

Closes #9011

### Other Information

Validated with the targeted MySQL-backed regression, the full SonarQube E2E package, `make lint`, and `make migration-script-lint`.