### PR TITLE
build(compose): make the devlake image registry configurable

### DIFF
--- a/docker-compose-dev-mysql.yml
+++ b/docker-compose-dev-mysql.yml
@@ -34,7 +34,7 @@ services:
       --skip-log-bin
 
   grafana:
-    image: devlake.docker.scarf.sh/apache/devlake-dashboard:latest
+    image: ${DEVLAKE_IMAGE_REGISTRY:-devlake.docker.scarf.sh}/apache/devlake-dashboard:latest
     build:
       context: grafana/
     ports:
@@ -82,7 +82,7 @@ services:
       - mysql
 
   config-ui:
-    image: devlake.docker.scarf.sh/apache/devlake-config-ui:latest
+    image: ${DEVLAKE_IMAGE_REGISTRY:-devlake.docker.scarf.sh}/apache/devlake-config-ui:latest
     build:
       context: "config-ui"
     ports:

--- a/docker-compose-dev-postgresql.yml
+++ b/docker-compose-dev-postgresql.yml
@@ -30,7 +30,7 @@ services:
       TZ: UTC
 
   grafana:
-    image: devlake.docker.scarf.sh/apache/devlake-dashboard:latest
+    image: ${DEVLAKE_IMAGE_REGISTRY:-devlake.docker.scarf.sh}/apache/devlake-dashboard:latest
     build:
       context: grafana/
     ports:
@@ -78,7 +78,7 @@ services:
       - postgres
 
   config-ui:
-    image: devlake.docker.scarf.sh/apache/devlake-config-ui:latest
+    image: ${DEVLAKE_IMAGE_REGISTRY:-devlake.docker.scarf.sh}/apache/devlake-config-ui:latest
     build:
       context: "config-ui"
     ports:

--- a/env.example
+++ b/env.example
@@ -18,6 +18,15 @@
 # Lake core #
 #############
 
+# Container image registry/prefix for the pre-built devlake-dashboard and
+# devlake-config-ui images used by the docker-compose-dev-*.yml files.
+# The default is the Scarf gateway (download analytics for the Apache project)
+# and is defined in the compose files themselves, so this entry stays commented
+# out: the compose services read this file via `env_file`, and an active
+# assignment would also inject the variable into the running containers.
+# Uncomment and set it (e.g. docker.io) to pull directly from Docker Hub.
+# DEVLAKE_IMAGE_REGISTRY=devlake.docker.scarf.sh
+
 # Lake plugin dir, absolute path or relative path
 PLUGIN_DIR=bin/plugins
 REMOTE_PLUGIN_DIR=python/plugins


### PR DESCRIPTION
### Summary

`docker-compose-dev-mysql.yml` and `docker-compose-dev-postgresql.yml` pull the pre-built `devlake-dashboard` and `devlake-config-ui` images through `devlake.docker.scarf.sh`. Scarf is a gateway that records download analytics for the project. Some environments (corporate registries, air-gapped mirrors, privacy policies) need to pull those images directly instead.

This PR introduces `DEVLAKE_IMAGE_REGISTRY` so the registry prefix can be overridden, while keeping the Scarf gateway as the default:

```yaml
image: ${DEVLAKE_IMAGE_REGISTRY:-devlake.docker.scarf.sh}/apache/devlake-dashboard:latest
image: ${DEVLAKE_IMAGE_REGISTRY:-devlake.docker.scarf.sh}/apache/devlake-config-ui:latest
```

```bash
# opt out, pull straight from Docker Hub
DEVLAKE_IMAGE_REGISTRY=docker.io docker compose -f docker-compose-dev-mysql.yml up
```

3 files changed, +13/-4.

### Why the `env.example` entry is commented out

The three services read `./.env` via `env_file`. An **active** assignment there would not only drive the image substitution, it would also be injected as an environment variable into the running `devlake`, `config-ui` and `grafana` containers — a behaviour change unrelated to the goal. The default therefore lives inline in the compose files, and `env.example` only documents the knob.

### Validation

Rendered with Docker Compose 5.5.0 / Docker 29.5.3, for both compose files:

| Case | Result |
|---|---|
| Variable unset, existing `.env` from `main` | `docker compose config` **byte-identical** to `main` |
| `.env` copied from the new `env.example` | **byte-identical** to `main` |
| `DEVLAKE_IMAGE_REGISTRY=docker.io` in `.env` | `docker.io/apache/devlake-{dashboard,config-ui}:latest` |
| `DEVLAKE_IMAGE_REGISTRY=ghcr.io/example` in the shell | `ghcr.io/example/apache/devlake-…:latest` |
| Empty value | falls back to the Scarf default (`:-` semantics) |

Both endpoints were confirmed to resolve: `docker manifest inspect` succeeds for `devlake.docker.scarf.sh/apache/devlake-dashboard:latest`, and the Docker Hub registry API returns `200` for `apache/devlake-dashboard` and `apache/devlake-config-ui`, so the opt-out target really exists.

`env.example` still parses cleanly as a dotenv file, both compose files parse as YAML, and the commit message matches the `lint-commit-message` pattern.

### Deliberately out of scope

- `devops/releases/lake-v0.*/docker-compose.yml` — released artifacts, pinned to historical versions.
- `.devcontainer/docker-compose.yml` — Compose reads `.env` relative to that file, so a root-level `.env` would not apply; changing it would only look configurable.
- Every other image (`mysql`, `postgres`, `oauth2-proxy`, `mericodev/*`) keeps its existing registry.

No functional change for anyone who does not set the variable.

