### PR TITLE
build(ci): pin Go in migration-script-lint like the other container jobs

### DIFF
--- a/.github/workflows/migration-script-lint.yml
+++ b/.github/workflows/migration-script-lint.yml
@@ -30,6 +30,8 @@ jobs:
     container: mericodev/lake-builder:latest
     steps:
       - uses: actions/checkout@v6
+      - name: Install Go 1.26.6
+        run: backend/scripts/install-go.sh
       - name: migration script linting
         run: |
           go version


### PR DESCRIPTION
### Summary

`migration-script-lint` is the only job that runs inside
`mericodev/lake-builder:latest` **without** installing the pinned Go toolchain.
The image still ships **Go 1.20.4**, while `backend/go.mod` declares `go 1.26`.

`test.yml`, `test-e2e.yml` and `golangci-lint.yml` all bootstrap the toolchain
via `backend/scripts/install-go.sh` (added in #9031 / #9056). This PR adds the
same step to the remaining job, using the identical step name and command:

```yaml
      - uses: actions/checkout@v6
      - name: Install Go 1.26.6
        run: backend/scripts/install-go.sh
      - name: migration script linting
```

### Why it matters even though the job is green today

Go ≤ 1.20 does not treat a higher `go` directive as a hard error — it only
reports it when compilation fails for another reason. The job therefore passes,
but it builds and runs `core/migration/linter/main.go` under a language version
six major releases behind what the project declares. Any migration script that
uses post-1.20 language or standard-library features would fail here for a
reason unrelated to the lint itself, and the failure message would point at the
wrong thing.

This also removes the last place where the mutable `:latest` builder image
silently determines the Go version used to run project code.

### Cost

`install-go.sh` is idempotent: it checks for an already-installed toolchain
under `/opt/go/$GO_VERSION` before downloading. Measured on a verification run
(worst case, nothing pre-installed): **2.8 s** for download, checksum
verification and extraction, in a job that takes about **45 s** in total.

`install-libgit2.sh` and `install-mockery.sh` are deliberately **not** added —
the migration linter needs neither cgo bindings nor generated mocks.

### Validation

Verified on a fork branch that mirrors the upstream workflow step lists:
[run 33620580891](https://github.com/DoDiODev/devlake/actions/runs/33620580891),
13/13 jobs green. In the `migration-script-lint` job the linting step now
reports:

```
installed Go 1.26.6 in /opt/go/1.26.6
go version go1.26.6 linux/amd64
```

instead of the image-provided 1.20.4.

### Note for reviewers

This PR does not require a new builder image. It works with the current
`mericodev/lake-builder:latest` precisely because `install-go.sh` installs the
toolchain at job runtime — the same mechanism the other three container jobs
already rely on.

