### PR TITLE
[Jira] Fix false-positive "field name is duplicated" warnings when multiple boards share a connection

### DIFF
--- a/backend/plugins/jira/tasks/epic_extractor.go
+++ b/backend/plugins/jira/tasks/epic_extractor.go
@@ -103,8 +103,11 @@ func getIssueFieldMap(db dal.Dal, connectionId uint64, logger log.Logger) (map[s
 	}
 	issueFieldMap := make(map[string]models.JiraIssueField)
 	for _, v := range allIssueFields {
-		if _, ok := issueFieldMap[v.Name]; ok {
-			logger.Warn(nil, "filed name %s is duplicated", v.Name)
+		if existing, ok := issueFieldMap[v.Name]; ok {
+			// Same field can appear on multiple boards; only warn on a real name collision.
+			if existing.ID != v.ID {
+				logger.Warn(nil, "field name %s is duplicated (IDs: %s, %s)", v.Name, existing.ID, v.ID)
+			}
 			if v.SchemaType == "user" {
 				issueFieldMap[v.Name] = v
 			}


### PR DESCRIPTION
closes: #9052

Summary
getIssueFieldMap() logged a "field name is duplicated" warning every time
a field name appeared more than once in _tool_jira_issue_fields, even when
it was the exact same field just present on multiple boards. On a
connection with several boards this produced hundreds of false-positive
warnings per pipeline run.

Root cause
_tool_jira_issue_fields stores one row per (connection_id, board_id, field
id), so a field present on N boards produces N rows with the same ID but
the same Name. getIssueFieldMap() warned on any second occurrence of a
Name without checking whether the ID actually differed, so board
recurrence was misread as a name collision.

Fix
Only warn when two different field IDs share the same display name, which
is the actual ambiguous case. The existing SchemaType == "user" override
is unchanged. Also fixed a typo in the log message: "filed name" -> "field
name".