### PR TITLE
Add Atlassian API Gateway migrate to v3 search

### DIFF
--- a/backend/plugins/jira/SEARCH_API_MIGRATION.md
+++ b/backend/plugins/jira/SEARCH_API_MIGRATION.md
@@ -1,0 +1,45 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Jira Search API migration notes
+
+## What changed
+- Jira Cloud issue and epic collection now uses /rest/api/3/search/jql with HTTP POST body payload.
+- Jira Server and Jira Data Center continue to use /rest/api/2/search with HTTP GET query parameters.
+- Search endpoint selection is now Cloud-only for v3; all non-Cloud deployments fall back to v2 for compatibility.
+
+## Jira Cloud request payload
+For Cloud search calls, request data is sent in JSON payload instead of query string:
+- jql
+- maxResults
+- expand (changelog)
+- fields (*all)
+- nextPageToken (only for subsequent pages)
+
+## Pagination behavior
+- Cloud pagination is token-based (nextPageToken) and requests pages sequentially.
+- Collection ends when nextPageToken is absent in response.
+- Response body is preserved after token extraction so downstream parsers can still read the same body.
+
+## Authentication considerations
+- Authentication behavior is unchanged by this migration.
+- Atlassian API Gateway mode (api.atlassian.com) continues to work with Bearer Access Token.
+- Standard Jira Cloud (*.atlassian.net) continues to support BasicAuth (email + API token) where configured.
+
+## Backward compatibility
+- Jira Server remains on v2 search and v2 user lookup paths.
+- Jira Data Center and unknown non-Cloud deployment values are intentionally treated as non-Cloud and use v2 search.
+- Existing JQL composition, incremental windowing, and issue ordering (ORDER BY created ASC) are preserved.

--- a/backend/plugins/jira/api/connection_api.go
+++ b/backend/plugins/jira/api/connection_api.go
@@ -58,7 +58,10 @@ func testConnection(ctx context.Context, connection models.JiraConn) (*JiraTestC
 	}
 	serverInfoFail := "Failed testing the serverInfo: [ " + res.Request.URL.String() + " ]"
 	// check if `/rest/` was missing
