### PR TITLE
fix(gitlab): add missing commit_updated_at column used by the MR incremental filter

### DIFF
--- a/backend/plugins/gitlab/models/migrationscripts/20260812_add_mr_commit_updated_at.go
+++ b/backend/plugins/gitlab/models/migrationscripts/20260812_add_mr_commit_updated_at.go
@@ -1,0 +1,50 @@
+/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package migrationscripts
+
+import (
+	"time"
+
+	"github.com/apache/incubator-devlake/core/context"
+	"github.com/apache/incubator-devlake/core/errors"
+	"github.com/apache/incubator-devlake/core/plugin"
+)
+
+var _ plugin.MigrationScript = (*addMrCommitUpdatedAt)(nil)
+
+type mrCommitUpdatedAt struct {
+	CommitUpdatedAt *time.Time
+}
+
+func (mrCommitUpdatedAt) TableName() string {
+	return "_tool_gitlab_merge_requests"
+}
+
+type addMrCommitUpdatedAt struct{}
+
+func (*addMrCommitUpdatedAt) Up(basicRes context.BasicRes) errors.Error {
+	return errors.Convert(basicRes.GetDal().AutoMigrate(&mrCommitUpdatedAt{}))
+}
+
+func (*addMrCommitUpdatedAt) Version() uint64 {
+	return 20260812000001
+}
+
+func (*addMrCommitUpdatedAt) Name() string {
+	return "gitlab: add commit_updated_at to merge requests"
+}

--- a/backend/plugins/gitlab/models/migrationscripts/register.go
+++ b/backend/plugins/gitlab/models/migrationscripts/register.go
@@ -54,5 +54,6 @@ func All() []plugin.MigrationScript {
 		new(addIsChildToPipelines240906),
 		new(addPrSizeExcludedFileExtensions),
 		new(addAdditionsDeletionsToMr),
+		new(addMrCommitUpdatedAt),
 	}
 }

--- a/backend/plugins/gitlab/models/mr.go
+++ b/backend/plugins/gitlab/models/mr.go
@@ -53,6 +53,11 @@ type GitlabMergeRequest struct {
 	Component        string `gorm:"type:varchar(255)"`
 	Additions        *int   `gorm:"comment:Lines added in this MR diff only"`
 	Deletions        *int   `gorm:"comment:Lines deleted in this MR diff only"`
+	// CommitUpdatedAt holds the most recent authored date among the commits of this MR.
+	// GitLab does not bump `updated_at` for every push (e.g. force-pushes), so this
+	// timestamp is used in addition to GitlabUpdatedAt to detect MRs that changed
+	// during incremental collection.
+	CommitUpdatedAt *time.Time `gorm:"comment:Latest authored date of the commits belonging to this MR"`
 	common.NoPKModel
 }
 

--- a/backend/plugins/gitlab/tasks/mr_commit_extractor.go
+++ b/backend/plugins/gitlab/tasks/mr_commit_extractor.go
@@ -104,7 +104,37 @@ func ExtractApiMergeRequestsCommits(subtaskCtx plugin.SubTaskContext) errors.Err
 		return err
 	}
 
-	return extractor.Execute()
+	if err := extractor.Execute(); err != nil {
+		return err
+	}
+
+	return updateMrCommitUpdatedAt(subtaskCtx)
+}
+
+// updateMrCommitUpdatedAt refreshes `_tool_gitlab_merge_requests.commit_updated_at` with the
+// latest authored date of the MR's commits. GitLab does not always bump the MR's own
+// `updated_at` when commits are pushed (e.g. force-pushes), so subtasks collecting
+// MR sub-entities incrementally would otherwise skip those MRs.
+func updateMrCommitUpdatedAt(subtaskCtx plugin.SubTaskContext) errors.Error {
+	data := subtaskCtx.GetData().(*GitlabTaskData)
+	return subtaskCtx.GetDal().Exec(`
+		UPDATE _tool_gitlab_merge_requests AS gmr
+		SET commit_updated_at = (
+			SELECT MAX(gmc.commit_authored_date)
+			FROM _tool_gitlab_mr_commits gmc
+			WHERE gmc.connection_id = gmr.connection_id
+			  AND gmc.merge_request_id = gmr.gitlab_id
+		)
+		WHERE gmr.connection_id = ?
+		  AND gmr.project_id = ?
+		  AND EXISTS (
+			SELECT 1
+			FROM _tool_gitlab_mr_commits gmc
+			WHERE gmc.connection_id = gmr.connection_id
+			  AND gmc.merge_request_id = gmr.gitlab_id
+		  )`,
+		data.Options.ConnectionId, data.Options.ProjectId,
+	)
 }
 
 // Convert the API response to our DB model instance

