### PR TITLE
fix(gh-copilot): trim enterprise/organization slugs to fix connection validation failure

### DIFF
--- a/backend/plugins/gh-copilot/api/connection.go
+++ b/backend/plugins/gh-copilot/api/connection.go
@@ -18,6 +18,8 @@ limitations under the License.
 package api
 
 import (
+	"strings"
+
 	"github.com/apache/incubator-devlake/core/errors"
 	"github.com/apache/incubator-devlake/core/plugin"
 	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
@@ -93,7 +95,7 @@ func validateConnection(connection *models.GhCopilotConnection) errors.Error {
 	if connection == nil {
 		return errors.BadInput.New("connection is required")
 	}
-	if connection.Organization == "" && !connection.HasEnterprise() {
+	if strings.TrimSpace(connection.Organization) == "" && !connection.HasEnterprise() {
 		return errors.BadInput.New("either enterprise or organization is required")
 	}
 	if connection.Token == "" {

--- a/backend/plugins/gh-copilot/api/connection_test.go
+++ b/backend/plugins/gh-copilot/api/connection_test.go
@@ -18,12 +18,62 @@ limitations under the License.
 package api
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	helper "github.com/apache/incubator-devlake/helpers/pluginhelper/api"
 	"github.com/apache/incubator-devlake/plugins/gh-copilot/models"
 )
+
+func decodeBody(t *testing.T, raw string) map[string]interface{} {
+	t.Helper()
+	var body map[string]interface{}
+	if err := json.Unmarshal([]byte(raw), &body); err != nil {
+		t.Fatalf("failed to unmarshal test payload: %v", err)
+	}
+	return body
+}
+
+func TestValidateConnection_EnterpriseSlugOnly_ViaDecode(t *testing.T) {
+	body := decodeBody(t, `{
+		"name": "my-copilot-conn",
+		"endpoint": "https://api.github.com",
+		"organization": "",
+		"enterprise": "my-company",
+		"token": "ghp_example",
+		"rateLimitPerHour": 5000
+	}`)
+
+	connection := &models.GhCopilotConnection{}
+	assert.NoError(t, helper.Decode(body, connection, vld))
+
+	connection.Normalize()
+	assert.Equal(t, "my-company", connection.Enterprise)
+	assert.True(t, connection.HasEnterprise())
+
+	err := validateConnection(connection)
+	assert.NoError(t, err)
+}
+
+func TestValidateConnection_EnterpriseSlugWithWhitespace_ViaDecode(t *testing.T) {
+	body := decodeBody(t, `{
+		"organization": "   ",
+		"enterprise": "  my-company  ",
+		"token": "ghp_example"
+	}`)
+
+	connection := &models.GhCopilotConnection{}
+	assert.NoError(t, helper.Decode(body, connection, vld))
+
+	connection.Normalize()
+	assert.Equal(t, "my-company", connection.Enterprise)
+	assert.Equal(t, "", connection.Organization)
+
+	err := validateConnection(connection)
+	assert.NoError(t, err)
+}
 
 func TestValidateConnection_Success(t *testing.T) {
 	connection := &models.GhCopilotConnection{

--- a/backend/plugins/gh-copilot/models/connection.go
+++ b/backend/plugins/gh-copilot/models/connection.go
@@ -118,4 +118,6 @@ func (connection *GhCopilotConnection) Normalize() {
 	if connection.RateLimitPerHour <= 0 {
 		connection.RateLimitPerHour = DefaultRateLimitPerHour
 	}
+	connection.Organization = strings.TrimSpace(connection.Organization)
+	connection.Enterprise = strings.TrimSpace(connection.Enterprise)
 }

--- a/backend/plugins/gh-copilot/service/connection_test_helper.go
+++ b/backend/plugins/gh-copilot/service/connection_test_helper.go
@@ -64,7 +64,7 @@ func TestConnection(ctx stdctx.Context, br corectx.BasicRes, connection *models.
 	hasOrg := strings.TrimSpace(connection.Organization) != ""
 
 	if !hasEnterprise && !hasOrg {
-		return nil, errors.BadInput.New("either enterprise or organization must be specified")
+		return nil, errors.BadInput.New("either enterprise or organization is required")
 	}
 
 	apiClient, err := helper.NewApiClientFromConnection(ctx, br, connection)

--- a/config-ui/src/api/connection/index.ts
+++ b/config-ui/src/api/connection/index.ts
@@ -56,6 +56,7 @@ export const test = (
       | 'adminApiKey'
       | 'organization'
       | 'organizationId'
+      | 'enterprise'
       | 'customHeaders'
     >
   >,
@@ -79,6 +80,7 @@ export const testOld = (
     | 'adminApiKey'
     | 'organization'
     | 'organizationId'
+    | 'enterprise'
     | 'customHeaders'
   >,
 ): Promise<IConnectionOldTestResult> => request(`/plugins/${plugin}/test`, { method: 'post', data: payload });

--- a/config-ui/src/types/connection.ts
+++ b/config-ui/src/types/connection.ts
@@ -38,6 +38,7 @@ export interface IConnectionAPI {
   rateLimitPerHour?: number;
   organization?: string;
   organizationId?: string;
+  enterprise?: string;
   customHeaders?: ICustomHeader[];
 }
 
@@ -95,5 +96,6 @@ export interface IConnection {
   rateLimitPerHour?: number;
   organization?: string;
   organizationId?: string;
+  enterprise?: string;
   customHeaders?: ICustomHeader[];
 }


### PR DESCRIPTION
### Summary
Fixes #8991 — GitHub Copilot connector's "Test Connection" fails with
either enterprise or organization is required even when a valid Enterprise
Slug is filled in and Organization is left blank.

### Root Cause
validateConnection() checked Organization for emptiness without trimming
it, while HasEnterprise() already trimmed Enterprise. This mismatch meant
a slug with incidental whitespace (e.g. copy/pasted from GitHub) could be
treated as "present" in one check and "empty" in another. A second, separate
copy of this same check in connection_test_helper.go also had a different
error message, showing the two had drifted out of sync.
The frontend's IConnectionAPI/IConnection types were also missing the
enterprise field, and the test/testOld API payload types didn't
include it either — a type-safety gap worth closing alongside this fix.

### Fix
- models/connection.go — trim Organization/Enterprise in Normalize()
- api/connection.go — trim Organization in validateConnection()
- service/connection_test_helper.go — align error message with the above
- api/connection_test.go — added regression tests going through the real
  JSON decode path (hyphenated slug, whitespace-only org)
- config-ui/src/types/connection.ts — added missing enterprise field
- config-ui/src/api/connection/index.ts — added enterprise to payload types