### PR TITLE
server/services: add optional DeleteProject hook for plugin-owned project state

### DIFF
--- a/backend/server/services/project.go
+++ b/backend/server/services/project.go
@@ -19,10 +19,11 @@ package services
 
 import (
 	"fmt"
-	"golang.org/x/exp/slices"
-	"golang.org/x/sync/errgroup"
 	"strings"
 	"time"
+
+	"golang.org/x/exp/slices"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/apache/incubator-devlake/core/dal"
 	"github.com/apache/incubator-devlake/core/errors"
@@ -33,6 +34,11 @@ import (
 
 type ProjectService interface {
 	RenameProject(db dal.Transaction, oldProjectName, newProjectName string) errors.Error
+}
+
+// ProjectDeleteHook is an optional hook; kept separate from ProjectService so existing implementers aren't broken.
+type ProjectDeleteHook interface {
+	DeleteProject(db dal.Transaction, projectName string) errors.Error
 }
 
 var projectService ProjectService
@@ -379,6 +385,12 @@ func DeleteProject(name string) errors.Error {
 			}
 		}
 	}()
+	// let plugins validate/clean up their own state inside the same transaction before core rows are deleted
+	if hook, ok := projectService.(ProjectDeleteHook); ok {
+		if err = hook.DeleteProject(tx, name); err != nil {
+			return err
+		}
+	}
 	err = tx.Delete(&models.Project{}, dal.Where("name = ?", name))
 	if err != nil {
 		return errors.Default.Wrap(err, "error deleting project")


### PR DESCRIPTION
### Summary
Fixes #9081. The generic `DELETE /projects/:projectName` flow
(`services.DeleteProject`) has no lifecycle hook for plugins/features
with project-scoped state, unlike `PatchProject`'s rename flow, which
already calls `projectService.RenameProject(...)`. Feature-owned
records can be left stale or orphaned when a project is deleted
directly through this endpoint.

### Root Cause
`ProjectService` only defines `RenameProject`. `DeleteProject` deletes
core records (project, mappings, metric settings, blueprint) with no
equivalent extension point, so any plugin/feature relying on its own
project-deletion flow to clean up state never gets invoked when
deletion happens through the core API.

### Fix
- Added `ProjectDeleteHook`, a separate optional interface (not a new
  required method on `ProjectService`), so existing downstream
  implementations that only support renaming aren't broken.
- `DeleteProject` now checks via type assertion whether the injected
  `projectService` also implements `ProjectDeleteHook`, and if so
  invokes it inside the same deletion transaction, before core rows
  are deleted — a hook error rolls back the whole deletion, and any
  cleanup it performs commits atomically with core deletion.

**Known limitation:** `deleteProjectBlueprint(name)` runs before the
transaction/hook, so a hook veto can't stop the blueprint from already
being deleted. Not addressed in this PR — flagging for a possible
follow-up.
