### PR TITLE
chore(python): deprecate Python plugin framework (Phase 1 of #9092)

### DIFF
--- a/backend/core/plugin/plugin_meta.go
+++ b/backend/core/plugin/plugin_meta.go
@@ -44,6 +44,14 @@ type PluginIcon interface {
 	SvgIcon() string
 }
 
+// PluginDeprecation is implemented by plugins that have been deprecated.
+// The DeprecationMessage should describe why the plugin is deprecated and
+// what users should migrate to. Returns an empty string for non-deprecated
+// plugins.
+type PluginDeprecation interface {
+	DeprecationMessage() string
+}
+
 // PluginSource abstracts data sources
 type PluginSource interface {
 	Connection() dal.Tabler

--- a/backend/core/runner/loader.go
+++ b/backend/core/runner/loader.go
@@ -91,6 +91,7 @@ func LoadGoPlugins(basicRes context.BasicRes) errors.Error {
 func LoadRemotePlugins(basicRes context.BasicRes) errors.Error {
 	remotePluginDir := basicRes.GetConfig("REMOTE_PLUGIN_DIR")
 	if remotePluginDir != "" {
+		basicRes.GetLogger().Warn(nil, "DEPRECATION WARNING: The Python plugin framework (PyDevLake) is deprecated and will be removed in 3 months. See https://github.com/apache/devlake/issues/9092 for the deprecation plan and migration guide. Please migrate Python plugins (e.g. azuredevops) to the Go-based equivalents (e.g. azuredevops_go).")
 		basicRes.GetLogger().Info("Loading remote plugins")
 		remote.Init(basicRes)
 		walkErr := filepath.WalkDir(remotePluginDir, func(path string, d fs.DirEntry, err error) error {

--- a/backend/python/README.md
+++ b/backend/python/README.md
@@ -16,6 +16,28 @@ limitations under the License.
 -->
 # Pydevlake
 
+> **⚠️ DEPRECATED — Scheduled for removal.**
+> The Python plugin framework (PyDevLake) is deprecated and will be removed from
+> Apache DevLake in 3 months per the deprecation plan in
+> [#9092](https://github.com/apache/devlake/issues/9092).
+>
+> Reasons:
+> - Only one plugin (`azuredevops`) ever shipped on this framework; the `dbt`
+>   plugin was already removed (#8970).
+> - No feature/fix commits to Python plugins since Dec 2025; only dependency
+>   refreshes and runtime bumps land.
+> - A fully-featured Go implementation, `azuredevops_go`, now supersedes the
+>   Python `azuredevops` plugin (including on-premises support, #9014).
+>
+> **What you should do:**
+> - New plugins: write them in **Go**. See `backend/plugins/` for 40+ reference
+>   implementations.
+> - Existing `azuredevops` (Python) users: migrate to `azuredevops_go` (a
+>   migration guide will be published during the deprecation window).
+>
+> No new Python plugins will be accepted. Only critical security fixes will land
+> during the deprecation window.
+
 Pydevlake is a framework for writing plugins for [DevLake](https://devlake.apache.org/) in Python. The framework source code
 can be found in [here](./pydevlake).
 

--- a/backend/python/plugins/azuredevops/README.md
+++ b/backend/python/plugins/azuredevops/README.md
@@ -15,3 +15,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Azure Devops Python Plugin
+
+> **⚠️ DEPRECATED — Scheduled for removal in 3 months.**
+> This Python `azuredevops` plugin is deprecated in favor of the Go-based
+> [`azuredevops_go`](../../plugins/azuredevops_go) plugin, which has broader
+> feature coverage (including Azure DevOps Server / on-premises support, #9014).
+>
+> Please migrate existing connections and scopes to `azuredevops_go`. A migration
+> guide will be published during the deprecation window — see
+> [#9092](https://github.com/apache/devlake/issues/9092) for the full plan and
+> timeline.
+>
+> No new features or fixes (other than critical security fixes) will be accepted
+> on this plugin.

--- a/backend/server/api/plugininfo/plugininifo.go
+++ b/backend/server/api/plugininfo/plugininifo.go
@@ -75,8 +75,9 @@ type PluginMetric struct {
 }
 
 type PluginMeta struct {
-	Plugin string       `json:"plugin"`
-	Metric PluginMetric `json:"metric"`
+	Plugin     string       `json:"plugin"`
+	Metric     PluginMetric `json:"metric"`
+	Deprecated bool         `json:"deprecated"`
 }
 
 type PluginMetas []PluginMeta
@@ -205,6 +206,10 @@ func GetPluginMetas(c *gin.Context) {
 	err := plugin.TraversalPlugin(func(name string, p plugin.PluginMeta) errors.Error {
 		pluginMeta := PluginMeta{
 			Plugin: name,
+		}
+
+		if dp, ok := p.(plugin.PluginDeprecation); ok {
+			pluginMeta.Deprecated = dp.DeprecationMessage() != ""
 		}
 
 		// if this plugin has the plugin task info

--- a/backend/server/services/remote/plugin/plugin_impl.go
+++ b/backend/server/services/remote/plugin/plugin_impl.go
@@ -238,4 +238,16 @@ func (p *remotePluginImpl) MigrationScripts() []plugin.MigrationScript {
 	return append(p.migrationScripts, migrationscripts.All(p.name)...)
 }
 
+// DeprecationMessage implements plugin.PluginDeprecation. All remote (Python)
+// plugins are deprecated and scheduled for removal in 3 months per the
+// deprecation plan in issue #9092.
+func (p *remotePluginImpl) DeprecationMessage() string {
+	return fmt.Sprintf(
+		"This Python plugin (%s) is DEPRECATED and will be removed in 3 months. "+
+			"Please migrate to the Go-based equivalent. "+
+			"See https://github.com/apache/devlake/issues/9092 for the deprecation plan and migration guide.",
+		p.name,
+	)
+}
+
 var _ models.RemotePlugin = (*remotePluginImpl)(nil)

--- a/config-ui/src/plugins/register/azure/config.tsx
+++ b/config-ui/src/plugins/register/azure/config.tsx
@@ -28,6 +28,9 @@ export const AzureConfig: IPluginConfig = {
   name: 'Azure DevOps',
   icon: ({ color }) => <Icon fill={color} />,
   sort: 2,
+  isDeprecated: true,
+  deprecationMessage:
+    'This Python-based Azure DevOps plugin is DEPRECATED and will be removed in 3 months. Please migrate to the Go-based "Azure DevOps Go" plugin. See https://github.com/apache/devlake/issues/9092 for the deprecation plan and migration guide.',
   connection: {
     docLink: DOC_URL.PLUGIN.AZUREDEVOPS.BASIS,
     initialValues: {},

--- a/config-ui/src/routes/connection/connections.tsx
+++ b/config-ui/src/routes/connection/connections.tsx
@@ -95,8 +95,12 @@ export const Connections = () => {
           return (
             <li key={plugin} onClick={() => handleShowListDialog(plugin)}>
               {pluginConfig.isBeta && <span className="beta">Beta</span>}
+              {pluginConfig.isDeprecated && <span className="deprecated">Deprecated</span>}
               <span className="logo">{pluginConfig.icon({ color: colorPrimary })}</span>
               <span className="name">{pluginConfig.name}</span>
+              {pluginConfig.isDeprecated && pluginConfig.deprecationMessage && (
+                <span className="deprecation-note">{pluginConfig.deprecationMessage}</span>
+              )}
               <span className="count">
                 {connectionCount ? (
                   <Badge color={colorPrimary} text={`${connectionCount} connections`} />
@@ -116,8 +120,12 @@ export const Connections = () => {
           return (
             <li key={plugin} onClick={() => handleShowListDialog(plugin)}>
               {pluginConfig.isBeta && <span className="beta">Beta</span>}
+              {pluginConfig.isDeprecated && <span className="deprecated">Deprecated</span>}
               <span className="logo">{pluginConfig.icon({ color: colorPrimary })}</span>
               <span className="name">{pluginConfig.name}</span>
+              {pluginConfig.isDeprecated && pluginConfig.deprecationMessage && (
+                <span className="deprecation-note">{pluginConfig.deprecationMessage}</span>
+              )}
               <span className="count">
                 {connectionCount ? (
                   <Badge color={colorPrimary} text={`${connectionCount} connections`} />

--- a/config-ui/src/routes/connection/styled.ts
+++ b/config-ui/src/routes/connection/styled.ts
@@ -82,6 +82,26 @@ export const Wrapper = styled.div`
       border-radius: 8px;
     }
 
+    & > .deprecated {
+      position: absolute;
+      top: 0;
+      left: 0;
+      padding: 4px 8px;
+      font-size: 12px;
+      color: ${({ theme }) => theme.colors.textInverse};
+      background-color: ${({ theme }) => theme.colors.error};
+      border-radius: 8px;
+    }
+
+    & > .deprecation-note {
+      margin-top: 4px;
+      padding: 0 8px;
+      font-size: 11px;
+      line-height: 1.4;
+      color: ${({ theme }) => theme.colors.error};
+      text-align: center;
+    }
+
     & > .logo {
       width: 60px;
       height: 60px;

--- a/config-ui/src/types/plugin.ts
+++ b/config-ui/src/types/plugin.ts
@@ -22,6 +22,8 @@ export interface IPluginConfig {
   icon: ({ color }: { color: string }) => React.ReactNode;
   sort: number;
   isBeta?: boolean;
+  isDeprecated?: boolean;
+  deprecationMessage?: string;
   connection: {
     docLink: string;
     initialValues?: Record<string, any>;


### PR DESCRIPTION
## Summary

Phase 1 (Warning) of the Python plugin deprecation plan in #9092. Adds deprecation warnings across the backend and frontend so users are informed that the Python plugin framework (PyDevLake) will be removed in 3 months, and that they should migrate to Go-based plugins (e.g. `azuredevops` → `azuredevops_go`).

This PR does **not** remove any code. It only surfaces deprecation notices.

## Changes

### Backend
- **`backend/python/README.md`** — DEPRECATED banner at the top explaining why, the timeline, and migration guidance for new plugins (write Go) and existing `azuredevops` users (migrate to `azuredevops_go`).
- **`backend/python/plugins/azuredevops/README.md`** — marks the plugin deprecated, points to `azuredevops_go`.
- **`backend/core/runner/loader.go`** — emits a one-time `WARN` log at server startup when remote (Python) plugins are being loaded:
  ```
  DEPRECATION WARNING: The Python plugin framework (PyDevLake) is deprecated and will be removed in 3 months. See https://github.com/apache/devlake/issues/9092 ...
  ```
- **`backend/core/plugin/plugin_meta.go`** — new `PluginDeprecation` interface (`DeprecationMessage() string`).
- **`backend/server/services/remote/plugin/plugin_impl.go`** — `remotePluginImpl` implements `PluginDeprecation`; all remote/Python plugins report a deprecation message.
- **`backend/server/api/plugininfo/plugininifo.go`** — `GET /plugins` now returns a `deprecated` boolean per plugin so the frontend can detect deprecated plugins.

### Frontend (config-ui)
- **`config-ui/src/types/plugin.ts`** — added `isDeprecated?` and `deprecationMessage?` to `IPluginConfig`.
- **`config-ui/src/plugins/register/azure/config.tsx`** — `AzureConfig` (the Python `azuredevops` plugin) is now flagged `isDeprecated: true` with a migration message.
- **`config-ui/src/routes/connection/connections.tsx`** — renders a red **Deprecated** badge + deprecation note on deprecated plugin cards in the Connections page.
- **`config-ui/src/routes/connection/styled.ts`** — styles for the new `.deprecated` badge and `.deprecation-note`.

## Plan timeline (from #9092)

| Phase | Window | Status |
| --- | --- | --- |
| 1. Warning | T+0 | **This PR** |
| 2. Freeze | T+1 month | Not started |
| 3. Migration assist | T+1~T+3 months | Not started |
| 4. Removal | T+3 months | Not started |

## Verification

- `go vet ./core/runner/... ./core/plugin/... ./server/api/plugininfo/... ./server/services/remote/...` — clean
- `tsc --noEmit` — no new errors (only pre-existing missing test deps)

## Related issue

Closes: no (this is Phase 1 of the plan in #9092; the issue stays open until Phase 4 removal).
Refs: #9092