### PR TITLE
fix: abort request context when apikey doesn't match

### DIFF
--- a/backend/server/api/middlewares.go
+++ b/backend/server/api/middlewares.go
@@ -264,6 +264,7 @@ func CheckAuthorizationHeader(c *gin.Context, logger log.Logger, db dal.Dal, api
 		return false
 	}
 	if !matched {
+		c.Abort()
 		c.JSON(http.StatusForbidden, &apiBody{
 			Success: false,
 			Message: "path doesn't match api key's scope",


### PR DESCRIPTION
### Summary
abort request context when apikey doesn't match
