### PR TITLE
fix(org): resolve API handlers at request time to survive late plugin init

### DIFF
--- a/backend/plugins/org/impl/impl.go
+++ b/backend/plugins/org/impl/impl.go
@@ -102,24 +102,41 @@ func (p Org) RootPkgPath() string {
 	return "github.com/apache/incubator-devlake/plugins/org"
 }
 
-func (p Org) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
+// wrapHandler defers the resolution of p.handlers to request time.
+// ApiResources() may be evaluated during route registration, which can happen
+// before InitPlugins() has called Init() (InitPlugins runs inside
+// pipelineServiceInit); a bound method value like p.handlers.GetTeam would
+// capture a nil receiver permanently, making every org endpoint panic with a
+// nil pointer dereference. See https://github.com/apache/devlake/issues/9021.
+func (p *Org) wrapHandler(
+	method func(*api.Handlers, *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error),
+) plugin.ApiResourceHandler {
+	return func(input *plugin.ApiResourceInput) (*plugin.ApiResourceOutput, errors.Error) {
+		if p.handlers == nil {
+			return nil, errors.Internal.New("org plugin is not initialized yet, please retry later")
+		}
+		return method(p.handlers, input)
+	}
+}
+
+func (p *Org) ApiResources() map[string]map[string]plugin.ApiResourceHandler {
 	return map[string]map[string]plugin.ApiResourceHandler{
 		"teams.csv": {
-			"GET": p.handlers.GetTeam,
-			"PUT": p.handlers.CreateTeam,
+			"GET": p.wrapHandler((*api.Handlers).GetTeam),
+			"PUT": p.wrapHandler((*api.Handlers).CreateTeam),
 		},
 		"users.csv": {
-			"GET": p.handlers.GetUser,
-			"PUT": p.handlers.CreateUser,
+			"GET": p.wrapHandler((*api.Handlers).GetUser),
+			"PUT": p.wrapHandler((*api.Handlers).CreateUser),
 		},
 
 		"user_account_mapping.csv": {
-			"GET": p.handlers.GetUserAccountMapping,
-			"PUT": p.handlers.CreateUserAccountMapping,
+			"GET": p.wrapHandler((*api.Handlers).GetUserAccountMapping),
+			"PUT": p.wrapHandler((*api.Handlers).CreateUserAccountMapping),
 		},
 		"project_mapping.csv": {
-			"GET": p.handlers.GetProjectMapping,
-			"PUT": p.handlers.CreateProjectMapping,
+			"GET": p.wrapHandler((*api.Handlers).GetProjectMapping),
+			"PUT": p.wrapHandler((*api.Handlers).CreateProjectMapping),
 		},
 	}
 }

--- a/backend/plugins/org/impl/impl_test.go
+++ b/backend/plugins/org/impl/impl_test.go
@@ -1,0 +1,42 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package impl
+
+import (
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/plugin"
+	"github.com/stretchr/testify/assert"
+)
+
+// Route registration may evaluate ApiResources() before InitPlugins() has run
+// (see https://github.com/apache/devlake/issues/9021). Handlers obtained from
+// an uninitialized plugin must fail gracefully instead of panicking with a
+// nil pointer dereference, and keep working once Init() runs later.
+func TestApiResourcesBeforeInitFailsGracefully(t *testing.T) {
+	p := &Org{}
+	for resource, methods := range p.ApiResources() {
+		for method, handler := range methods {
+			assert.NotPanics(t, func() {
+				out, err := handler(&plugin.ApiResourceInput{})
+				assert.Nilf(t, out, "%s %s should return no output before Init", method, resource)
+				assert.NotNilf(t, err, "%s %s should return an error before Init", method, resource)
+			}, "%s %s must not panic before Init", method, resource)
+		}
+	}
+}


### PR DESCRIPTION
### Summary

All `plugins/org` API endpoints (`teams.csv`, `users.csv`, `user_account_mapping.csv`, `project_mapping.csv`) panic with a nil pointer dereference whenever route registration wins the race against plugin initialization — full diagnosis with startup-log evidence in #9021.

`InitPlugins()` (the only thing that calls `PluginInit.Init()` in server mode) runs inside `pipelineServiceInit()`, while `registerPluginEndpoints` evaluates each plugin's `ApiResources()` independently. The org plugin returned **bound method values** (`p.handlers.GetTeam`), and Go captures the receiver at evaluation time — if `Init()` hasn't run yet, the router permanently holds handlers bound to a nil `*Handlers`. A pending DB migration at boot makes the bad ordering deterministic, which is why this bit several users after upgrades (#8590, #8271, #7957, #7219).

This fix resolves `p.handlers` at **request time** via method expressions, returning a clean 500 with "org plugin is not initialized yet, please retry later" during the (brief) pre-init window instead of panicking forever after it.

- `go build` / `go vet` / `gofmt` clean on the touched packages
- New unit test `TestApiResourcesBeforeInitFailsGracefully` covers every org endpoint pre-init (panicked before this change, clean error now)
- e2e tests unchanged (require `E2E_DB_URL`)

A broader alternative would be moving `InitPlugins()` ahead of route registration in server startup — deliberately not done here to keep the change scoped to the affected plugin; happy to follow up if maintainers prefer that direction.

### Does this close any open issues?

Closes #9021
