### PR TITLE
build(ci): consolidate database, builder and mockery pins

### DIFF
--- a/.github/workflows/build-builder.yml
+++ b/.github/workflows/build-builder.yml
@@ -23,10 +23,10 @@ on:
 jobs:
   build-lake:
     name: Build lake-builder image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v6
-    - uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+    - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
         password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -36,7 +36,7 @@ jobs:
         run: backend/scripts/install-libgit2.sh
       - name: Install Go 1.26.6
         run: backend/scripts/install-go.sh
-      - name: Install mockery 3.7.2
+      - name: Install mockery 3.7.4
         run: backend/scripts/install-mockery.sh
       - name: Cache golangci-lint
         id: cache-golangci-lint

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       db:
-        image: mysql:8
+        image: mysql:8.4.11
         env:
           MYSQL_DATABASE: lake
           MYSQL_USER: merico
@@ -84,7 +84,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       db:
-        image: postgres:14.2
+        image: postgres:18.4
         env:
           POSTGRES_DB: lake
           POSTGRES_USER: merico

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,7 @@ jobs:
       run: backend/scripts/install-libgit2.sh
     - name: Install Go 1.26.6
       run: backend/scripts/install-go.sh
-    - name: Install mockery 3.7.2
+    - name: Install mockery 3.7.4
       run: backend/scripts/install-mockery.sh
     - name: Build Python
       run: |

--- a/backend/Dockerfile.local
+++ b/backend/Dockerfile.local
@@ -47,7 +47,7 @@ RUN mkdir -p /tmp/build && cd /tmp/build && \
     make -j$(nproc) install && \
     ldconfig
 
-RUN go install github.com/vektra/mockery/v3@v3.7.2
+RUN go install github.com/vektra/mockery/v3@v3.7.4
 RUN go install github.com/swaggo/swag/cmd/swag@v1.16.6
 
 WORKDIR /app

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -27,7 +27,7 @@ PYTHON_DIR ?= "./python"
 all: build
 
 go-dep:
-	go install github.com/vektra/mockery/v3@v3.7.2
+	go install github.com/vektra/mockery/v3@v3.7.4
 	go install github.com/swaggo/swag/cmd/swag@v1.16.6
 	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 

--- a/backend/scripts/install-mockery.sh
+++ b/backend/scripts/install-mockery.sh
@@ -17,7 +17,7 @@
 
 set -eu
 
-MOCKERY_VERSION=3.7.2
+MOCKERY_VERSION=3.7.4
 INSTALL_DIR=/opt/mockery/$MOCKERY_VERSION
 MOCKERY_BIN=$INSTALL_DIR/mockery
 
@@ -61,11 +61,11 @@ fi
 case "$(uname -m)" in
     x86_64|amd64)
         archive_name=mockery_${MOCKERY_VERSION}_Linux_x86_64.tar.gz
-        archive_sha256=db819b897de126634cefeb3773a3b76eea7769c718f0e5e62e968ab00add12c6
+        archive_sha256=d5eef52e238a4262b78ab5a93811826a8bfcff7b0128133c6597e3bf2f0f7337
         ;;
     aarch64|arm64)
         archive_name=mockery_${MOCKERY_VERSION}_Linux_arm64.tar.gz
-        archive_sha256=27141b83d8bccc29d66ed91093da69604b320d417bd562d819c8b0372f1444ad
+        archive_sha256=fe591f9ef5ada76c3dee4b8f451aad6748d002e9713fab4bad26b194ff826c4b
         ;;
     *)
         echo "unsupported architecture: $(uname -m)" >&2

--- a/devops/deployment/k8s/k8s-deploy.yaml
+++ b/devops/deployment/k8s/k8s-deploy.yaml
@@ -63,7 +63,7 @@ spec:
     spec:
       containers:
         - name: mysql
-          image: mysql:8
+          image: mysql:8.4.11
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3306

--- a/devops/docker/lake-builder/Dockerfile
+++ b/devops/docker/lake-builder/Dockerfile
@@ -64,7 +64,7 @@ RUN mv /root/go /go &&\
 
 # Install Golang Tools
 RUN export GOPATH=/go &&  \
-    go install github.com/vektra/mockery/v3@v3.7.2 &&  \
+    go install github.com/vektra/mockery/v3@v3.7.4 &&  \
     go install github.com/swaggo/swag/cmd/swag@v1.16.1
 
 # Golang Env


### PR DESCRIPTION
### Summary

This PR consolidates CI and deployment pins that had drifted away from the versions DevLake is actually developed and operated against. It replaces floating database image tags in the E2E workflow and the Kubernetes sample manifest, refreshes the builder-image publish workflow, and lifts every mockery installation site to a single current version.

There are **no Go module changes, no schema or migration-script changes, no API changes and no frontend changes**. Nothing here alters product behaviour: the diff is limited to CI workflows, the Kubernetes sample manifest, the builder images and the mockery bootstrap.

<details>
<summary>9 changed files, +13 / −13</summary>

```
.github/workflows/build-builder.yml
.github/workflows/golangci-lint.yml
.github/workflows/test-e2e.yml
.github/workflows/test.yml
backend/Dockerfile.local
backend/Makefile
backend/scripts/install-mockery.sh
devops/deployment/k8s/k8s-deploy.yaml
devops/docker/lake-builder/Dockerfile
```

</details>

---

### 1. `build(ci): pin active database images`

