### PR TITLE
build(ci): add Dependabot configuration for all package ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -187,6 +187,12 @@ updates:
         update-types:
           - patch
     ignore:
+      # MySQL 8.4 is the selected LTS line. The registry also exposes unrelated
+      # higher numeric tags (currently 26.7.0), which Dependabot treats as a
+      # valid major upgrade; changing the database major is always manual.
+      - dependency-name: mysql
+        update-types:
+          - version-update:semver-major
       # The build image tracks the active LTS line. Node 26 is not an LTS
       # release, and a trial run confirmed that without this rule Dependabot
       # proposes moving from 24 to 25.
@@ -239,6 +245,11 @@ updates:
           - minor
           - patch
     ignore:
+      # Keep MySQL on the selected 8.4 LTS major; patch/minor updates within
+      # that line remain automated.
+      - dependency-name: mysql
+        update-types:
+          - version-update:semver-major
       - dependency-name: jenkins/jenkins
       - dependency-name: atlassian/jira-software
       - dependency-name: atlassian/bitbucket-server

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,272 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Dependabot version updates.
+#
+# Conventions used throughout this file:
+#   * `commit-message.prefix: build(deps)` matches the commit convention that
+#     `.github/workflows/commit-msg.yml` enforces on every pull request.
+#   * Minor and patch updates are grouped into a single pull request per
+#     ecosystem; majors stay separate so they remain individually reviewable.
+#   * `ignore` entries document deliberately deferred upgrades. Each one names
+#     the reason, so the rule can be removed once the reason disappears.
+#
+# Known coverage gaps (intentionally not automated):
+#   * Compose files use their own `docker-compose` ecosystem. Its filename
+#     matcher does not accept the two multi-suffix names
+#     `docker-compose-dev-mysql.yml` and `docker-compose-dev-postgresql.yml`,
+#     so the images in those files stay on manual maintenance.
+#   * Workflow `container:` and `services:` images are not covered either: the
+#     `github-actions` ecosystem only updates `uses:` references.
+#   * `backend/scripts/install-mockery.sh` pins a tool version in a shell
+#     script and is not a supported manifest format.
+version: 2
+updates:
+  # ---------------------------------------------------------------- Go -----
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    groups:
+      go-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # The Go toolchain directive is coupled to the CI bootstrap version and
+      # to the golang base images; it is raised deliberately, never by a bot.
+      - dependency-name: go
+      # git2go is ABI-coupled to the libgit2 version installed in the builder
+      # image. A mismatch fails at link time, so this is always manual.
+      - dependency-name: github.com/libgit2/git2go/*
+      # swag v2 is still a release candidate and requires regenerating every
+      # swagger annotation. Tracked as an externally gated upgrade.
+      - dependency-name: github.com/swaggo/swag
+        update-types:
+          - version-update:semver-major
+
+  # -------------------------------------------------------------- npm ------
+  - package-ecosystem: npm
+    directory: /config-ui
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    groups:
+      js-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # TypeScript 7 is the native-port compiler. Upgrading requires validating
+      # the whole build chain (vite, eslint, type definitions) in one go.
+      - dependency-name: typescript
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: npm
+    directory: /e2e
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    # This directory has no lockfile. Without `increase`, Dependabot would stay
+    # silent as long as a new release still satisfies the declared caret range.
+    versioning-strategy: increase
+    groups:
+      e2e-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+
+  # ------------------------------------------------------------- Python ----
+  - package-ecosystem: pip
+    directories:
+      - /backend/python
+      - /backend/python/pydevlake
+      - /backend/python/plugins/azuredevops
+      - /backend/python/test/fakeplugin
+      - /grafana/scripts
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    groups:
+      python-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      # pydevlake is written against Pydantic 1 and SQLModel 0.0.8. SQLModel is
+      # still pre-1.0, so SemVer treats even 0.0.8 -> 0.0.30 as a patch, yet that
+      # release pulls in SQLAlchemy 2 and Pydantic 2 and breaks
+      # `pydevlake/model.py` with "Passing primary_key is not supported when also
+      # passing a sa_column". Verified on a fork: the bump landed in the group
+      # and turned unit-test and test-e2e red.
+      # Drop both entries once pydevlake has been migrated to Pydantic 2.
+      - dependency-name: sqlmodel
+      - dependency-name: pydantic
+        update-types:
+          - version-update:semver-major
+
+  # ------------------------------------------------------------- Docker ----
+  #
+  # This block covers both Dockerfiles and Kubernetes manifests: the `docker`
+  # file fetcher also picks up YAML files that carry `apiVersion` and `kind`,
+  # which is why `/devops/deployment/k8s` is listed here. Only the `mysql`
+  # image there is pinned to a version; the `apache/devlake*` images use
+  # `latest` and are left untouched.
+  #
+  # Note on Docker tag semantics: language base images encode their version in
+  # the tag, so `node:24 -> node:25` is a major update while
+  # `python:3.11 -> python:3.14` would count as a minor one. All three images
+  # define a runtime rather than a dependency: the Python tag has to match what
+  # the Poetry lockfiles resolve against, and the Go tag has to match the `go`
+  # directive in backend/go.mod and the toolchain used by CI. They are raised
+  # deliberately, so they are ignored here.
+  - package-ecosystem: docker
+    directories:
+      - /backend
+      - /config-ui
+      - /grafana
+      - /devops/docker/lake-builder
+      - /.devcontainer
+      - /devops/deployment/k8s
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    groups:
+      docker-patch:
+        patterns:
+          - "*"
+        update-types:
+          - patch
+    ignore:
+      # The build image tracks the active LTS line. Node 26 is not an LTS
+      # release, and a trial run confirmed that without this rule Dependabot
+      # proposes moving from 24 to 25.
+      - dependency-name: node
+        update-types:
+          - version-update:semver-major
+      # Ignored for minor as well, because a jump such as 3.11 -> 3.14 is a
+      # minor update in tag terms while being a runtime change in practice.
+      - dependency-name: python
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      - dependency-name: golang
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+      # Dependabot strips the registry host from the dependency name, so this
+      # must be "devcontainers/go" and not "mcr.microsoft.com/devcontainers/go".
+      - dependency-name: devcontainers/go
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+
+  # ----------------------------------------------------- Docker Compose ---
+  #
+  # The separate Compose updater recognises four of the six non-release
+  # Compose files. The two docker-compose-dev-*.yml names are not matched by
+  # its current filename regexp and therefore remain a documented manual gap.
+  # Jira, Jenkins and Bitbucket are compatibility fixtures rather than runtime
+  # dependencies; their deliberately old versions must not be raised blindly.
+  - package-ecosystem: docker-compose
+    directories:
+      - /
+      - /.devcontainer
+      - /devops/deployment/temporal
+      - /backend/test/e2e/remote
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    groups:
+      compose-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: jenkins/jenkins
+      - dependency-name: atlassian/jira-software
+      - dependency-name: atlassian/bitbucket-server
+
+  # ------------------------------------------------------ GitHub Actions ---
+  #
+  # Most workflows reference actions by tag, while the docker/* actions are
+  # pinned to a commit SHA with a `# vX.Y.Z` comment. Dependabot updates a
+  # SHA pin to the new SHA and rewrites that comment, so pinning is preserved.
+  #
+  # Dependabot never proposes a change of action *namespace*. Migrating to a
+  # differently owned action stays a manual step because ASF infrastructure
+  # maintains an allow-list of permitted actions.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: "06:00"
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: build(deps)
+    groups:
+      actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so that dependency updates arrive as reviewable
pull requests instead of periodic manual audits.

This is a configuration-only change. No source file, build step or runtime
behaviour is touched, and rolling it back means deleting one file.

The configuration contains seven update entries across 19 directory entries:

| Ecosystem | Directories | Manifests found |
|---|---|---|
| `gomod` | `/backend` | `go.mod` |
| `npm` | `/config-ui` | `package.json` + `yarn.lock` |
| `npm` | `/e2e` | `package.json` (no lockfile) |
| `pip` | `/backend/python`, `/backend/python/pydevlake`, `/backend/python/plugins/azuredevops`, `/backend/python/test/fakeplugin`, `/grafana/scripts` | 2 × `requirements.txt`, 3 × `pyproject.toml` + `poetry.lock` |
| `docker` | `/backend`, `/config-ui`, `/grafana`, `/devops/docker/lake-builder`, `/.devcontainer`, `/devops/deployment/k8s` | 6 Dockerfiles + `k8s-deploy.yaml` |
| `docker-compose` | `/`, `/.devcontainer`, `/devops/deployment/temporal`, `/backend/test/e2e/remote` | 4 Compose files |
| `github-actions` | `/` | 14 workflows + `.github/actions/auto-cherry-pick` |

## Design decisions

**Weekly schedule, five open pull requests per ecosystem.** Enough to keep the
tree moving without flooding review capacity.

**Minor and patch updates are grouped, majors stay separate.** A grouped pull
request keeps low-risk churn to a single review; a major change deserves its own
discussion. This mirrors how the recent manual dependency batches were split.

**`commit-message.prefix: build(deps)`.** `.github/workflows/commit-msg.yml`
rejects any commit that does not match its conventional-commit pattern. The
prefix was verified against that exact regular expression, including the grouped
form (`build(deps): bump the … group across 5 directories with 3 updates`) and
the development-dependency form (`build(deps-dev): …`).

**Language base images are pinned deliberately, so they are ignored.** In Docker
tag semantics `python:3.11 → python:3.14` and `golang:1.26 → golang:1.27` are
*minor* updates. They are not dependency bumps, though: the Python tag has to
match what the Poetry lockfiles resolve against, and the Go tag has to match the
`go` directive in `backend/go.mod` and the toolchain used by CI. Both are
therefore ignored for minor as well as major updates and remain a conscious,
manual decision. `node` is ignored for majors only, because the build image
tracks the active LTS line and Node 26 is not an LTS release.

**`versioning-strategy: increase` for `/e2e`.** That directory declares
`"@playwright/test": "^1.58.2"` and has no lockfile. With the default strategy
Dependabot only rewrites a manifest once a release leaves the declared range, so
the entry would have produced nothing while still looking configured.

**`git2go` is never bumped automatically.** It is ABI-coupled to the libgit2
version installed in the builder image; a mismatch fails at link time.

## Action pinning

Most workflows reference actions by tag. The `docker/*` actions are pinned to a
commit SHA with a `# vX.Y.Z` comment, for example:

```yaml
uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
```

Dependabot updates such a pin to the new commit SHA and rewrites the version
comment, so the pinning style is preserved rather than replaced by a tag.

Dependabot never proposes changing the *namespace* of an action. Moving to a
differently owned action stays a manual step, which matters here because ASF
infrastructure maintains an allow-list of permitted actions.

Files that are not valid workflows are not read at all — this includes
`.github/workflows/codespell.yml.action-blocked-by-asf` and
`go-checklist.yml.bak`. The blocked Codespell action is therefore left alone.

## Deferred upgrades

Every `ignore` entry carries a comment explaining why it exists, so it can be
removed once the reason no longer applies:

| Entry | Reason |
|---|---|
| `typescript` (major) | TypeScript 7 is the native-port compiler; adopting it means validating the whole build chain at once |
| `node` (major) | Node 26 is not an LTS release |
| `github.com/swaggo/swag` (major) | swag v2 is still a release candidate and requires regenerating every swagger annotation |
| `github.com/libgit2/git2go/*` | ABI-coupled to libgit2 |
| `go` | the toolchain directive moves together with CI and the base images |
| `mysql` (major, Docker and Compose) | keep the database on the selected MySQL 8.4 LTS line; the registry exposes unrelated higher numeric tags such as `26.7.0` |
| `python`, `golang`, `devcontainers/go` (major + minor) | runtime decisions, see above; Dependabot strips the registry host from the dependency name |
| `jenkins/jenkins`, `atlassian/jira-software`, `atlassian/bitbucket-server` in Compose | deliberately conservative compatibility fixtures, not runtime dependencies |

**Compose files use their own ecosystem.** The `docker-compose` updater covers
`docker-compose.datasources.yml`, `.devcontainer/docker-compose.yml`,
`devops/deployment/temporal/docker-compose-temporal.yml` and
`backend/test/e2e/remote/docker-compose.test.yml`. The three datasource images
listed above are ignored; regular database image updates remain enabled, while
MySQL major changes remain a deliberate manual decision.

## Not covered

Stating this explicitly, because a configuration file can otherwise suggest more
coverage than it provides:

- **`docker-compose-dev-mysql.yml` and
  `docker-compose-dev-postgresql.yml`** — the Compose ecosystem exists, but its
  current filename matcher accepts only one hyphenated segment after
  `compose`; these two multi-suffix names are not fetched. Their database and
  OAuth2 Proxy images remain manual.
- **Workflow `container:` and `services:` images** — the `github-actions`
  ecosystem only updates `uses:` references. Compose updates therefore still
  require a consistency check against the database service images in CI.
- **`backend/scripts/install-mockery.sh`** — a tool version inside a shell
  script.
- **`apache/skywalking-eyes@main`** — a branch reference rather than a version.
- **Unpinned entries in `backend/python/requirements.txt`** — without a version
  constraint there is nothing to raise.

## Validation

- YAML parses cleanly.
- Validated against the SchemaStore `dependabot-2.0.json` schema (Draft 7) with
  no violations, which also confirms the plural `directories` key and every
  `update-types` value used.
- All 19 directory entries exist and contain the expected manifest. The
  Compose filename matcher was tested against all six non-release Compose
  files: four match and the two documented dev files do not.
- The commit message convention was checked against the regular expression in
  `.github/workflows/commit-msg.yml` for six representative bot commit forms.

### Verified on a fork before opening this PR

This configuration was run against a fork with version updates enabled. On
2026-09-01 it produced **17 pull requests** across five ecosystems, which
confirms the behaviour that matters here:

- **Grouping works.** `js-minor-patch` bundled 21 updates into a single PR,
  `actions-minor-patch` bundled 4, and `python-minor-patch` bundled 3 across two
  directories. Major bumps stayed outside the groups, as intended.
- **Action pins stay pins.** The `github-actions` group PR rewrote SHAs to new
  SHAs and carried the `# vX.Y.Z` comment along, e.g.
  `docker/setup-qemu-action@ce36039…  # v4.0.0` became
  `docker/setup-qemu-action@96fe6ef…  # v4.2.0`. No pin was downgraded to a tag.
- **`versioning-strategy: increase` is required for `/e2e`.** It produced
  `update @playwright/test requirement from ^1.58.2 to ^1.62.1` - a bump that
  would otherwise stay silent, because the new release already satisfies the
  declared caret range and that directory has no lockfile.
- **The `ignore` rules hold.** `typescript` is at 6.0.3 with 7.0.2 available and
  no PR was raised. The language images (`node`, `golang`, `python`) were
  likewise left alone.
- **`open-pull-requests-limit` throttles.** The `github-actions` ecosystem
  stopped exactly at its limit of 5.

The Compose entry was exercised in a subsequent fork run on 2026-09-02. It
processed all four configured files. PostgreSQL was correctly proposed from
`18.4-alpine` to `18.6-alpine`, but MySQL was proposed from `8.4.11` to the
unrelated numeric tag `26.7.0` in all four directories. This surfaced one more
issue that is fixed in this branch:

- `mysql` now ignores `version-update:semver-major` in both the `docker` and
  `docker-compose` blocks. Patch and minor updates within the selected 8.4 LTS
  line remain enabled.
- The corrected file was validated again against the SchemaStore Draft 7 schema
  with zero violations and copied byte-for-byte to the fork test branch.
- Dependabot then closed all four incorrect pull requests (#37-#40) itself,
  commented that MySQL was no longer being updated, and deleted all four head
  branches. This is a direct behavioural test of the ignore rule rather than
  only a schema check.

Two issues surfaced during that run and are already fixed in this branch:

1. `dependency-name: mcr.microsoft.com/devcontainers/go` never matched, because
   Dependabot strips the registry host from the dependency name. Using
   `devcontainers/go` fixes it - after the change Dependabot closed the
   superfluous PR itself with *"Looks like devcontainers/go is no longer being
   updated by Dependabot"*.
2. Explicit `labels` were dropped. Dependabot only creates its *default* labels
   automatically; labels named in the configuration must already exist, and none
   of the ones originally chosen exist in this repository. Every PR carried a
   *"The following labels could not be found"* warning. Without the key,
   Dependabot applies and creates its defaults, so no repository setup is
   required up front. Maintainers can add their own labels later if they want
   them.

### Known limitation: the `gomod` ecosystem

The sixth ecosystem, `gomod`, could not be verified. It fails for a reason that
is independent of this configuration: `backend/mocks/` is gitignored while
tracked sources such as `helpers/unithelper` import it, so `go mod tidy` cannot
resolve those packages and Dependabot aborts after every version bump.

The same failure reproduces on a plain checkout without Dependabot involved:

```
go: github.com/apache/incubator-devlake/helpers/unithelper imports
        github.com/apache/incubator-devlake/mocks/core/dal: no matching versions for query "latest"
```

Generating the mocks first makes `go mod tidy` exit cleanly and leaves `go.mod`
and `go.sum` byte-identical, so the module itself is consistent.

This is tracked separately in #9088. Until it is
resolved, the `gomod` block in this file will not produce pull requests. It is
kept in place so that Go updates start working as soon as the underlying issue
is fixed - reviewers may of course prefer to drop the block until then.

## Rollback

Delete the file. Dependabot reevaluates open version-update pull requests when
the configuration changes and may close obsolete ones automatically, as the
fork test demonstrated for all four ignored MySQL-major pull requests. Any pull
request that remains open after reevaluation must be closed manually.