--- a/backend/plugins/gitlab/tasks/shared.go
+++ b/backend/plugins/gitlab/tasks/shared.go
@@ -198,7 +198,8 @@ func GetMergeRequestsIterator(taskCtx plugin.SubTaskContext, apiCollector *api.S
 			// Filter by the LATER of gitlab_updated_at or commit_updated_at.
 			// Using only gitlab_updated_at misses MRs where new commits were pushed
 			// without the MR itself being updated (e.g. force-pushed commits).
-			// COALESCE handles MRs with no recorded commit_updated_at.
+			// commit_updated_at is maintained by the MR commit extractor and is NULL
+			// for MRs without collected commits, hence the COALESCE.
 			clauses = append(clauses, dal.Where(
 				`GREATEST(gmr.gitlab_updated_at, COALESCE(gmr.commit_updated_at, gmr.gitlab_updated_at)) > ?`,
 				*apiCollector.GetSince(),


### PR DESCRIPTION
# fix(gitlab): add missing `commit_updated_at` column used by the MR incremental filter

## Summary

#8959 changed `GetMergeRequestsIterator` (`backend/plugins/gitlab/tasks/shared.go`) to
filter merge requests by

```sql
GREATEST(gmr.gitlab_updated_at, COALESCE(gmr.commit_updated_at, gmr.gitlab_updated_at)) > ?
```

but `commit_updated_at` does not exist on `_tool_gitlab_merge_requests`. There is no field
on the `GitlabMergeRequest` model, no migration script, and no code writing the value —
the only occurrences of the identifier in the whole repository are the three lines added
by that PR.

Consequently every **incremental** run of `Collect MR Notes` — the only caller passing a
stateful collector, `mr_commit_collector.go` passes `nil` — fails with:

```
subtask Collect MR Notes ended unexpectedly
  Error 1054 (42S22): Unknown column 'gmr.commit_updated_at' in 'where clause'
```

## Approach

Rather than reverting #8959, this PR makes the intended behaviour actually work:

* add `CommitUpdatedAt *time.Time` to `GitlabMergeRequest`
* add migration script `20260812_add_mr_commit_updated_at.go` (registered in `register.go`)
* maintain the column in `ExtractApiMergeRequestsCommits`: after extraction it is set to
  the latest `commit_authored_date` of the MR's commits, scoped to the current
  connection/project
* the filter in `GetMergeRequestsIterator` is left as introduced by #8959 and now resolves
  against a real column, so MRs that received new commits without their own `updated_at`
  being bumped (e.g. force-pushes) are picked up again

## Testing

* `make migration-script-lint`
* `go test ./plugins/gitlab/e2e/ -run TestGitlabMrCommitDataFlow` — green on **MySQL 8**
  and **PostgreSQL 14**; the extractor's `UPDATE ... SET ... = (SELECT MAX(...))` and the
  `GREATEST`/`COALESCE` filter behave identically on both engines
* `go test ./plugins/ -run TestTableInfo`

## Notes

The `GREATEST(...)` expression returns `NULL` on MySQL when `gitlab_updated_at` is `NULL`,
so such MRs stay excluded — same as before #8959, where `gitlab_updated_at > ?` also
evaluated to `NULL`. No behaviour change there.