| File | Before | After | Rationale |
|---|---|---|---|
| `.github/workflows/test-e2e.yml` | `mysql:8` | `mysql:8.4.11` | Floating major tag; the active dev/remote E2E stacks run 8.4.11. |
| `.github/workflows/test-e2e.yml` | `postgres:14.2` | `postgres:18.4` | Four majors behind the version DevLake is operated on. |
| `devops/deployment/k8s/k8s-deploy.yaml` | `mysql:8` | `mysql:8.4.11` | Same floating tag in the sample deployment. |

Historical artefacts under `devops/releases/**` are intentionally left untouched.

### 2. `ci(builder): refresh runner and login action`

| File | Before | After | Rationale |
|---|---|---|---|
| `build-builder.yml` | `runs-on: ubuntu-20.04` | `ubuntu-24.04` | `ubuntu-20.04` is retired on GitHub-hosted runners. |
| `build-builder.yml` | `docker/login-action@f054a8b…` | `docker/login-action@dbcb8138…` `# v4.6.0` | The pinned commit dates from 2021-06-22. Still an immutable SHA, now with a version comment. Same action, so no change in terms of the ASF allowed-actions policy. |

Buildx was evaluated and deliberately **not** introduced: the workflow's direct `docker build` has no concrete need for it, and mixing that in would hide a build-system change behind a pin refresh.

### 3. `build(deps): bump mockery to 3.7.4`

Follow-up to #9029, which introduced mockery v3.7.2. All active installation sites move in lockstep so the CI bootstrap, the Makefile target and the builder images cannot drift apart:

| File | Site |
|---|---|
| `.github/workflows/test.yml` | bootstrap step before the unit tests |
| `.github/workflows/golangci-lint.yml` | bootstrap step before `make mock` in the lint job |
| `backend/scripts/install-mockery.sh` | `MOCKERY_VERSION` + both release SHA-256 sums |
| `backend/Makefile` | `go-dep` target |
| `backend/Dockerfile.local` | local builder image |
| `devops/docker/lake-builder/Dockerfile` | published builder image |

The two pinned archive checksums were verified against the official `vektra/mockery` v3.7.4 `checksum.txt`:

```
d5eef52e238a4262b78ab5a93811826a8bfcff7b0128133c6597e3bf2f0f7337  mockery_3.7.4_Linux_x86_64.tar.gz
fe591f9ef5ada76c3dee4b8f451aad6748d002e9713fab4bad26b194ff826c4b  mockery_3.7.4_Linux_arm64.tar.gz
```

`make mock` under v3.7.4 regenerates all 65 mock files with an identical tree hash, so **no generated code is part of this PR**. The v3 configuration files `.mockery.core.yml` and `.mockery.helpers.yml` are unchanged, as is their required ordering (helper mocks import generated core mocks).

---

### Dropped: the Super-Linter migration

An earlier revision of this PR also migrated `.github/workflows/yaml-lint.yml` from the archived `github/super-linter/slim@v4` to `super-linter/super-linter/slim@…` (v8.7.0). **That commit has been removed.**

The first CI attempt on this branch returned `startup_failure` for the `yaml-lint` workflow, with no jobs started. The cause is the ASF allowed-actions policy: `github/super-linter` is permitted, but the `super-linter/super-linter` organisation is not on the allowlist, so the workflow is rejected before it starts. This repository already carries a precedent for that constraint in `.github/workflows/codespell.yml.action-blocked-by-asf`.

`.github/workflows/yaml-lint.yml` is therefore left **untouched** in this PR. The migration is still worth doing — the `github/super-linter` repository ends at v7 and the maintained continuation is the new namespace — but it needs an ASF INFRA request to allowlist the action first. Happy to file that separately, or to follow whatever route the maintainers prefer.

---

### Validation

- YAML parser over all four changed workflows and the K8s manifest
- `kubectl apply --dry-run=client --validate=false` on the K8s manifest
- `bash -n backend/scripts/install-mockery.sh`
- SHA-256 comparison against the official mockery v3.7.4 release `checksum.txt`
- `make mock` with mockery v3.7.4: 65 files regenerated, **zero diff**
- `make build`: all plugins, mocks, Swagger generation and the server
- `make unit-test-go`: exit code 0, 554 passing packages, no failures

Fork-CI runs, **9/9 green**, covering `builder image`, `lint (go)`, `migration-script-lint`, `unit-test`, `e2e (mysql)`, `e2e (postgres)`, `config-ui`, `check Apache license header` and `check grafana dashboards`:

| Run | Base | Result |
|---|---|---|
| [32739264272](https://github.com/DoDiODev/devlake/actions/runs/32739264272) | on top of #9061 | 9/9 |
| [32741016217](https://github.com/DoDiODev/devlake/actions/runs/32741016217) | on top of plain `main` | 9/9 |

An `e2e (postgres)` job was **added** to the fork-CI harness for this proof, because the previous harness only ran MySQL and therefore never exercised the `postgres:18.4` pin. The builder image is rebuilt from `devops/docker/lake-builder/Dockerfile` on the branch, so both runs also validate the mockery 3.7.4 installation.

### Note on an earlier `Error 1091`

An early fork-CI run of this branch failed in `e2e (mysql)` on `Error 1091` in the Jira `TestMigrationSchema`. That was **not** caused by the MySQL pin: a baseline run without any of these files reproduced it identically. The root cause was the GORM `v1.31` upgrade in #9061 and was fixed there. The run on the plain `main` baseline confirms the `mysql:8.4.11` pin itself is sound.

This PR is **independent of #9061** — it applies cleanly to `main` and is CI-verified on that base.