-	if res.StatusCode == http.StatusNotFound && !strings.HasSuffix(connection.Endpoint, "/rest/") {
+	// Skip this hint for Atlassian API Gateway endpoints — they already include /rest/ in the path
+	// and a 404 on serverInfo there indicates a wrong Cloud ID, not a missing /rest/ segment.
+	isGatewayEndpoint := strings.Contains(connection.Endpoint, "api.atlassian.com")
+	if res.StatusCode == http.StatusNotFound && !strings.HasSuffix(connection.Endpoint, "/rest/") && !isGatewayEndpoint {
 		endpointUrl, err := url.Parse(connection.Endpoint)
 		if err != nil {
 			return nil, errors.Convert(err)

--- a/backend/plugins/jira/api/connection_api_test.go
+++ b/backend/plugins/jira/api/connection_api_test.go
@@ -1,0 +1,144 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/apache/incubator-devlake/core/config"
+	implcontext "github.com/apache/incubator-devlake/impls/context"
+	"github.com/apache/incubator-devlake/impls/logruslog"
+	"github.com/apache/incubator-devlake/plugins/jira/models"
+	"github.com/go-playground/validator/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// initTestDeps wires up the package-level basicRes and vld.
+// DefaultBasicRes satisfies context.BasicRes and only needs config + logger;
+// dal can be nil because NewApiClientFromConnection never calls GetDal.
+func initTestDeps(t *testing.T) {
+	t.Helper()
+	basicRes = implcontext.NewDefaultBasicRes(config.GetConfig(), logruslog.Global, nil)
+	vld = validator.New()
+}
+
+// serverInfoResponse is the minimal Jira serverInfo payload used in tests.
+type serverInfoResponse struct {
+	DeploymentType string `json:"deploymentType"`
+	Version        string `json:"version"`
+	VersionNumbers []int  `json:"versionNumbers"`
+}
+
+// newJiraTestServer creates an httptest.Server that responds to Jira REST paths.
+// It records the Authorization header sent by the client for later assertion.
+func newJiraTestServer(t *testing.T, authHeaderOut *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if authHeaderOut != nil {
+			*authHeaderOut = r.Header.Get("Authorization")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.HasSuffix(r.URL.Path, "/api/2/serverInfo"):
+			json.NewEncoder(w).Encode(serverInfoResponse{
+				DeploymentType: "Cloud",
+				Version:        "1001.0.0",
+				VersionNumbers: []int{1001, 0, 0},
+			})
+		case strings.Contains(r.URL.Path, "/agile/1.0/board"):
+			json.NewEncoder(w).Encode(map[string]interface{}{"values": []interface{}{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+// TestTestConnection_Gateway verifies that a gateway-style endpoint with
+// authMethod=AccessToken sends "Authorization: Bearer <token>" and succeeds.
+func TestTestConnection_Gateway(t *testing.T) {
+	initTestDeps(t)
+
+	var capturedAuth string
+	srv := newJiraTestServer(t, &capturedAuth)
+	defer srv.Close()
+
+	conn := models.JiraConn{}
+	conn.Endpoint = srv.URL + "/rest/"
+	conn.AuthMethod = "AccessToken"
+	conn.Token = "my-scoped-gateway-token"
+
+	resp, err := testConnection(context.Background(), conn)
+	require.Nil(t, err, "testConnection should succeed for gateway endpoint")
+	require.NotNil(t, resp)
+	assert.True(t, resp.Success)
+	assert.Equal(t, "Bearer my-scoped-gateway-token", capturedAuth,
+		"gateway mode must send Bearer token, not Basic credentials")
+}
+
+// TestTestConnection_StandardCloud verifies backward compatibility:
+// a standard atlassian.net endpoint with BasicAuth still works.
+func TestTestConnection_StandardCloud(t *testing.T) {
+	initTestDeps(t)
+
+	var capturedAuth string
+	srv := newJiraTestServer(t, &capturedAuth)
+	defer srv.Close()
+
+	conn := models.JiraConn{}
+	conn.Endpoint = srv.URL + "/rest/"
+	conn.AuthMethod = "BasicAuth"
+	conn.Username = "user@example.com"
+	conn.Password = "api-token-value"
+
+	resp, err := testConnection(context.Background(), conn)
+	require.Nil(t, err, "testConnection should succeed for standard cloud endpoint")
+	require.NotNil(t, resp)
+	assert.True(t, resp.Success)
+	assert.True(t, strings.HasPrefix(capturedAuth, "Basic "),
+		"standard cloud mode must send Basic auth header")
+}
+
+// TestTestConnection_NonGateway404ShowsHint verifies that when a non-gateway endpoint
+// is missing /rest/ and returns 404, the helpful hint message is included in the error.
+func TestTestConnection_NonGateway404ShowsHint(t *testing.T) {
+	initTestDeps(t)
+
+	// Server that always returns 404
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	// URL intentionally missing /rest/ — should trigger the "please try" hint
+	connMissingRest := models.JiraConn{}
+	connMissingRest.Endpoint = srv.URL + "/"
+	connMissingRest.AuthMethod = "BasicAuth"
+	connMissingRest.Username = "u"
+	connMissingRest.Password = "p"
+
+	_, errMissingRest := testConnection(context.Background(), connMissingRest)
+	require.NotNil(t, errMissingRest)
+	assert.Contains(t, errMissingRest.Error(), "please try",
+		"non-gateway 404 should include the /rest/ hint")
+}

--- a/backend/plugins/jira/tasks/epic_collector.go
+++ b/backend/plugins/jira/tasks/epic_collector.go
@@ -82,9 +82,9 @@ func CollectEpics(taskCtx plugin.SubTaskContext) errors.Error {
 		jql = buildJQL(*apiCollector.GetSince(), loc)
 	}
 
-	// Choose API endpoint based on JIRA deployment type
-	if strings.EqualFold(string(data.JiraServerInfo.DeploymentType), string(models.DeploymentServer)) {
-		logger.Info("Using api/2/search for JIRA Server")
+	searchEndpoint := getJiraSearchEndpoint(data.JiraServerInfo.DeploymentType)
+	if searchEndpoint == jiraSearchEndpointV2 {
+		logger.Info("Using api/2/search for non-Cloud JIRA")
 		err = setupApiV2Collector(apiCollector, data, epicIterator, jql)
 	} else {
 		logger.Info("Using api/3/search/jql for JIRA Cloud")
@@ -102,7 +102,7 @@ func setupApiV2Collector(apiCollector *api.StatefulApiCollector, data *JiraTaskD
 		ApiClient:   data.ApiClient,
 		PageSize:    100,
 		Incremental: false,
-		UrlTemplate: "api/2/search",
+		UrlTemplate: jiraSearchEndpointV2,
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			epicKeys := []string{}
@@ -152,25 +152,36 @@ func setupApiV3Collector(apiCollector *api.StatefulApiCollector, data *JiraTaskD
 		ApiClient:             data.ApiClient,
 		PageSize:              100,
 		Incremental:           false,
-		UrlTemplate:           "api/3/search/jql",
+		UrlTemplate:           jiraSearchEndpointV3,
 		GetNextPageCustomData: getNextPageCustomDataForV3,
+		Method:                http.MethodPost,
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
-			query := url.Values{}
 			epicKeys := []string{}
-			for _, e := range reqData.Input.([]interface{}) {
-				epicKeys = append(epicKeys, *e.(*string))
+			input, ok := reqData.Input.([]interface{})
+			if !ok {
+				return nil, errors.Default.New("invalid input type, expected []interface{}")
+			}
+			for _, e := range input {
+				epicKey, ok := e.(*string)
+				if ok && epicKey != nil {
+					epicKeys = append(epicKeys, *epicKey)
+				}
+			}
+			return url.Values{}, nil
+		},
+		RequestBody: func(reqData *api.RequestData) map[string]interface{} {
+			epicKeys := []string{}
+			input, ok := reqData.Input.([]interface{})
+			if ok {
+				for _, e := range input {
+					epicKey, castOk := e.(*string)
+					if castOk && epicKey != nil {
+						epicKeys = append(epicKeys, *epicKey)
+					}
+				}
 			}
 			localJQL := fmt.Sprintf("issue in (%s) and %s", strings.Join(epicKeys, ","), jql)
-			query.Set("jql", localJQL)
-			query.Set("maxResults", fmt.Sprintf("%v", reqData.Pager.Size))
-			query.Set("expand", "changelog")
-			query.Set("fields", "*all")
-
-			if reqData.CustomData != nil {
-				query.Set("nextPageToken", reqData.CustomData.(string))
-			}
-
-			return query, nil
+			return buildJiraV3SearchRequestBody(localJQL, reqData)
 		},
 		Input: epicIterator,
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {

--- a/backend/plugins/jira/tasks/epic_collector_test.go
+++ b/backend/plugins/jira/tasks/epic_collector_test.go
@@ -178,22 +178,32 @@ func TestEpicCollectorApiEndpointSelection(t *testing.T) {
 		{
 			name:             "JIRA Server should use api/2/search",
 			deploymentType:   models.DeploymentServer,
-			expectedEndpoint: "api/2/search",
+			expectedEndpoint: jiraSearchEndpointV2,
 		},
 		{
 			name:             "JIRA Cloud should use api/3/search/jql",
 			deploymentType:   models.DeploymentCloud,
-			expectedEndpoint: "api/3/search/jql",
+			expectedEndpoint: jiraSearchEndpointV3,
 		},
 		{
 			name:             "Lowercase server should use api/2/search",
 			deploymentType:   "server",
-			expectedEndpoint: "api/2/search",
+			expectedEndpoint: jiraSearchEndpointV2,
 		},
 		{
 			name:             "Uppercase CLOUD should use api/3/search/jql",
 			deploymentType:   "CLOUD",
-			expectedEndpoint: "api/3/search/jql",
+			expectedEndpoint: jiraSearchEndpointV3,
+		},
+		{
+			name:             "JIRA Data Center should use api/2/search",
+			deploymentType:   "Data Center",
+			expectedEndpoint: jiraSearchEndpointV2,
+		},
+		{
+			name:             "Unknown deployment should use api/2/search",
+			deploymentType:   "Unknown",
+			expectedEndpoint: jiraSearchEndpointV2,
 		},
 	}
 
@@ -202,11 +212,7 @@ func TestEpicCollectorApiEndpointSelection(t *testing.T) {
 			// Test the API endpoint selection logic from CollectEpics function
 			var selectedEndpoint string
 
-			if strings.EqualFold(string(tt.deploymentType), string(models.DeploymentServer)) {
-				selectedEndpoint = "api/2/search"
-			} else {
-				selectedEndpoint = "api/3/search/jql"
-			}
+			selectedEndpoint = getJiraSearchEndpoint(tt.deploymentType)
 
 			if selectedEndpoint != tt.expectedEndpoint {
 				t.Errorf("API endpoint selection for %s: got %s, want %s",

--- a/backend/plugins/jira/tasks/issue_collector.go
+++ b/backend/plugins/jira/tasks/issue_collector.go
@@ -95,8 +95,9 @@ func CollectIssues(taskCtx plugin.SubTaskContext) errors.Error {
 		pageSize = 100
 	}
 
-	if strings.EqualFold(string(data.JiraServerInfo.DeploymentType), string(models.DeploymentServer)) {
-		logger.Info("Using api/2/search for JIRA Server issue collection")
+	searchEndpoint := getJiraSearchEndpoint(data.JiraServerInfo.DeploymentType)
+	if searchEndpoint == jiraSearchEndpointV2 {
+		logger.Info("Using api/2/search for non-Cloud JIRA issue collection")
 		err = setupIssueV2Collector(apiCollector, data, filterJql, pageSize)
 	} else {
 		logger.Info("Using api/3/search/jql for JIRA Cloud issue collection")
@@ -180,7 +181,7 @@ func setupIssueV2Collector(apiCollector *api.StatefulApiCollector, data *JiraTas
 	return apiCollector.InitCollector(api.ApiCollectorArgs{
 		ApiClient:   data.ApiClient,
 		PageSize:    pageSize,
-		UrlTemplate: "api/2/search",
+		UrlTemplate: jiraSearchEndpointV2,
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
 			query := url.Values{}
 			query.Set("jql", filterJql)
@@ -212,18 +213,14 @@ func setupIssueV3Collector(apiCollector *api.StatefulApiCollector, data *JiraTas
 	return apiCollector.InitCollector(api.ApiCollectorArgs{
 		ApiClient:             data.ApiClient,
 		PageSize:              pageSize,
-		UrlTemplate:           "api/3/search/jql",
+		UrlTemplate:           jiraSearchEndpointV3,
 		GetNextPageCustomData: getNextPageCustomDataForV3,
+		Method:                http.MethodPost,
 		Query: func(reqData *api.RequestData) (url.Values, errors.Error) {
-			query := url.Values{}
-			query.Set("jql", filterJql)
-			query.Set("maxResults", fmt.Sprintf("%v", reqData.Pager.Size))
-			query.Set("expand", "changelog")
-			query.Set("fields", "*all")
-			if reqData.CustomData != nil {
-				query.Set("nextPageToken", reqData.CustomData.(string))
-			}
-			return query, nil
+			return url.Values{}, nil
+		},
+		RequestBody: func(reqData *api.RequestData) map[string]interface{} {
+			return buildJiraV3SearchRequestBody(filterJql, reqData)
 		},
 		ResponseParser: func(res *http.Response) ([]json.RawMessage, errors.Error) {
 			var data struct {
@@ -268,7 +265,7 @@ func getTimeZone(taskCtx plugin.SubTaskContext) (*time.Location, errors.Error) {
 	var resp *http.Response
 	var path string
 	var query url.Values
-	if strings.EqualFold(string(data.JiraServerInfo.DeploymentType), string(models.DeploymentServer)) {
+	if !isJiraCloudDeployment(data.JiraServerInfo.DeploymentType) {
 		path = "api/2/user"
 		query = url.Values{"username": []string{conn.Username}}
 	} else {

--- a/backend/plugins/jira/tasks/search_api_test.go
+++ b/backend/plugins/jira/tasks/search_api_test.go
@@ -1,0 +1,117 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tasks
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	devlakeerrors "github.com/apache/incubator-devlake/core/errors"
+	helperapi "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
+	"github.com/apache/incubator-devlake/plugins/jira/models"
+)
+
+func TestGetJiraSearchEndpoint(t *testing.T) {
+	tests := []struct {
+		name           string
+		deploymentType models.DeploymentType
+		want           string
+	}{
+		{name: "Cloud uses v3", deploymentType: models.DeploymentCloud, want: jiraSearchEndpointV3},
+		{name: "Lowercase cloud uses v3", deploymentType: "cloud", want: jiraSearchEndpointV3},
+		{name: "Server uses v2", deploymentType: models.DeploymentServer, want: jiraSearchEndpointV2},
+		{name: "Data Center uses v2", deploymentType: "Data Center", want: jiraSearchEndpointV2},
+		{name: "Unknown uses v2", deploymentType: "something-else", want: jiraSearchEndpointV2},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getJiraSearchEndpoint(tt.deploymentType); got != tt.want {
+				t.Fatalf("getJiraSearchEndpoint() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildJiraV3SearchRequestBody(t *testing.T) {
+	requestData := &helperapi.RequestData{
+		Pager: &helperapi.Pager{Size: 100},
+	}
+	body := buildJiraV3SearchRequestBody("project = DEV", requestData)
+
+	if body["jql"] != "project = DEV" {
+		t.Fatalf("expected jql in body")
+	}
+	if body["maxResults"] != 100 {
+		t.Fatalf("expected maxResults=100, got %v", body["maxResults"])
+	}
+	if body["expand"] != "changelog" {
+		t.Fatalf("expected expand=changelog")
+	}
+	if body["fields"] != "*all" {
+		t.Fatalf("expected fields=*all")
+	}
+	if _, ok := body["nextPageToken"]; ok {
+		t.Fatalf("did not expect nextPageToken when CustomData is nil")
+	}
+
+	requestData.CustomData = "token-123"
+	body = buildJiraV3SearchRequestBody("project = DEV", requestData)
+	if body["nextPageToken"] != "token-123" {
+		t.Fatalf("expected nextPageToken=token-123, got %v", body["nextPageToken"])
+	}
+
+	requestData.CustomData = 123
+	body = buildJiraV3SearchRequestBody("project = DEV", requestData)
+	if _, ok := body["nextPageToken"]; ok {
+		t.Fatalf("did not expect nextPageToken for non-string CustomData")
+	}
+}
+
+func TestGetNextPageCustomDataForV3(t *testing.T) {
+	response := &http.Response{Body: io.NopCloser(strings.NewReader("{\"nextPageToken\":\"abc\",\"issues\":[]}"))}
+	customData, err := getNextPageCustomDataForV3(nil, response)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if token, ok := customData.(string); !ok || token != "abc" {
+		t.Fatalf("expected token abc, got %v", customData)
+	}
+
+	bodyAfter, readErr := io.ReadAll(response.Body)
+	if readErr != nil {
+		t.Fatalf("failed to read response body after parsing token: %v", readErr)
+	}
+	if string(bodyAfter) != "{\"nextPageToken\":\"abc\",\"issues\":[]}" {
+		t.Fatalf("response body should remain readable after token extraction")
+	}
+
+	response = &http.Response{Body: io.NopCloser(strings.NewReader("{\"issues\":[]}"))}
+	_, err = getNextPageCustomDataForV3(nil, response)
+	if !devlakeerrors.Is(err, helperapi.ErrFinishCollect) {
+		t.Fatalf("expected ErrFinishCollect when nextPageToken is missing, got %v", err)
+	}
+
+	response = &http.Response{Body: io.NopCloser(strings.NewReader("{"))}
+	_, err = getNextPageCustomDataForV3(nil, response)
+	if err == nil {
+		t.Fatalf("expected unmarshal error for malformed JSON")
+	}
+}

--- a/backend/plugins/jira/tasks/shared.go
+++ b/backend/plugins/jira/tasks/shared.go
@@ -18,11 +18,42 @@ limitations under the License.
 package tasks
 
 import (
+	"net/http"
+	"strings"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/models/domainlayer/ticket"
 	"github.com/apache/incubator-devlake/helpers/pluginhelper/api"
-	"net/http"
+	"github.com/apache/incubator-devlake/plugins/jira/models"
 )
+
+const jiraSearchEndpointV2 = "api/2/search"
+const jiraSearchEndpointV3 = "api/3/search/jql"
+
+func isJiraCloudDeployment(deploymentType models.DeploymentType) bool {
+	return strings.EqualFold(string(deploymentType), string(models.DeploymentCloud))
+}
+
+func getJiraSearchEndpoint(deploymentType models.DeploymentType) string {
+	if isJiraCloudDeployment(deploymentType) {
+		return jiraSearchEndpointV3
+	}
+	// Jira Server and Data Center continue using v2 search for compatibility.
+	return jiraSearchEndpointV2
+}
+
+func buildJiraV3SearchRequestBody(jql string, reqData *api.RequestData) map[string]interface{} {
+	body := map[string]interface{}{
+		"jql":        jql,
+		"maxResults": reqData.Pager.Size,
+		"expand":     "changelog",
+		"fields":     "*all",
+	}
+	if nextPageToken, ok := reqData.CustomData.(string); ok && nextPageToken != "" {
+		body["nextPageToken"] = nextPageToken
+	}
+	return body
+}
 
 func GetTotalPagesFromResponse(res *http.Response, args *api.ApiCollectorArgs) (int, errors.Error) {
 	body := &JiraPagination{}

--- a/config-ui/src/plugins/register/jira/connection-fields/auth.test.ts
+++ b/config-ui/src/plugins/register/jira/connection-fields/auth.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Regex constants (mirror exactly what auth.tsx defines)
+// ---------------------------------------------------------------------------
+const JIRA_CLOUD_REGEX   = /^https:\/\/\w+\.atlassian\.net\/rest\/$/;
+const JIRA_GATEWAY_REGEX = /^https:\/\/api\.atlassian\.com\/ex\/jira\/[^/]+\/rest\/$/;
+
+// ---------------------------------------------------------------------------
+// Endpoint builder (mirrors handleChangeCloudId in auth.tsx)
+// ---------------------------------------------------------------------------
+function buildGatewayEndpoint(cloudId: string): string {
+  return cloudId ? `https://api.atlassian.com/ex/jira/${cloudId}/rest/` : '';
+}
+
+// ---------------------------------------------------------------------------
+// Cloud ID extractor (mirrors the load-time useEffect in auth.tsx)
+// ---------------------------------------------------------------------------
+function extractCloudId(endpoint: string): string | null {
+  const match = endpoint.match(/\/ex\/jira\/([^/]+)\//);
+  return match ? match[1] : null;
+}
+
+// ---------------------------------------------------------------------------
+// JIRA_GATEWAY_REGEX tests
+// ---------------------------------------------------------------------------
+describe('JIRA_GATEWAY_REGEX', () => {
+  it('accepts a valid gateway URL with UUID Cloud ID', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://api.atlassian.com/ex/jira/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rest/')).toBe(true);
+  });
+
+  it('accepts a valid gateway URL with short Cloud ID', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://api.atlassian.com/ex/jira/mycloud123/rest/')).toBe(true);
+  });
+
+  it('rejects gateway URL missing trailing slash', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://api.atlassian.com/ex/jira/abc123/rest')).toBe(false);
+  });
+
+  it('rejects gateway URL missing /rest/', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://api.atlassian.com/ex/jira/abc123/')).toBe(false);
+  });
+
+  it('rejects standard Jira Cloud URL', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://mycompany.atlassian.net/rest/')).toBe(false);
+  });
+
+  it('rejects Jira Server URL', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://jira.mycompany.com/rest/')).toBe(false);
+  });
+
+  it('rejects gateway URL with extra path segment after /rest/', () => {
+    expect(JIRA_GATEWAY_REGEX.test('https://api.atlassian.com/ex/jira/abc123/rest/extra/')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JIRA_CLOUD_REGEX regression tests — must not break existing behaviour
+// ---------------------------------------------------------------------------
+describe('JIRA_CLOUD_REGEX (regression)', () => {
+  it('accepts a standard Jira Cloud URL', () => {
+    expect(JIRA_CLOUD_REGEX.test('https://mycompany.atlassian.net/rest/')).toBe(true);
+  });
+
+  it('rejects gateway URL', () => {
+    expect(JIRA_CLOUD_REGEX.test('https://api.atlassian.com/ex/jira/abc123/rest/')).toBe(false);
+  });
+
+  it('rejects Jira Server URL', () => {
+    expect(JIRA_CLOUD_REGEX.test('https://jira.mycompany.com/rest/')).toBe(false);
+  });
+
+  it('rejects cloud URL missing trailing slash', () => {
+    expect(JIRA_CLOUD_REGEX.test('https://mycompany.atlassian.net/rest')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildGatewayEndpoint tests
+// ---------------------------------------------------------------------------
+describe('buildGatewayEndpoint', () => {
+  it('builds the correct URL from a UUID Cloud ID', () => {
+    expect(buildGatewayEndpoint('a1b2c3d4-e5f6-7890-abcd-ef1234567890')).toBe(
+      'https://api.atlassian.com/ex/jira/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rest/',
+    );
+  });
+
+  it('builds the correct URL from a short Cloud ID', () => {
+    expect(buildGatewayEndpoint('mycloud123')).toBe(
+      'https://api.atlassian.com/ex/jira/mycloud123/rest/',
+    );
+  });
+
+  it('returns empty string for empty Cloud ID', () => {
+    expect(buildGatewayEndpoint('')).toBe('');
+  });
+
+  it('produced URL matches JIRA_GATEWAY_REGEX', () => {
+    const url = buildGatewayEndpoint('test-cloud-id');
+    expect(JIRA_GATEWAY_REGEX.test(url)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCloudId tests — verifies the edit-mode useEffect can pre-fill Cloud ID
+// ---------------------------------------------------------------------------
+describe('extractCloudId', () => {
+  it('extracts UUID Cloud ID from a saved gateway endpoint', () => {
+    expect(extractCloudId('https://api.atlassian.com/ex/jira/a1b2c3d4-e5f6-7890-abcd-ef1234567890/rest/')).toBe(
+      'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+    );
+  });
+
+  it('extracts short Cloud ID', () => {
+    expect(extractCloudId('https://api.atlassian.com/ex/jira/mycloud123/rest/')).toBe('mycloud123');
+  });
+
+  it('returns null for a standard cloud URL', () => {
+    expect(extractCloudId('https://mycompany.atlassian.net/rest/')).toBeNull();
+  });
+
+  it('round-trips: build then extract returns original Cloud ID', () => {
+    const id = 'round-trip-id-123';
+    expect(extractCloudId(buildGatewayEndpoint(id))).toBe(id);
+  });
+});

--- a/config-ui/src/plugins/register/jira/connection-fields/auth.tsx
+++ b/config-ui/src/plugins/register/jira/connection-fields/auth.tsx
@@ -23,8 +23,10 @@ import { Radio, Input } from 'antd';
 import { Block, ExternalLink } from '@/components';
 import { DOC_URL } from '@/release';
 
-const JIRA_CLOUD_REGEX = /^https:\/\/\w+.atlassian.net\/rest\/$/;
+const JIRA_CLOUD_REGEX   = /^https:\/\/\w+\.atlassian\.net\/rest\/$/;
+const JIRA_GATEWAY_REGEX = /^https:\/\/api\.atlassian\.com\/ex\/jira\/[^/]+\/rest\/$/;
 
+type JiraVersion = 'cloud' | 'gateway' | 'server';
 type Method = 'BasicAuth' | 'AccessToken';
 
 interface Props {
@@ -37,10 +39,17 @@ interface Props {
 }
 
 export const Auth = ({ type, initialValues, values, setValues, setErrors }: Props) => {
-  const [version, setVersion] = useState('cloud');
+  const [version, setVersion] = useState<JiraVersion>('cloud');
+  const [cloudId, setCloudId] = useState('');
 
   useEffect(() => {
-    if (initialValues.endpoint && !JIRA_CLOUD_REGEX.test(initialValues.endpoint)) {
+    if (!initialValues.endpoint) return;
+    if (JIRA_GATEWAY_REGEX.test(initialValues.endpoint)) {
+      setVersion('gateway');
+      // Extract the Cloud ID from the saved endpoint so the field pre-fills on edit
+      const match = initialValues.endpoint.match(/\/ex\/jira\/([^/]+)\//);
+      if (match) setCloudId(match[1]);
+    } else if (!JIRA_CLOUD_REGEX.test(initialValues.endpoint)) {
       setVersion('server');
     }
   }, [initialValues.endpoint]);
@@ -73,22 +82,32 @@ export const Auth = ({ type, initialValues, values, setValues, setErrors }: Prop
   }, [values]);
 
   const handleChangeVersion = (e: RadioChangeEvent) => {
-    const version = e.target.value;
-
+    const v = e.target.value as JiraVersion;
+    setCloudId('');
     setValues({
       endpoint: '',
-      authMethod: 'BasicAuth',
+      // Gateway always uses AccessToken (scoped API token); others default to BasicAuth
+      authMethod: v === 'gateway' ? 'AccessToken' : 'BasicAuth',
       username: undefined,
       password: undefined,
       token: undefined,
     });
-
-    setVersion(version);
+    setVersion(v);
   };
 
   const handleChangeEndpoint = (e: React.ChangeEvent<HTMLInputElement>) => {
     setValues({
       endpoint: e.target.value,
+    });
+  };
+
+  const handleChangeCloudId = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const id = e.target.value.trim();
+    setCloudId(id);
+    // Auto-construct the gateway endpoint from the Cloud ID so the user never
+    // has to type the full URL manually.
+    setValues({
+      endpoint: id ? `https://api.atlassian.com/ex/jira/${id}/rest/` : '',
     });
   };
 
@@ -124,32 +143,64 @@ export const Auth = ({ type, initialValues, values, setValues, setErrors }: Prop
       <Block title="Jira Version" required>
         <Radio.Group value={version} onChange={handleChangeVersion}>
           <Radio value="cloud">Jira Cloud</Radio>
+          <Radio value="gateway">Jira Cloud (Atlassian API Gateway)</Radio>
           <Radio value="server">Jira Server / Jira Data Center</Radio>
         </Radio.Group>
 
-        <Block
-          style={{ marginTop: 8, marginBottom: 0 }}
-          title="Endpoint URL"
-          description={
-            <>
-              {version === 'cloud'
-                ? 'Provide the Jira instance API endpoint. For Jira Cloud, e.g. https://your-company.atlassian.net/rest/. Please note that the endpoint URL should end with /.'
-                : ''}
-              {version === 'server'
-                ? 'Provide the Jira instance API endpoint. For Jira Server / Jira Data Center, e.g. https://jira.your-company.com/rest/. Please note that the endpoint URL should end with /.'
-                : ''}
-            </>
-          }
-          required
-        >
-          <Input
-            style={{ width: 386 }}
-            placeholder="Your Endpoint URL"
-            value={values.endpoint}
-            onChange={handleChangeEndpoint}
-          />
-        </Block>
+        {version !== 'gateway' && (
+          <Block
+            style={{ marginTop: 8, marginBottom: 0 }}
+            title="Endpoint URL"
+            description={
+              <>
+                {version === 'cloud'
+                  ? 'Provide the Jira instance API endpoint. For Jira Cloud, e.g. https://your-company.atlassian.net/rest/. Please note that the endpoint URL should end with /.'
+                  : ''}
+                {version === 'server'
+                  ? 'Provide the Jira instance API endpoint. For Jira Server / Jira Data Center, e.g. https://jira.your-company.com/rest/. Please note that the endpoint URL should end with /.'
+                  : ''}
+              </>
+            }
+            required
+          >
+            <Input
+              style={{ width: 386 }}
+              placeholder="Your Endpoint URL"
+              value={values.endpoint}
+              onChange={handleChangeEndpoint}
+            />
+          </Block>
+        )}
       </Block>
+
+      {version === 'gateway' && (
+        <>
+          <Block
+            title="Cloud ID"
+            description="Your Atlassian Cloud ID. Find it at admin.atlassian.com → Settings → Organisation."
+            required
+          >
+            <Input
+              style={{ width: 386 }}
+              placeholder="e.g. a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+              value={cloudId}
+              onChange={handleChangeCloudId}
+            />
+          </Block>
+          <Block
+            title="Scoped API Token"
+            description="API token for your Atlassian Managed Service Account with Jira read scopes."
+            required
+          >
+            <Input.Password
+              style={{ width: 386 }}
+              placeholder={type === 'update' ? '********' : 'Your Scoped API Token'}
+              value={values.token}
+              onChange={handleChangeToken}
+            />
+          </Block>
+        </>
+      )}
 
       {version === 'cloud' && (
         <>


### PR DESCRIPTION
This pull request modernizes and clarifies the Jira Search API usage in the plugin, introducing a clear separation between Jira Cloud and non-Cloud (Server/Data Center) deployments. It standardizes endpoint selection, request formatting, and pagination, and adds comprehensive tests and documentation for the migration. The changes improve maintainability, compatibility, and future extensibility of the Jira plugin.

**Jira Search API migration and endpoint selection:**

* Introduced `getJiraSearchEndpoint` and related helpers in `shared.go` to select the correct search endpoint (`api/3/search/jql` for Cloud with POST body, `api/2/search` for non-Cloud with GET query) based on deployment type, and refactored all collectors to use these helpers. [[1]](diffhunk://#diff-9c17ac288ec03b3416b5138130a441484b1ee22976ee858a029e41bd6ef53ea8R21-R57) [[2]](diffhunk://#diff-63f9c67746a5f69337461dcf96e19c32fd63aacddd7c7bb60c05c7a3c11ed969L85-R87) [[3]](diffhunk://#diff-47ec8ec3295c2df75a29ccda1277b07c5c2468f3c3ecc83967320e152a988dc7L98-R100) [[4]](diffhunk://#diff-a28ec3e7aa74a2fd85fa4125d466f6e3792847d8c98249c9ff0ccfd8fbd8d8b1L205-R215)
* Added `buildJiraV3SearchRequestBody` for Cloud search requests, ensuring the correct JSON payload is sent, and updated collectors to use this for POST requests. [[1]](diffhunk://#diff-9c17ac288ec03b3416b5138130a441484b1ee22976ee858a029e41bd6ef53ea8R21-R57) [[2]](diffhunk://#diff-63f9c67746a5f69337461dcf96e19c32fd63aacddd7c7bb60c05c7a3c11ed969L155-R184) [[3]](diffhunk://#diff-47ec8ec3295c2df75a29ccda1277b07c5c2468f3c3ecc83967320e152a988dc7L215-R223)
* Ensured correct handling of user lookup and time zone retrieval for non-Cloud deployments, improving compatibility.

**Testing and documentation:**

* Added comprehensive unit tests for endpoint selection, request body construction, and pagination logic in `search_api_test.go`, and expanded tests for epic collector endpoint selection. [[1]](diffhunk://#diff-196540b20629582dfe1b70baddd0fa850efbde62a60dbe7d7d233f8352ae3ed0R1-R117) [[2]](diffhunk://#diff-a28ec3e7aa74a2fd85fa4125d466f6e3792847d8c98249c9ff0ccfd8fbd8d8b1L181-R206)
* Introduced `SEARCH_API_MIGRATION.md` to document the migration, endpoint differences, request/pagination formats, and compatibility considerations.

**Authentication and connection improvements:**

* Refined connection testing logic to avoid misleading hints for Atlassian API Gateway endpoints when `/rest/` is missing, and added tests for both Bearer token and BasicAuth scenarios. [[1]](diffhunk://#diff-688e17d94abebb55f9ca9bcca2b61dfc13f5cf8812ec86c502f5640aed293b6eL61-R64) [[2]](diffhunk://#diff-7f35cdd4126695e57475f7c6e7b5cc81cba60b8a1c1e483e27d918950ff8e181R1-R144)

These changes provide a robust foundation for handling Jira's evolving APIs while maintaining backward compatibility and improving developer clarity.