### PR TITLE
fix(config-ui): improve copy text contrast in dark mode

### DIFF
--- a/config-ui/src/components/action/copy-text/index.tsx
+++ b/config-ui/src/components/action/copy-text/index.tsx
@@ -28,7 +28,8 @@ const Wrapper = styled.div`
   align-items: center;
   justify-content: space-between;
   padding: 6px 8px;
-  background: #f0f4fe;
+  color: ${({ theme }) => theme.colors.text};
+  background: ${({ theme }) => theme.colors.infoBg};
 `;
 
 interface Props {


### PR DESCRIPTION
<!--
Licensed to the Apache Software Foundation (ASF) under one or more
contributor license agreements.  See the NOTICE file distributed with
this work for additional information regarding copyright ownership.
The ASF licenses this file to You under the Apache License, Version 2.0
(the "License"); you may not use this file except in compliance with
the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software
distributed under the License is distributed on an "AS IS" BASIS,
WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
See the License for the specific language governing permissions and
limitations under the License.
-->

### Summary
Fix the readability of copyable text fields in dark mode.

This fixes the copyable fields displayed in the following locations:
- Webhook connection view:
    - Post to register/update an incident
    - Post to close a registered incident
    - Post to register a deployment
    - Post to register/update a pull request
    - Newly generated API key
- Webhook creation result dialog
- API Keys page when displaying a newly generated key

### Does this close any open issues?
None

### Screenshots
| Theme | Before | After |
|--|--|--|
| Dark | <img width="809" height="241" alt="CleanShot 2026-07-29 at 20 27 05" src="https://github.com/user-attachments/assets/3f3a726f-ba43-42ac-a12e-36141cbb6706" /> | <img width="813" height="237" alt="CleanShot 2026-07-29 at 20 28 28" src="https://github.com/user-attachments/assets/7f02ea66-9cc7-42d3-ab51-ddb09ffc8408" /> |
| Light | <img width="813" height="240" alt="CleanShot 2026-07-29 at 20 29 06" src="https://github.com/user-attachments/assets/e26d5251-298d-45a1-92e2-2273052ec5f1" /> | <img width="814" height="243" alt="CleanShot 2026-07-29 at 20 30 06" src="https://github.com/user-attachments/assets/ee566ccb-e97a-44f9-9086-7219173ec0e1" /> |


### Other Information
None