### PR TITLE
chore(deps): bump CI Go bootstrap to 1.26.6

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,7 +34,7 @@ jobs:
         run: git config --global --add safe.directory $(pwd)
       - name: Install libgit2 1.5 for git2go v34
         run: backend/scripts/install-libgit2.sh
-      - name: Install Go 1.26.2
+      - name: Install Go 1.26.6
         run: backend/scripts/install-go.sh
       - name: Install mockery 3.7.2
         run: backend/scripts/install-mockery.sh

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -52,7 +52,7 @@ jobs:
       - run: git config --global --add safe.directory $(pwd)
       - name: Install libgit2 1.5 for git2go v34
         run: backend/scripts/install-libgit2.sh
-      - name: Install Go 1.26.2
+      - name: Install Go 1.26.6
         run: backend/scripts/install-go.sh
       - name: Build Python
         run: |
@@ -96,7 +96,7 @@ jobs:
       - run: git config --global --add safe.directory $(pwd)
       - name: Install libgit2 1.5 for git2go v34
         run: backend/scripts/install-libgit2.sh
-      - name: Install Go 1.26.2
+      - name: Install Go 1.26.6
         run: backend/scripts/install-go.sh
       - name: Build Python
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
       run: git config --global --add safe.directory $(pwd)
     - name: Install libgit2 1.5 for git2go v34
       run: backend/scripts/install-libgit2.sh
-    - name: Install Go 1.26.2
+    - name: Install Go 1.26.6
       run: backend/scripts/install-go.sh
     - name: Install mockery 3.7.2
       run: backend/scripts/install-mockery.sh

--- a/backend/scripts/install-go.sh
+++ b/backend/scripts/install-go.sh
@@ -17,7 +17,7 @@
 
 set -eu
 
-GO_VERSION=1.26.2
+GO_VERSION=1.26.6
 INSTALL_DIR=/opt/go/$GO_VERSION
 GO_BIN=$INSTALL_DIR/bin/go
 
@@ -54,11 +54,11 @@ fi
 case "$(uname -m)" in
     x86_64|amd64)
         archive_name=go${GO_VERSION}.linux-amd64.tar.gz
-        archive_sha256=990e6b4bbba816dc3ee129eaeaf4b42f17c2800b88a2166c265ac1a200262282
+        archive_sha256=708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89
         ;;
     aarch64|arm64)
         archive_name=go${GO_VERSION}.linux-arm64.tar.gz
-        archive_sha256=c958a1fe1b361391db163a485e21f5f228142d6f8b584f6bef89b26f66dc5b23
+        archive_sha256=d0507e9e9d7fe012aae570108cbd76c15de879e17130ab8cb90d4d7445cb1f2e
         ;;
     *)
         echo "unsupported architecture: $(uname -m)" >&2


### PR DESCRIPTION
### Summary

Upgrade the job-local Go bootstrap from 1.26.2 to 1.26.6 in the Apache CI
workflows. Go 1.26.6 contains the fixes for the standard-library advisories
reported against earlier 1.26 patch releases.

The change intentionally keeps `backend/go.mod` and all `golang:1.26-*` image
tags on the floating 1.26 minor line. It only changes:

- `backend/scripts/install-go.sh`: version and official Linux amd64/arm64
  SHA-256 checksums;
- the four visible bootstrap step names in the lint, unit-test, MySQL E2E and
  PostgreSQL E2E jobs.

### Security verification

`govulncheck` v1.7.0 was run with Go 1.26.6 against the complete backend package
graph after mock generation. It reports **zero reachable standard-library
findings**. Remaining findings belong to Go modules and are handled separately;
this PR does not mix module upgrades into the toolchain patch.

Both Linux archive checksums were verified against the official Go download
catalog and the downloaded archives. In the unchanged
`mericodev/lake-builder:latest` image, the installer was tested from the image's
Go 1.20.4 baseline:

1. install Go 1.26.6 into `/opt/go/1.26.6`;
2. verify `go version go1.26.6 linux/amd64`;
3. run the installer again and verify the no-op path.

### Verification

- `sh -n backend/scripts/install-go.sh`
- `actionlint` on all three changed workflows
- installer checksum/install/idempotency test in
  `mericodev/lake-builder:latest`
- `make mock` — 64 generated mock files
- `make unit-test` — green, including Azure DevOps 8 passed/1 skipped and
  pydevlake 10 passed
- `make e2e-test-go-plugins` and `make e2e-test` against isolated MySQL 8 — green
- `make e2e-test-go-plugins` and `make e2e-test` against isolated PostgreSQL
  14.2 — green
- `govulncheck ./...` with Go 1.26.6 — 0 reachable standard-library findings

### Builder image

The published builder image still contains Go 1.20.4. The job-local,
checksum-verified bootstrap keeps the affected jobs independent of a builder
republish; refreshing the image remains a separate maintainer follow-up.
